### PR TITLE
Should walk though the unaryExpr to transfrom any function calls too.

### DIFF
--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -683,6 +683,18 @@ function getParamFromUnaryExpression(node: any, scopeManager: ScopeManager, name
         end: node.end,
     };
 
+    // Walk through the unary expression to transform any function calls
+    walk.recursive(unaryExpr, scopeManager, {
+        CallExpression(node: any, scopeManager: ScopeManager) {
+            if (!node._transformed) {
+                transformCallExpression(node, scopeManager);
+            }
+        },
+        MemberExpression(node: any) {
+            transformMemberExpression(node, '', scopeManager);
+        },
+    });
+
     return unaryExpr;
 }
 


### PR DESCRIPTION
Here's a test case:
```
//@version=6
indicator("RSI Divergence Detector", overlay=false)

// RSI Calculation
len = 14
src = close
up = ta.rma(math.max(ta.change(src), 0), len)
down = ta.rma(-math.min(ta.change(src), 0), len)
rsi = down == 0 ? 100 : up == 0 ? 0 : 100 - (100 / (1 + up / down))
plot(rsi, "RSI", color=#7E57C2)
hline(70, "Overbought", color=#787B86, linestyle=hline.style_dashed)
hline(30, "Oversold", color=#787B86, linestyle=hline.style_dashed)

// Divergence Logic
// We use a simple pivot detection to find local lows
lookback = 5
pl = ta.pivotlow(src, lookback, lookback)
rsi_pl = ta.pivotlow(rsi, lookback, lookback)

// Detect Bullish Divergence: Price Lower Low, RSI Higher Low
// Note: This is a simplified detection for visual aid
bullish_div = not na(pl) and (src[lookback] < src[lookback + 20]) and (rsi[lookback] > rsi[lookback + 20])

plotshape(bullish_div, title="Bullish Divergence", style=shape.labelup, location=location.bottom, color=color.green, text="BULL", textcolor=color.white, offset=-lookback)
```
The expression:
```
down = ta.rma(-math.min(ta.change(src), 0), len)
```
has unary argument `-math.min(ta.change(src), 0)`, we should work though it to process function calls
 
