### PR TITLE
## [0.9.11] - 2026-04-12 - `time()` HTF Semantics, `timeframe.change()` & Live-Stream `var` Snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [0.9.11] - 2026-04-12 - `time()` HTF Semantics, `timeframe.change()` & Live-Stream `var` Snapshots
+
+### Added
+
+- **`time()` with a `timeframe` argument**: **`TimeHelper`** now aligns the active bar to the **higher timeframe** and returns the **opening timestamp** of the HTF bar that contains the current bar (intraday, daily, weekly, monthly). Empty or chart-matching timeframe still returns the bar’s own time. **`timeframe_bars_back`** handling was removed in favor of this alignment model (see TradingView-style HTF `time()`).
+- **Session + HTF `time()`**: When **`session`** is set, the session test uses the **aligned HTF time**, not only the chart bar time.
+- **`timeframe.change(timeframe)`**: Implemented on **`Timeframe`** — compares **previous vs current** bar open times aligned to the target TF and returns **`true`** on the **first bar of a new HTF period** (uses shared **`normalizeTimeframe`** / **`alignToTimeframe`** from **`Time.ts`**).
+- **Tests**: **`time-function.test.ts`**, **`timeframe-change.test.ts`**.
+
+### Fixed
+
+- **Live stream (`runLive`) and `var` state**: Re-execution of the **last bar** no longer relies only on **`_removeLastResult`** for **`var`** persistence. The runtime **snapshots `var` / `let` / `const` / `params`** before the last bar, then **restores** that snapshot before refetch and re-run, so **`var`** entries stay consistent when the feed updates (avoids in-place drift across streaming ticks).
+
+---
+
 ## [0.9.10] - 2026-04-07 - Drawing Caps, Linefill Dedupe & Live-Stream Throttle
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.10",
+    "version": "0.9.11",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -741,6 +741,21 @@ export class PineTS {
      * Snapshot the var/let/const/params Series state for streaming rollback.
      * Captures the data array length and last value for each variable so we can
      * restore to this exact state before re-executing the last bar.
+     *
+     * PERF NOTE: This currently snapshots ALL scopes (const, var, let, params).
+     * In practice, only `var` variables need snapshot/restore because:
+     *   - `let` variables are re-initialized every bar via $.init() — they reset naturally
+     *   - `const` variables are set once and never modified
+     *   - `params` are function parameters, not modified across bars
+     * Only `var` variables persist and get modified in-place by $.set() (e.g. n += 1),
+     * which causes drift on streaming re-execution.
+     * If this becomes a bottleneck, narrow to `['var']` only.
+     *
+     * An even lighter alternative: make $.set() on var Series append-only (push
+     * instead of in-place modify). Then the existing pop-based _removeLastResult
+     * would correctly revert var state without any snapshot. This would require
+     * changes to the core Series/set mechanics.
+     *
      * @private
      */
     private _snapshotVarState(context: Context): any {

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -380,6 +380,7 @@ export class PineTS {
 
         const startIdx = this.data.length - periods;
         let processedUpToIdx = startIdx; // Track what we've fully processed
+        let varSnapshot: any = null; // Snapshot of var state before last bar processing
 
         // Unified loop handles both historical and live data
         while (true) {
@@ -391,7 +392,23 @@ export class PineTS {
                 const toProcess = Math.min(unprocessedCount, pageSize);
                 const previousResultLength = this._getResultLength(context.result);
 
-                await this._executeIterations(context, this._transpiledCode, processedUpToIdx, processedUpToIdx + toProcess);
+                // If this batch includes the last bar AND live streaming is enabled,
+                // snapshot the state BEFORE processing the last bar so we can restore
+                // it cleanly on streaming re-execution.
+                const batchEnd = processedUpToIdx + toProcess;
+                if (enableLiveStream && batchEnd >= availableData && toProcess > 1) {
+                    // Process all bars except the last one
+                    await this._executeIterations(context, this._transpiledCode, processedUpToIdx, batchEnd - 1);
+                    // Snapshot state before the last bar
+                    varSnapshot = this._snapshotVarState(context);
+                    // Now process the last bar
+                    await this._executeIterations(context, this._transpiledCode, batchEnd - 1, batchEnd);
+                } else if (enableLiveStream && batchEnd >= availableData && toProcess === 1) {
+                    // Only 1 bar to process (the last one) — snapshot is already set from previous batch
+                    await this._executeIterations(context, this._transpiledCode, processedUpToIdx, batchEnd);
+                } else {
+                    await this._executeIterations(context, this._transpiledCode, processedUpToIdx, batchEnd);
+                }
 
                 processedUpToIdx += toProcess;
 
@@ -400,6 +417,8 @@ export class PineTS {
                 yield pageContext;
                 continue;
             }
+
+            // UNUSED — snapshot is now taken in #1 before processing the last bar
 
             // #2: Caught up to current data (processedUpToIdx === this.data.length)
 
@@ -435,9 +454,37 @@ export class PineTS {
             // and any `if barstate.islast` drawing logic never executes.
             context.length = this.data.length;
 
-            // Always recalculate last candle + new ones
-            // Remove last result (will be recalculated with fresh data)
-            this._removeLastResult(context);
+            // Restore variable state to the snapshot (before last bar was processed).
+            // This is more reliable than _removeLastResult's pop-based approach for
+            // var variables, which can drift when re-executing modifies values in-place.
+            // _restoreVarState handles var/let/const/params Series truncation,
+            // so we skip _removeLastResult (which would double-pop).
+            this._restoreVarState(context, varSnapshot);
+
+            // Still need to remove last result and market data series entries
+            // (these are not covered by _restoreVarState)
+            if (Array.isArray(context.result)) {
+                context.result.pop();
+            } else if (typeof context.result === 'object' && context.result !== null) {
+                for (let key in context.result) {
+                    if (Array.isArray(context.result[key])) {
+                        context.result[key].pop();
+                    }
+                }
+            }
+            // Pop market data series (close, open, high, low, volume, etc.)
+            context.data.close.data.pop();
+            context.data.open.data.pop();
+            context.data.high.data.pop();
+            context.data.low.data.pop();
+            context.data.volume.data.pop();
+            context.data.hl2.data.pop();
+            context.data.hlc3.data.pop();
+            context.data.ohlc4.data.pop();
+            context.data.hlcc4.data.pop();
+            context.data.openTime.data.pop();
+            if (context.data.closeTime) context.data.closeTime.data.pop();
+            context.data.bar_index.data.pop();
 
             // Step back one position to reprocess last candle
             processedUpToIdx = this.data.length - (newCandles + 1);
@@ -445,6 +492,11 @@ export class PineTS {
             // Roll back drawing objects created during the previous processing of
             // these bars so they don't accumulate on each streaming tick.
             context.rollbackDrawings(processedUpToIdx);
+
+            // If new candles arrived, invalidate snapshot (will re-snapshot after next full process)
+            if (newCandles > 0) {
+                varSnapshot = null;
+            }
 
             // Next iteration of loop will process from updated position (#1)
 
@@ -682,6 +734,87 @@ export class PineTS {
         rollbackVariables(context);
         if (context.lctx) {
             context.lctx.forEach((lctx: any) => rollbackVariables(lctx));
+        }
+    }
+
+    /**
+     * Snapshot the var/let/const/params Series state for streaming rollback.
+     * Captures the data array length and last value for each variable so we can
+     * restore to this exact state before re-executing the last bar.
+     * @private
+     */
+    private _snapshotVarState(context: Context): any {
+        const contextVarNames = ['const', 'var', 'let', 'params'];
+        const snapshot: any = { main: {}, lctx: [] };
+
+        const snapContainer = (container: any) => {
+            const snap: any = {};
+            for (const ctxVarName of contextVarNames) {
+                if (!container[ctxVarName]) continue;
+                snap[ctxVarName] = {};
+                for (const key in container[ctxVarName]) {
+                    const item = container[ctxVarName][key];
+                    if (item instanceof Series) {
+                        // Save length AND the last value so we can restore both
+                        const len = item.data.length;
+                        const lastVal = len > 0 ? item.data[len - 1] : undefined;
+                        snap[ctxVarName][key] = { len, lastVal };
+                    }
+                }
+            }
+            return snap;
+        };
+
+        snapshot.main = snapContainer(context);
+        if (context.lctx) {
+            const lctxSnaps: any[] = [];
+            context.lctx.forEach((lctx: any) => lctxSnaps.push(snapContainer(lctx)));
+            snapshot.lctx = lctxSnaps;
+        }
+
+        // Also snapshot result and data array lengths
+        snapshot.resultLength = this._getResultLength(context.result);
+        snapshot.dataLength = context.data.close?.data?.length ?? 0;
+
+        return snapshot;
+    }
+
+    /**
+     * Restore var/let/const/params Series state from a snapshot.
+     * Truncates each Series' data array back to the snapshotted length.
+     * @private
+     */
+    private _restoreVarState(context: Context, snapshot: any): void {
+        if (!snapshot) return;
+        const contextVarNames = ['const', 'var', 'let', 'params'];
+
+        const restoreContainer = (container: any, snap: any) => {
+            for (const ctxVarName of contextVarNames) {
+                if (!snap[ctxVarName] || !container[ctxVarName]) continue;
+                for (const key in snap[ctxVarName]) {
+                    const item = container[ctxVarName][key];
+                    const snapInfo = snap[ctxVarName][key];
+                    if (item instanceof Series && snapInfo && typeof snapInfo.len === 'number') {
+                        // Truncate back to snapshot length
+                        if (item.data.length > snapInfo.len) {
+                            item.data.length = snapInfo.len;
+                        }
+                        // Restore the last value (which may have been modified in-place)
+                        if (snapInfo.len > 0 && snapInfo.lastVal !== undefined) {
+                            item.data[snapInfo.len - 1] = snapInfo.lastVal;
+                        }
+                    }
+                }
+            }
+        };
+
+        restoreContainer(context, snapshot.main);
+        if (context.lctx && snapshot.lctx) {
+            let i = 0;
+            context.lctx.forEach((lctx: any) => {
+                if (snapshot.lctx[i]) restoreContainer(lctx, snapshot.lctx[i]);
+                i++;
+            });
         }
     }
 

--- a/src/namespaces/Time.ts
+++ b/src/namespaces/Time.ts
@@ -3,6 +3,77 @@
 import { Series } from '../Series';
 import { parseArgsForPineParams } from './utils';
 
+// ── Timeframe alignment utilities ───────────────────────────────────
+
+/**
+ * Normalize a Pine Script timeframe string to a canonical form.
+ * e.g. "1D" → "D", "60" → "60", "1W" → "W", "" → ""
+ */
+export function normalizeTimeframe(tf: string): string {
+    if (!tf) return '';
+    const s = tf.trim().toUpperCase();
+    if (s === '1D' || s === 'D') return 'D';
+    if (s === '1W' || s === 'W') return 'W';
+    if (s === '1M' || s === 'M') return 'M';
+    // Strip leading "1" from minute timeframes only if it's just "1" (1 minute)
+    return s;
+}
+
+/**
+ * Compute the opening timestamp of the higher-timeframe bar that contains the given timestamp.
+ *
+ * For intraday TFs (minutes): floor to the nearest multiple of the TF duration within the day.
+ * For daily: floor to UTC day start (00:00 UTC).
+ * For weekly: floor to Monday 00:00 UTC.
+ * For monthly: floor to 1st of month 00:00 UTC.
+ */
+export function alignToTimeframe(timestamp: number, tf: string): number {
+    const MS_MIN = 60_000;
+    const MS_DAY = 86_400_000;
+
+    // Parse timeframe to minutes
+    const tfMinutes = parseTimeframeMinutes(tf);
+
+    if (tf === 'M') {
+        // Monthly: floor to 1st of month 00:00 UTC
+        const d = new Date(timestamp);
+        return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+    }
+
+    if (tf === 'W') {
+        // Weekly: floor to Monday 00:00 UTC
+        const d = new Date(timestamp);
+        const day = d.getUTCDay(); // 0=Sun, 1=Mon, ...
+        const daysToMonday = day === 0 ? 6 : day - 1;
+        return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - daysToMonday);
+    }
+
+    if (tf === 'D' || tfMinutes >= 1440) {
+        // Daily: floor to 00:00 UTC
+        return Math.floor(timestamp / MS_DAY) * MS_DAY;
+    }
+
+    // Intraday: floor to the nearest multiple of the TF duration
+    // Align relative to the start of the UTC day
+    const tfMs = tfMinutes * MS_MIN;
+    const dayStart = Math.floor(timestamp / MS_DAY) * MS_DAY;
+    const elapsed = timestamp - dayStart;
+    const alignedElapsed = Math.floor(elapsed / tfMs) * tfMs;
+    return dayStart + alignedElapsed;
+}
+
+/**
+ * Parse a Pine Script timeframe string to minutes.
+ * "5" → 5, "60" → 60, "240" → 240, "D" → 1440, "W" → 10080, "M" → 43200
+ */
+function parseTimeframeMinutes(tf: string): number {
+    if (tf === 'D') return 1440;
+    if (tf === 'W') return 10080;
+    if (tf === 'M') return 43200;
+    const n = parseInt(tf, 10);
+    return isNaN(n) ? 1440 : n;
+}
+
 // ── Shared timezone utility ──────────────────────────────────────────
 
 interface DateParts {
@@ -170,20 +241,33 @@ export class TimeHelper {
         const parsed = parseArgsForPineParams<any>(unwrapped, TIME_SIGNATURES, TIME_ARGS_TYPES);
 
         const barsBack = parsed.bars_back ?? 0;
-        const tfBarsBack = parsed.timeframe_bars_back ?? 0;
-        const totalOffset = barsBack + tfBarsBack;
+        const timeframe = parsed.timeframe || '';
 
+        // Get the current bar's timestamp (with bars_back offset on the chart TF)
         const timeSeries = this.context.data[this.dataField];
-        const currentTime = Series.from(timeSeries).get(totalOffset);
+        const currentTime = Series.from(timeSeries).get(barsBack);
+        if (isNaN(currentTime) || currentTime == null) return NaN;
 
-        // TODO: implement proper timeframe filtering
-        // For now, return the bar's time at the computed offset regardless of timeframe
-        if (parsed.session !== undefined) {
-            const timezone = parsed.timezone || this.context.pine?.syminfo?.timezone || 'UTC';
-            return this._isInSession(currentTime, parsed.session, timezone) ? currentTime : NaN;
+        // If timeframe is empty or matches the chart timeframe, return the bar's own time
+        const chartTF = this.context.timeframe || '';
+        const normalizedTF = normalizeTimeframe(timeframe);
+        const normalizedChartTF = normalizeTimeframe(chartTF);
+
+        let htfBarTime: number;
+        if (!normalizedTF || normalizedTF === normalizedChartTF) {
+            htfBarTime = currentTime;
+        } else {
+            // Compute the opening timestamp of the higher-timeframe bar that contains this bar
+            htfBarTime = alignToTimeframe(currentTime, normalizedTF);
         }
 
-        return currentTime;
+        // Session filtering
+        if (parsed.session !== undefined && parsed.session !== '') {
+            const timezone = parsed.timezone || this.context.pine?.syminfo?.timezone || 'UTC';
+            return this._isInSession(htfBarTime, parsed.session, timezone) ? htfBarTime : NaN;
+        }
+
+        return htfBarTime;
     }
 
     /**

--- a/src/namespaces/Timeframe.ts
+++ b/src/namespaces/Timeframe.ts
@@ -1,4 +1,5 @@
 import { Series } from '../Series';
+import { alignToTimeframe, normalizeTimeframe as normalizeTFFromTime } from './Time';
 const TF_UNITS = ['S', 'D', 'W', 'M'];
 
 /**
@@ -101,11 +102,29 @@ export class Timeframe {
         return !this.isdwm;
     }
 
-    // public change(timeframe: string) {
-    //     const prevOpenTime = this.context.data.openTime.get(this.context.data.openTime.length - 2);
-    //     const currentOpenTime = this.context.data.openTime.get(this.context.data.openTime.length - 1);
+    /**
+     * Detects changes in the specified timeframe.
+     * Returns true on the first bar of a new HTF period, false otherwise.
+     *
+     * Works by aligning current and previous bar timestamps to the target
+     * timeframe and comparing — if they differ, a new period has started.
+     */
+    public change(timeframe: any): boolean {
+        const tf = typeof timeframe === 'function' ? timeframe() : timeframe;
+        const resolved = tf instanceof Series ? tf.get(0) : tf;
+        const normalizedTarget = normalizeTFFromTime(resolved || '');
+        if (!normalizedTarget) return false;
 
-    // }
+        const currentTime = Series.from(this.context.data.openTime).get(0);
+        const prevTime = Series.from(this.context.data.openTime).get(1);
+
+        if (isNaN(currentTime) || isNaN(prevTime)) return false;
+
+        const currentAligned = alignToTimeframe(currentTime, normalizedTarget);
+        const prevAligned = alignToTimeframe(prevTime, normalizedTarget);
+
+        return currentAligned !== prevAligned;
+    }
     public from_seconds(seconds: number) {
         if (seconds < 60) {
             //valid seconds timeframes are 1, 5, 15, 30, 45, everything in between should be rounded to the next valid timeframe

--- a/tests/namespaces/time-function.test.ts
+++ b/tests/namespaces/time-function.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Mock provider has daily data. Use daily chart with higher TF alignment tests.
+// For intraday tests, use Binance provider.
+
+describe('time() function — timeframe alignment (daily chart)', () => {
+    // Mock data: daily bars from 2025-01-01 to 2025-06-01
+    const makePineTS = () => new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-06-01').getTime());
+
+    it('time("W") returns weekly-aligned timestamps on daily chart', async () => {
+        const code = `
+//@version=5
+indicator("time W test")
+t_w = time("W")
+t_bar = time
+plot(t_w, "weekly")
+plot(t_bar, "bar")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const weeklyData = plots['weekly'].data.filter((d: any) => d.value != null && !isNaN(d.value));
+        expect(weeklyData.length).toBeGreaterThan(0);
+
+        // Weekly timestamps should be on Mondays at 00:00 UTC
+        for (const d of weeklyData) {
+            const date = new Date(d.value);
+            expect(date.getUTCDay()).toBe(1); // Monday
+            expect(date.getUTCHours()).toBe(0);
+            expect(date.getUTCMinutes()).toBe(0);
+        }
+
+        // Should be a staircase: same value for 7 consecutive daily bars
+        let sameCount = 0;
+        for (let i = 1; i < weeklyData.length; i++) {
+            if (weeklyData[i].value === weeklyData[i - 1].value) sameCount++;
+        }
+        // Most daily bars within the same week should have the same weekly timestamp
+        expect(sameCount).toBeGreaterThan(weeklyData.length * 0.7);
+    });
+
+    it('time("M") returns monthly-aligned timestamps on daily chart', async () => {
+        const code = `
+//@version=5
+indicator("time M test")
+t_m = time("M")
+plot(t_m, "monthly")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const monthlyData = plots['monthly'].data.filter((d: any) => d.value != null && !isNaN(d.value));
+        expect(monthlyData.length).toBeGreaterThan(0);
+
+        // Monthly timestamps should be on the 1st at 00:00 UTC
+        for (const d of monthlyData) {
+            const date = new Date(d.value);
+            expect(date.getUTCDate()).toBe(1);
+            expect(date.getUTCHours()).toBe(0);
+            expect(date.getUTCMinutes()).toBe(0);
+        }
+
+        // Should have ~5 unique monthly values for Jan-May
+        const uniqueMonths = new Set(monthlyData.map((d: any) => d.value));
+        expect(uniqueMonths.size).toBeGreaterThanOrEqual(4);
+        expect(uniqueMonths.size).toBeLessThanOrEqual(6);
+    });
+
+    it('time("D") on daily chart returns same as time variable', async () => {
+        const code = `
+//@version=5
+indicator("time D on D test")
+t_d = time("D")
+t_bar = time
+plot(t_d, "daily_fn")
+plot(t_bar, "bar")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const dailyFnData = plots['daily_fn'].data;
+        const barData = plots['bar'].data;
+
+        // On a daily chart, time("D") should equal time
+        let checked = 0;
+        for (let i = 0; i < dailyFnData.length; i++) {
+            if (dailyFnData[i].value != null && barData[i].value != null) {
+                expect(dailyFnData[i].value).toBe(barData[i].value);
+                checked++;
+            }
+        }
+        expect(checked).toBeGreaterThan(0);
+    });
+
+    it('time("") returns current bar time', async () => {
+        const code = `
+//@version=5
+indicator("time empty test")
+t_empty = time("")
+t_bar = time
+plot(t_empty, "empty")
+plot(t_bar, "bar")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const emptyData = plots['empty'].data;
+        const barData = plots['bar'].data;
+
+        let checked = 0;
+        for (let i = 0; i < emptyData.length; i++) {
+            if (emptyData[i].value != null && barData[i].value != null) {
+                expect(emptyData[i].value).toBe(barData[i].value);
+                checked++;
+            }
+        }
+        expect(checked).toBeGreaterThan(0);
+    });
+
+    it('time("W") steps at week boundaries', async () => {
+        const code = `
+//@version=5
+indicator("time W boundary test")
+t_w = time("W")
+plot(t_w, "weekly")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const weeklyData = plots['weekly'].data.filter((d: any) => d.value != null && !isNaN(d.value));
+        const uniqueWeeks = [...new Set(weeklyData.map((d: any) => d.value))].sort((a: number, b: number) => a - b);
+
+        // Each unique week should be 7 days apart
+        for (let i = 1; i < uniqueWeeks.length; i++) {
+            expect(uniqueWeeks[i] - uniqueWeeks[i - 1]).toBe(7 * 86400000);
+        }
+    });
+});
+
+describe('time() function — intraday alignment (Binance)', () => {
+    // Use Binance 15min data for intraday timeframe tests
+    const makePineTS = () => new PineTS(Provider.Binance, 'BTCUSDC', '15', 200);
+
+    it('time("D") returns daily-aligned timestamps on 15min chart', async () => {
+        const code = `
+//@version=5
+indicator("time D on 15m")
+t_d = time("D")
+t_bar = time
+plot(t_d, "daily")
+plot(t_bar, "bar")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const dailyData = plots['daily'].data;
+        const barData = plots['bar'].data;
+
+        // Daily time should be staircase: same for all bars in a day
+        let stairFound = false;
+        for (let i = 1; i < dailyData.length; i++) {
+            const d1 = dailyData[i - 1].value;
+            const d2 = dailyData[i].value;
+            const b1 = barData[i - 1].value;
+            const b2 = barData[i].value;
+            if (d1 == null || d2 == null || b1 == null || b2 == null) continue;
+
+            // Bar times always increase
+            expect(b2).toBeGreaterThan(b1);
+
+            // Within same day, daily should be constant
+            if (d2 === d1 && b2 > b1) stairFound = true;
+        }
+        expect(stairFound).toBe(true);
+
+        // All daily values should be at 00:00 UTC
+        for (const d of dailyData) {
+            if (d.value != null && !isNaN(d.value)) {
+                const date = new Date(d.value);
+                expect(date.getUTCHours()).toBe(0);
+                expect(date.getUTCMinutes()).toBe(0);
+            }
+        }
+    });
+
+    it('time("60") returns hourly-aligned timestamps on 15min chart', async () => {
+        const code = `
+//@version=5
+indicator("time 60 on 15m")
+t_h = time("60")
+plot(t_h, "hourly")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const hourlyData = plots['hourly'].data;
+
+        // Hourly timestamps should be at :00 minutes
+        for (const d of hourlyData) {
+            if (d.value != null && !isNaN(d.value)) {
+                const date = new Date(d.value);
+                expect(date.getUTCMinutes()).toBe(0);
+            }
+        }
+
+        // With 15min bars, each hourly value repeats 4 times then steps
+        let sameCount = 0, stepCount = 0;
+        for (let i = 1; i < hourlyData.length; i++) {
+            if (hourlyData[i].value == null || hourlyData[i - 1].value == null) continue;
+            if (hourlyData[i].value === hourlyData[i - 1].value) sameCount++;
+            else stepCount++;
+        }
+        // ~75% same, ~25% step (3 same per 1 step)
+        expect(sameCount).toBeGreaterThan(stepCount * 2);
+    });
+
+    it('time("240") returns 4h-aligned timestamps on 15min chart', async () => {
+        const code = `
+//@version=5
+indicator("time 240 on 15m")
+t_4h = time("240")
+plot(t_4h, "4h")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const fourHData = plots['4h'].data;
+
+        // 4h timestamps should have hours at 0, 4, 8, 12, 16, or 20
+        for (const d of fourHData) {
+            if (d.value != null && !isNaN(d.value)) {
+                const date = new Date(d.value);
+                expect(date.getUTCHours() % 4).toBe(0);
+                expect(date.getUTCMinutes()).toBe(0);
+            }
+        }
+    });
+});
+
+describe('time() function — session filtering', () => {
+    const makePineTS = () => new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-02-01').getTime());
+
+    it('time with session returns NaN outside session hours', async () => {
+        // On daily bars, session "0800-1600" should filter based on the bar's time
+        // Since mock daily bars have openTime at 00:00 UTC, they fall outside 08:00-16:00
+        // This tests the session filtering mechanism
+        const code = `
+//@version=5
+indicator("time session test")
+t_in = time("D", "0000-2359")
+t_out = time("D", "0100-0200")
+plot(t_in, "in_session")
+plot(t_out, "out_session")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const inData = plots['in_session'].data;
+        const outData = plots['out_session'].data;
+
+        // 0000-2359 should include all bars (daily bars at 00:00 UTC are in 00:00-23:59)
+        const validIn = inData.filter((d: any) => d.value != null && !isNaN(d.value));
+        expect(validIn.length).toBeGreaterThan(0);
+
+        // 0100-0200 should exclude daily bars at 00:00 UTC
+        const validOut = outData.filter((d: any) => d.value != null && !isNaN(d.value));
+        const nanOut = outData.filter((d: any) => d.value == null || isNaN(d.value));
+        expect(nanOut.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/namespaces/timeframe-change.test.ts
+++ b/tests/namespaces/timeframe-change.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+describe('timeframe.change() — daily chart', () => {
+    const makePineTS = () => new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-04-01').getTime());
+
+    it('timeframe.change("W") fires on first bar of each week', async () => {
+        const code = `
+//@version=5
+indicator("tf.change W test")
+chg = timeframe.change("W") ? 1 : 0
+plot(chg, "weekly_change")
+plot(dayofweek, "dow")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const chgData = plots['weekly_change'].data.filter((d: any) => d.value != null);
+        expect(chgData.length).toBeGreaterThan(0);
+
+        // Count changes — should be roughly one per week over ~90 days = ~12-13 weeks
+        const changeCount = chgData.filter((d: any) => d.value === 1).length;
+        expect(changeCount).toBeGreaterThanOrEqual(10);
+        expect(changeCount).toBeLessThanOrEqual(15);
+
+        // Non-change bars should far outnumber change bars (6:1 ratio for weekly on daily)
+        const noChangeCount = chgData.filter((d: any) => d.value === 0).length;
+        expect(noChangeCount).toBeGreaterThan(changeCount * 4);
+    });
+
+    it('timeframe.change("M") fires on first bar of each month', async () => {
+        const code = `
+//@version=5
+indicator("tf.change M test")
+chg = timeframe.change("M") ? 1 : 0
+plot(chg, "monthly_change")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const chgData = plots['monthly_change'].data.filter((d: any) => d.value != null);
+        expect(chgData.length).toBeGreaterThan(0);
+
+        // Jan-Mar = 3 months, so 2-3 change events (first bar might not trigger if it's Jan 1st with no prior bar)
+        const changeCount = chgData.filter((d: any) => d.value === 1).length;
+        expect(changeCount).toBeGreaterThanOrEqual(2);
+        expect(changeCount).toBeLessThanOrEqual(4);
+    });
+
+    it('timeframe.change("D") always returns true on daily chart (every bar is a new day)', async () => {
+        const code = `
+//@version=5
+indicator("tf.change D on D test")
+chg = timeframe.change("D") ? 1 : 0
+plot(chg, "daily_change")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const chgData = plots['daily_change'].data.filter((d: any) => d.value != null);
+        // On a daily chart, every bar is a new day (except possibly bar 0 where prev is NaN)
+        const changes = chgData.filter((d: any) => d.value === 1).length;
+        const total = chgData.length;
+        // Nearly all bars should trigger (except first bar)
+        expect(changes).toBeGreaterThanOrEqual(total - 2);
+    });
+});
+
+describe('timeframe.change() — intraday chart (Binance)', () => {
+    const makePineTS = () => new PineTS(Provider.Binance, 'BTCUSDC', '15', 200);
+
+    it('timeframe.change("D") fires once per day on 15min chart', async () => {
+        const code = `
+//@version=5
+indicator("tf.change D on 15m")
+chg = timeframe.change("D") ? 1 : 0
+plot(chg, "daily_change")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const chgData = plots['daily_change'].data.filter((d: any) => d.value != null);
+
+        // 200 bars of 15min = ~50 hours = ~2 days → expect 1-3 daily changes
+        const changeCount = chgData.filter((d: any) => d.value === 1).length;
+        expect(changeCount).toBeGreaterThanOrEqual(1);
+        expect(changeCount).toBeLessThanOrEqual(4);
+
+        // Most bars should NOT be changes (96 bars per day, only 1 triggers)
+        const noChangeCount = chgData.filter((d: any) => d.value === 0).length;
+        expect(noChangeCount).toBeGreaterThan(changeCount * 10);
+    });
+
+    it('timeframe.change("60") fires every 4 bars on 15min chart', async () => {
+        const code = `
+//@version=5
+indicator("tf.change 60 on 15m")
+chg = timeframe.change("60") ? 1 : 0
+plot(chg, "hourly_change")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const chgData = plots['hourly_change'].data.filter((d: any) => d.value != null);
+
+        // 200 bars of 15min = ~50 hours → ~50 hourly changes
+        const changeCount = chgData.filter((d: any) => d.value === 1).length;
+        expect(changeCount).toBeGreaterThanOrEqual(40);
+        expect(changeCount).toBeLessThanOrEqual(55);
+
+        // Ratio should be roughly 1:3 (1 change per 4 bars)
+        const noChangeCount = chgData.filter((d: any) => d.value === 0).length;
+        expect(noChangeCount).toBeGreaterThan(changeCount * 2);
+        expect(noChangeCount).toBeLessThan(changeCount * 4);
+    });
+
+    it('timeframe.change("240") fires every 16 bars on 15min chart', async () => {
+        const code = `
+//@version=5
+indicator("tf.change 240 on 15m")
+chg = timeframe.change("240") ? 1 : 0
+plot(chg, "4h_change")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const chgData = plots['4h_change'].data.filter((d: any) => d.value != null);
+
+        // 200 bars of 15min = ~50 hours → ~12 four-hour changes
+        const changeCount = chgData.filter((d: any) => d.value === 1).length;
+        expect(changeCount).toBeGreaterThanOrEqual(10);
+        expect(changeCount).toBeLessThanOrEqual(15);
+    });
+});
+
+describe('timeframe.change() — consistency with time()', () => {
+    it('timeframe.change fires exactly when time() value changes', async () => {
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', '15', 100);
+        const code = `
+//@version=5
+indicator("tf.change vs time consistency")
+t_d = time("D")
+chg_d = timeframe.change("D") ? 1 : 0
+// Detect when time("D") changes manually
+manual_chg = ta.change(t_d) != 0 ? 1 : 0
+plot(chg_d, "tf_change")
+plot(manual_chg, "manual_change")
+`;
+        const { plots } = await pineTS.run(code);
+
+        const tfChg = plots['tf_change'].data;
+        const manualChg = plots['manual_change'].data;
+
+        // timeframe.change("D") should agree with ta.change(time("D")) != 0
+        let checked = 0;
+        for (let i = 0; i < tfChg.length; i++) {
+            if (tfChg[i].value != null && manualChg[i].value != null) {
+                expect(tfChg[i].value).toBe(manualChg[i].value);
+                checked++;
+            }
+        }
+        expect(checked).toBeGreaterThan(50);
+    });
+});


### PR DESCRIPTION
## [0.9.11] - 2026-04-12 - `time()` HTF Semantics, `timeframe.change()` & Live-Stream `var` Snapshots

### Added

- **`time()` with a `timeframe` argument**: **`TimeHelper`** now aligns the active bar to the **higher timeframe** and returns the **opening timestamp** of the HTF bar that contains the current bar (intraday, daily, weekly, monthly). Empty or chart-matching timeframe still returns the bar’s own time. **`timeframe_bars_back`** handling was removed in favor of this alignment model (see TradingView-style HTF `time()`).
- **Session + HTF `time()`**: When **`session`** is set, the session test uses the **aligned HTF time**, not only the chart bar time.
- **`timeframe.change(timeframe)`**: Implemented on **`Timeframe`** — compares **previous vs current** bar open times aligned to the target TF and returns **`true`** on the **first bar of a new HTF period** (uses shared **`normalizeTimeframe`** / **`alignToTimeframe`** from **`Time.ts`**).
- **Tests**: **`time-function.test.ts`**, **`timeframe-change.test.ts`**.

### Fixed

- **Live stream (`runLive`) and `var` state**: Re-execution of the **last bar** no longer relies only on **`_removeLastResult`** for **`var`** persistence. The runtime **snapshots `var` / `let` / `const` / `params`** before the last bar, then **restores** that snapshot before refetch and re-run, so **`var`** entries stay consistent when the feed updates (avoids in-place drift across streaming ticks).