### PR TITLE
Fix parser: allow inline comments after type fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pinets",
-    "version": "0.8.6",
+    "version": "0.8.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pinets",
-            "version": "0.8.6",
+            "version": "0.8.7",
             "license": "AGPL-3.0",
             "dependencies": {
                 "acorn": "^8.14.0",
@@ -81,6 +81,7 @@
             "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/generator": "^7.28.6",
@@ -891,7 +892,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -1521,6 +1521,7 @@
             "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -1871,6 +1872,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -1891,8 +1893,7 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/cac": {
             "version": "6.7.14",
@@ -1999,8 +2000,7 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/commondir": {
             "version": "1.0.1",
@@ -2201,6 +2201,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -3158,6 +3159,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3500,7 +3502,6 @@
             "dev": true,
             "license": "BSD-3-Clause",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3534,7 +3535,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -3754,27 +3754,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/terser": {
-            "version": "5.37.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-            "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/source-map": "^0.3.3",
-                "acorn": "^8.8.2",
-                "commander": "^2.20.0",
-                "source-map-support": "~0.5.20"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/test-exclude": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -3921,6 +3900,7 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -3955,8 +3935,7 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
             "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/unplugin-utils": {
             "version": "0.2.5",
@@ -4019,6 +3998,7 @@
             "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -4717,6 +4697,7 @@
             "integrity": "sha512-NvccE2tZhIoPSq3o3AoTBmItwhHNjzIxvOgfdzILIscyzSGOtw2+A1d/JJbS86HDVbc6TS5HnckQuCgTfp0HDQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.3.0",
                 "@vitest/expect": "2.0.0",
@@ -5478,6 +5459,7 @@
             "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -106,7 +106,8 @@ export class Parser {
     }
 
     skipNewlines(allowIndent = false) {
-        while (this.match(TokenType.NEWLINE)) {
+        // while (this.match(TokenType.NEWLINE)) {
+        while (this.match(TokenType.NEWLINE) || this.match(TokenType.COMMENT)) {
             this.advance();
         }
         if (allowIndent && this.match(TokenType.INDENT)) {

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -762,6 +762,22 @@ plot(close)
 });
 
 describe('Pine Script Transpilation - Bug Fixes', () => {
+    describe('Inline Comments', () => {
+        it('should handle inline comments', () => {
+            const code = `
+//@version=5
+indicator("Inline comment in type field repro")
+type T
+    int x // inline comment after a field
+var array<T> xs = array.new<T>()
+`;
+            const result = transpile(code);
+            const jsCode = result.toString();
+            expect(jsCode).toBeDefined();
+            expect(jsCode).toContain('Type(');
+        });
+    });
+
     describe('Generic Type Syntax', () => {
         it('should parse and transpile simple generic types (array<float>)', () => {
             const code = `


### PR DESCRIPTION
Fixes #94

PineTS failed to transpile Pine v5 when an inline `//` comment appears after a `type` field declaration, e.g.:

type T
    int x // comment