### PR TITLE
ta.bb should return result in order of [middle, upper, lower].

### DIFF
--- a/src/namespaces/ta/methods/bb.ts
+++ b/src/namespaces/ta/methods/bb.ts
@@ -97,6 +97,6 @@ export function bb(context: any) {
         const lower = middle - mult * stdev;
 
         // Return as tuple with double brackets
-        return [[context.precision(upper), context.precision(middle), context.precision(lower)]];
+        return [[context.precision(middle), context.precision(upper), context.precision(lower)]];
     };
 }


### PR DESCRIPTION
According to: https://www.tradingview.com/pine-script-reference/v6/#fun_ta.bb, we should have:
```
[middle, upper, lower] = ta.bb(close, 5, 4)
```