### PR TITLE
## [0.9.10] - 2026-04-07 - Drawing Caps, Linefill Dedupe & Live-Stream Throttle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [0.9.10] - 2026-04-07 - Drawing Caps, Linefill Dedupe & Live-Stream Throttle
+
+### Added
+
+- **`max_*_count` for drawing objects**: **Box**, **label**, **line**, and **polyline** helpers enforce **`max_boxes_count`**, **`max_labels_count`**, **`max_lines_count`**, and **`max_polylines_count`** from **`context.indicator`** (defaults **50**). When the active count exceeds the limit, the **oldest non-deleted** objects are marked deleted (**FIFO**), matching TradingView-style caps and avoiding unbounded growth.
+- **`linefill.new()` pair deduplication**: If a **linefill** already exists between the **same two lines** (either order), the existing object is **updated in place** (color, bar) instead of appending another — same behavior as TradingView when `linefill.new()` runs every bar without deleting the previous fill.
+- **`force_overlay` for linefills**: **`LinefillObject.toPlotData()`** sets **`force_overlay`** when **either** referenced line uses it; **`syncToPlot()`** emits **`__linefills_overlay__`** as a separate overlay plot (aligned with box/line/label splitting).
+- **Plot colors from chart theme getters**: **`plot()`** resolves **`options.color`** when it is a **bound function** (e.g. **`chart.fg_color`**, **`chart.bg_color`**) by calling it, so theme-driven colors work like on TradingView.
+
+### Fixed
+
+- **Live stream / pagination loop**: When **`runLive`** is on the **last bar** (caught up to the feed), the per-iteration delay now **always runs**, even if **`closeTime`** is still in the past — avoids tight loops that ignore **`interval`**. When a fetch **only updates the last candle** (no new bars), adds a **minimum ~1 s** spacing between API calls after the request completes, reducing provider hammering while a candle is forming or the market is quiet.
+
+---
+
 ## [0.9.9] - 2026-04-02 - Drawing Setters, NAMESPACES_LIKE Subscripts & force_overlay Sync
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.9",
+    "version": "0.9.10",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -326,8 +326,11 @@ export class PineTS {
                     if (enableLiveStream && !stopped) {
                         const currentCandle = ctx.marketData[ctx.idx];
                         const isHistorical = currentCandle && currentCandle.closeTime < Date.now();
+                        const isLastBar = ctx.idx >= ctx.marketData.length - 1;
 
-                        if (!isHistorical) {
+                        // Always throttle when on the last bar (caught up to current data).
+                        // For mid-stream historical pages, skip the delay so initial load is fast.
+                        if (!isHistorical || isLastBar) {
                             await new Promise((resolve) => setTimeout(resolve, interval));
                         }
                     }
@@ -406,12 +409,21 @@ export class PineTS {
             }
 
             // #3: Fetch new data, always starting from last candle's openTime
+            // Throttle: minimum 1 second between API fetches to prevent hammering
+            const fetchStart = Date.now();
             const { newCandles, updatedLastCandle } = await this._updateMarketData();
+            const fetchDuration = Date.now() - fetchStart;
 
             if (newCandles === 0 && !updatedLastCandle) {
                 // No new data available, yield null to signal caller
                 yield null as any;
                 continue;
+            }
+
+            // If only the last candle was updated (no new bars), throttle to avoid
+            // rapid-fire fetching when the market is closed or candle is still forming
+            if (newCandles === 0 && updatedLastCandle && fetchDuration < 1000) {
+                await new Promise((resolve) => setTimeout(resolve, 1000 - fetchDuration));
             }
 
             // #4: Data changed — bump version so secondary contexts know to refresh

--- a/src/namespaces/Plots.ts
+++ b/src/namespaces/Plots.ts
@@ -258,7 +258,9 @@ export class PlotHelper {
         //   - User didn't pass color  → use Pine Script default #2962ff
         //   - User passed a color string → use that value (e.g. '#089981')
         //   - User passed color = na  → undefined (QFChart hides the segment)
-        const rawColor = options.color;
+        let rawColor = options.color;
+        // Resolve bound functions (e.g. chart.fg_color, chart.bg_color)
+        if (typeof rawColor === 'function') rawColor = rawColor();
         const pointColor = hasExplicitColor
             ? (typeof rawColor === 'string' ? rawColor : undefined)
             : (rawColor || '#2962ff');

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -133,8 +133,29 @@ export class BoxHelper {
         b._helper = this;
         b._createdAtBar = this.context.idx;
         this._boxes.push(b);
+        this._enforceMaxCount();
         this.syncToPlot();
         return b;
+    }
+
+    /**
+     * Enforce max_boxes_count: auto-delete the oldest non-deleted boxes
+     * when the active count exceeds the limit (FIFO eviction).
+     */
+    private _enforceMaxCount(): void {
+        const maxCount = this.context.indicator?.max_boxes_count ?? 50;
+        const active = this._boxes.filter(b => !b._deleted);
+        if (active.length > maxCount) {
+            const toRemove = active.length - maxCount;
+            let removed = 0;
+            for (const b of this._boxes) {
+                if (removed >= toRemove) break;
+                if (!b._deleted) {
+                    b._deleted = true;
+                    removed++;
+                }
+            }
+        }
     }
 
     // box.new() — supports both chart.point and legacy signatures
@@ -325,6 +346,7 @@ export class BoxHelper {
         b._helper = this;
         b._createdAtBar = this.context.idx;
         this._boxes.push(b);
+        this._enforceMaxCount();
         this.syncToPlot();
         return b;
     }

--- a/src/namespaces/label/LabelHelper.ts
+++ b/src/namespaces/label/LabelHelper.ts
@@ -126,8 +126,25 @@ export class LabelHelper {
         lbl._helper = this;
         lbl._createdAtBar = this.context.idx;
         this._labels.push(lbl);
+        this._enforceMaxCount();
         this.syncToPlot();
         return lbl;
+    }
+
+    private _enforceMaxCount(): void {
+        const maxCount = this.context.indicator?.max_labels_count ?? 50;
+        const active = this._labels.filter(l => !l._deleted);
+        if (active.length > maxCount) {
+            const toRemove = active.length - maxCount;
+            let removed = 0;
+            for (const l of this._labels) {
+                if (removed >= toRemove) break;
+                if (!l._deleted) {
+                    l._deleted = true;
+                    removed++;
+                }
+            }
+        }
     }
 
     // label.new() — explicit Pine Script factory method
@@ -259,6 +276,7 @@ export class LabelHelper {
         lbl._helper = this;
         lbl._createdAtBar = this.context.idx;
         this._labels.push(lbl);
+        this._enforceMaxCount();
         this.syncToPlot();
         return lbl;
     }

--- a/src/namespaces/line/LineHelper.ts
+++ b/src/namespaces/line/LineHelper.ts
@@ -119,8 +119,25 @@ export class LineHelper {
         ln._helper = this;
         ln._createdAtBar = this.context.idx;
         this._lines.push(ln);
+        this._enforceMaxCount();
         this.syncToPlot();
         return ln;
+    }
+
+    private _enforceMaxCount(): void {
+        const maxCount = this.context.indicator?.max_lines_count ?? 50;
+        const active = this._lines.filter(l => !l._deleted);
+        if (active.length > maxCount) {
+            const toRemove = active.length - maxCount;
+            let removed = 0;
+            for (const l of this._lines) {
+                if (removed >= toRemove) break;
+                if (!l._deleted) {
+                    l._deleted = true;
+                    removed++;
+                }
+            }
+        }
     }
 
     // line.new() — explicit Pine Script factory method
@@ -280,6 +297,7 @@ export class LineHelper {
         ln._helper = this;
         ln._createdAtBar = this.context.idx;
         this._lines.push(ln);
+        this._enforceMaxCount();
         this.syncToPlot();
         return ln;
     }

--- a/src/namespaces/linefill/LinefillHelper.ts
+++ b/src/namespaces/linefill/LinefillHelper.ts
@@ -26,14 +26,28 @@ export class LinefillHelper {
 
     public syncToPlot() {
         this._ensurePlotsEntry();
-        // Store ALL linefills as a single array value at the first bar's time.
-        // Same aggregation pattern as lines and labels.
         const time = this.context.marketData[0]?.openTime || 0;
+        const allPlotData = this._linefills.map(lf => lf.toPlotData());
+
+        // Split force_overlay linefills into a separate overlay plot
+        const regular = allPlotData.filter((lf: any) => !lf.force_overlay);
+        const overlay = allPlotData.filter((lf: any) => lf.force_overlay);
+
         this.context.plots['__linefills__'].data = [{
             time,
-            value: this._linefills.map(lf => lf.toPlotData()),
+            value: regular,
             options: { style: 'linefill' },
         }];
+
+        if (overlay.length > 0) {
+            this.context.plots['__linefills_overlay__'] = {
+                title: '__linefills_overlay__',
+                data: [{ time, value: overlay, options: { style: 'linefill' } }],
+                options: { style: 'linefill', overlay: true },
+            };
+        } else {
+            delete this.context.plots['__linefills_overlay__'];
+        }
     }
 
     /**
@@ -55,6 +69,11 @@ export class LinefillHelper {
     // linefill.new(line1, line2, color) → series linefill
     // The transpiler may bundle named args into an object:
     //   linefill.new(line1, line2, {color: '#2196F3'})
+    //
+    // TradingView behavior: if a linefill already exists between the same two
+    // lines (in either order), the existing one is replaced rather than creating
+    // a duplicate. This prevents accumulation when linefill.new() is called
+    // every bar without explicitly deleting the old fill.
     new(line1: LineObject, line2: LineObject, color: any): LinefillObject {
         // Resolve thunks: in `var` UDT declarations, line.new() calls are hoisted
         // as thunks (functions). Resolve them here so LinefillObject stores actual
@@ -65,6 +84,25 @@ export class LinefillHelper {
         const rawColor = color && typeof color === 'object' && !Array.isArray(color) && 'color' in color
             ? color.color : color;
         const resolvedColor = this._resolve(rawColor) || '';
+
+        // Deduplicate: replace existing linefill between the same line pair
+        if (resolvedLine1 && resolvedLine2) {
+            const id1 = resolvedLine1.id;
+            const id2 = resolvedLine2.id;
+            for (const existing of this._linefills) {
+                if (existing._deleted) continue;
+                const eid1 = existing.line1?.id;
+                const eid2 = existing.line2?.id;
+                if ((eid1 === id1 && eid2 === id2) || (eid1 === id2 && eid2 === id1)) {
+                    // Update existing linefill in-place
+                    existing.color = resolvedColor;
+                    existing._createdAtBar = this.context.idx;
+                    this.syncToPlot();
+                    return existing;
+                }
+            }
+        }
+
         const lf = new LinefillObject(resolvedLine1, resolvedLine2, resolvedColor);
         lf._createdAtBar = this.context.idx;
         this._linefills.push(lf);

--- a/src/namespaces/linefill/LinefillObject.ts
+++ b/src/namespaces/linefill/LinefillObject.ts
@@ -63,11 +63,14 @@ export class LinefillObject {
                 style: ln.style, width: ln.width, _deleted: ln._deleted,
             };
         };
+        // Inherit force_overlay from lines: if either line is force_overlay, the fill is too
+        const forceOverlay = !!(this.line1?.force_overlay || this.line2?.force_overlay);
         return {
             id: this.id,
             line1: serializeLine(this.line1),
             line2: serializeLine(this.line2),
             color: this.color,
+            force_overlay: forceOverlay,
             _deleted: this._deleted,
         };
     }

--- a/src/namespaces/polyline/PolylineHelper.ts
+++ b/src/namespaces/polyline/PolylineHelper.ts
@@ -152,8 +152,25 @@ export class PolylineHelper {
         );
         pl._createdAtBar = this.context.idx;
         this._polylines.push(pl);
+        this._enforceMaxCount();
         this.syncToPlot();
         return pl;
+    }
+
+    private _enforceMaxCount(): void {
+        const maxCount = this.context.indicator?.max_polylines_count ?? 50;
+        const active = this._polylines.filter(p => !p._deleted);
+        if (active.length > maxCount) {
+            const toRemove = active.length - maxCount;
+            let removed = 0;
+            for (const p of this._polylines) {
+                if (removed >= toRemove) break;
+                if (!p._deleted) {
+                    p._deleted = true;
+                    removed++;
+                }
+            }
+        }
     }
 
     // polyline() direct call — mapped via NAMESPACES_LIKE → polyline.any()


### PR DESCRIPTION
## [0.9.10] - 2026-04-07 - Drawing Caps, Linefill Dedupe & Live-Stream Throttle

### Added

- **`max_*_count` for drawing objects**: **Box**, **label**, **line**, and **polyline** helpers enforce **`max_boxes_count`**, **`max_labels_count`**, **`max_lines_count`**, and **`max_polylines_count`** from **`context.indicator`** (defaults **50**). When the active count exceeds the limit, the **oldest non-deleted** objects are marked deleted (**FIFO**), matching TradingView-style caps and avoiding unbounded growth.
- **`linefill.new()` pair deduplication**: If a **linefill** already exists between the **same two lines** (either order), the existing object is **updated in place** (color, bar) instead of appending another — same behavior as TradingView when `linefill.new()` runs every bar without deleting the previous fill.
- **`force_overlay` for linefills**: **`LinefillObject.toPlotData()`** sets **`force_overlay`** when **either** referenced line uses it; **`syncToPlot()`** emits **`__linefills_overlay__`** as a separate overlay plot (aligned with box/line/label splitting).
- **Plot colors from chart theme getters**: **`plot()`** resolves **`options.color`** when it is a **bound function** (e.g. **`chart.fg_color`**, **`chart.bg_color`**) by calling it, so theme-driven colors work like on TradingView.

### Fixed

- **Live stream / pagination loop**: When **`runLive`** is on the **last bar** (caught up to the feed), the per-iteration delay now **always runs**, even if **`closeTime`** is still in the past — avoids tight loops that ignore **`interval`**. When a fetch **only updates the last candle** (no new bars), adds a **minimum ~1 s** spacing between API calls after the request completes, reducing provider hammering while a candle is forming or the market is quiet.