### PR TITLE
fix: allow live streaming when eDate is provided

### DIFF
--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -281,8 +281,14 @@ export class PineTS {
         // Start execution
         (async () => {
             try {
+                // When live streaming is requested with an eDate, clamp eDate to now
+                // to avoid gaps between historical data end and live data start
+                if (live && typeof this.eDate !== 'undefined') {
+                    this.eDate = Math.max(this.eDate, Date.now());
+                }
+
                 // Determine if live streaming is possible and requested
-                const isLiveCapable = typeof this.eDate === 'undefined' && !Array.isArray(this.source);
+                const isLiveCapable = !Array.isArray(this.source);
                 const enableLiveStream = isLiveCapable && live;
 
                 // Pass undefined for periods to include all data


### PR DESCRIPTION
Problem

When eDate is passed to PineTS, live streaming is disabled even when live: true is explicitly set in stream() options.
This forces users to choose between:

Passing eDate for accurate historical data bounds (but no live updates)
Omitting eDate for live updates (risking data gaps near date boundaries)
Solution

When live: true is requested in stream(), clamp eDate to Math.max(eDate, Date.now()) to ensure:

Historical data fetches up to the current time (no gaps)
Live streaming continues from the current time
This maintains backwards compatibility — behavior is unchanged when live: false or when eDate is not provided.

Changes

src/PineTS.class.ts: Modified stream() method to clamp
eDate when live streaming is requested
Testing

Tested manually with FMP provider. Existing tests pass (72 failures appear pre-existing in TA namespace, unrelated to this change).