### PR TITLE
## [0.9.14] - 2026-05-05 - UDT & Transpiler Hardening, `request.security`, Streaming & Drawing `na`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Change Log
 
+## [0.9.14] - 2026-05-05 - UDT & Transpiler Hardening, `request.security`, Streaming & Drawing `na`
+
+### Added
+
+- **`str.format_time(time, format, timezone)`**: Full string-based time formatting aligned with Pine Script (`Str.ts`, tests in `str.test.ts`).
+- **`for...of` runtime helpers**: Codegen uses **`$.iter`** / **`$.entries`** instead of brittle one-off special cases.
+- **UDT registry pre-pass**: **`preProcessUdtRegistry`** runs before analysis so **`ScopeManager`** is populated consistently (5 dedicated tests).
+
+### Fixed
+
+- **Live streaming with `eDate`**: **`runLive`** / live mode now works when an end date is provided; previously the combination was incorrectly rejected or behaved as non-live (**`PineTS.class.ts`**).
+- **`for...in` over `MemberExpression` iterables**: Destructuring in **`for...in`** when the iterable is a member expression (e.g. chained property access) is transformed correctly (**`MainTransformer`**).
+- **`request.security`**: Named arguments resolve through **`parseArgsForPineParams`** with **array/tuple-aware** `remaining_options`; secondary-context **bar alignment** improved; **`calc_bars_count`** threaded through the security pipeline.
+- **Callable drawing/table namespaces**: **`box`**, **`linefill`**, **`polyline`**, **`table`** — fixes for correct call vs instance dispatch in transpiled code.
+- **Reserved words in generated JS**: Transpiler avoids invalid identifiers when Pine names collide with JavaScript reserved words.
+- **Comma-separated typed declarations**: Multiple declarations on one line with shared type; guard tightened so **`chart.point[] a = ..., chart.point[] b = ...`** (dotted / repeated types) is split handled as separate statements instead of mis-parsing (**`parseTypedVarDeclaration`**).
+- **Contextual Pine Script keywords**: Parser treats keywords contextually so valid identifiers / constructs are not broken by overly greedy keyword rules.
+- **UDT field subscripts in call arguments**: Per-bar lookback (`seriesVar.field[1]`) inside function-call arguments is transformed correctly.
+- **UDT field-subscript & method transpiler**: Broader fixes for member access and methods on UDT instances.
+- **UDT `.new()` mixed positional + named args**: When the last argument is a plain object whose keys match UDT field names, it is stripped and applied as named fields instead of shifting positional slots (**`Core.ts` UDT constructor**).
+- **UFCS `obj.method()`**: Method names that are JS reserved words keep correct **`$M_`** naming without double **`_$N`** renames; **`Holder r = arr.get(0)`** with an explicit UDT type registers **`r`** for instance dispatch; **`.delete()`** on built-in drawing objects is not retargeted as a user method.
+- **Typed `na` for drawings**: **`box(na)`**, **`line(na)`**, **`label(na)`**, **`polyline(na)`**, **`linefill(na)`**, **`table(na)`** behave as Pine **typed `na`** / casts, not as calls that build empty drawing instances.
+- **UDT registration across function parameters**: Exiting a function that took a UDT parameter no longer clears outer-scope UDT-instance bindings — prior registrations are **snapshotted and restored** so patterns like **`var T x = T.new(...)`** plus **`foo(T x)`** still resolve **`x.foo()`** later.
+- **Plots & deleted drawings**: Deleted drawing objects are **omitted** from generated plot payloads so consumers do not see stale handles.
+- **Default colors**: Restored sensible default stroke/fill styling for **`box`** and **`polyline`** when colors are omitted.
+- **Documentation**: Various doc updates (merged with this release train).
+
+---
+
 ## [0.9.12] - 2026-04-15 - FMP Provider: `mintick`, Forex vs Crypto & Resilient `getSymbolInfo`
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.13",
+    "version": "0.9.14",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -736,6 +736,37 @@ export class Context {
         }
     }
 
+    /**
+     * Resolve an iterable for `for x in collection` codegen.
+     * Handles PineArrayObject (unwrap to inner JS array) and plain JS arrays uniformly.
+     * Returns the value itself if it's already iterable (Map, Set, etc.).
+     *
+     * Centralizing this here means the transpiler can emit a uniform shape regardless of
+     * whether the iterable is a built-in returning a plain array (e.g. box.all) or a UDT
+     * field holding a PineArrayObject — and future collection types only need to update
+     * this helper, not the codegen.
+     */
+    iter(source: any): any {
+        if (source == null) return [];
+        // PineArrayObject wraps the underlying JS array as `.array`
+        if (Array.isArray(source.array)) return source.array;
+        return source;
+    }
+
+    /**
+     * Resolve an iterable yielding [index, value] tuples for `for [i, x] in collection`
+     * destructuring codegen. PineArrayObject's [Symbol.iterator] yields scalar values, so
+     * we must explicitly call `.entries()` on the underlying array.
+     */
+    entries(source: any): IterableIterator<[number, any]> {
+        if (source == null) return [].entries();
+        if (Array.isArray(source.array)) return source.array.entries();
+        if (Array.isArray(source)) return source.entries();
+        // Map / Set / other iterables that already yield tuples
+        if (typeof source.entries === 'function') return source.entries();
+        return [].entries();
+    }
+
     //#region [Call Stack Management] ===========================
 
     private _callStack: string[] = [];

--- a/src/namespaces/Core.ts
+++ b/src/namespaces/Core.ts
@@ -191,7 +191,15 @@ export class Core {
         return _options;
     }
     indicator(...args) {
-        const options = parseIndicatorOptions(args);
+        // The transpiler wraps every positional arg with `$.param(...)`, which
+        // promotes booleans / numbers to a `Series` instance (strings and
+        // objects pass through as-is). Multi-signature matching in
+        // `parseArgsForPineParams` then fails the `boolean` / `number` type
+        // checks because a Series is neither — so `overlay=true`,
+        // `precision=N`, etc. silently drop back to defaults. Unwrap any
+        // Series here to expose the underlying scalar.
+        const unwrapped = args.map(a => a instanceof Series ? a.get(0) : a);
+        const options = parseIndicatorOptions(unwrapped);
 
         const defaults = {
             title: '',

--- a/src/namespaces/Core.ts
+++ b/src/namespaces/Core.ts
@@ -81,7 +81,13 @@ export class NAHelper {
     }
 
     any(series: any) {
+        // Pine Script function defaults like `param = na` get transpiled to JS
+        // `param = na`, where `na` is this NAHelper instance. When the caller
+        // omits the argument, the parameter ends up holding the helper itself
+        // — which must be recognised as NA, not as a regular object.
+        if (series instanceof NAHelper) return true;
         const val = Series.from(series).get(0);
+        if (val instanceof NAHelper) return true;
         // null/undefined are always na
         if (val === null || val === undefined) return true;
         // For numbers, check NaN (Pine Script na for numeric types)
@@ -502,23 +508,28 @@ export class Core {
                 // Map positional args to field names, applying defaults for missing args
                 const mappedArgs: Record<string, any> = {};
 
-                // Detect named args object: if the first (and only) argument is a plain
-                // object whose keys match field names, treat it as named arguments.
-                // This handles the Pine pattern: MyType.new(field1 = val1, field2 = val2)
-                // which the transpiler converts to: MyType.new({ field1: val1, field2: val2 })
+                // Detect a trailing named-args object. The transpiler turns
+                //   MyType.new(p1, p2, named1 = v1, named2 = v2)
+                // into
+                //   MyType.new(p1, p2, { named1: v1, named2: v2 })
+                // The named-args object is always the LAST positional, so check
+                // args[args.length - 1] — not args[0]. Pure-named calls (length 1)
+                // and mixed positional+named calls are both handled by this rule.
                 let namedArgs: Record<string, any> | null = null;
-                if (
-                    args.length === 1 &&
-                    args[0] &&
-                    typeof args[0] === 'object' &&
-                    !(args[0] instanceof Series) &&
-                    !Array.isArray(args[0]) &&
-                    !(args[0] instanceof PineTypeObject)
-                ) {
-                    const keys = Object.keys(args[0]);
-                    if (keys.length > 0 && keys.some((k) => definitionKeys.includes(k))) {
-                        namedArgs = args[0];
-                        args = []; // Clear positional args
+                if (args.length > 0) {
+                    const last = args[args.length - 1];
+                    if (
+                        last &&
+                        typeof last === 'object' &&
+                        !(last instanceof Series) &&
+                        !Array.isArray(last) &&
+                        !(last instanceof PineTypeObject)
+                    ) {
+                        const keys = Object.keys(last);
+                        if (keys.length > 0 && keys.some((k) => definitionKeys.includes(k))) {
+                            namedArgs = last;
+                            args = args.slice(0, -1);
+                        }
                     }
                 }
 

--- a/src/namespaces/Str.ts
+++ b/src/namespaces/Str.ts
@@ -3,6 +3,14 @@
 import { Series } from '../Series';
 import { Context } from '..';
 import { PineArrayObject, PineArrayType } from './array/PineArrayObject';
+import { getDatePartsInTimezone } from './Time';
+
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const MONTH_LONG = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+const DAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const DAY_LONG = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+const pad = (n: number, len: number) => String(n).padStart(len, '0');
 
 export class Str {
     constructor(private context: Context) {}
@@ -131,6 +139,109 @@ export class Str {
     }
     substring(source: string, begin_pos: number, end_pos: number) {
         return String(source).substring(begin_pos, end_pos);
+    }
+
+    /**
+     * Format a UNIX millisecond timestamp using Java SimpleDateFormat-style tokens
+     * (yyyy, MM, dd, HH, mm, ss, EEE, EEEE, MMM, MMMM, a, h, S, Z, etc.).
+     * Text inside single quotes is treated as a literal; '' produces a literal '.
+     */
+    format_time(time: any, format: string = "yyyy-MM-dd'T'HH:mm:ssZ", timezone?: string) {
+        if (time === null || time === undefined || (typeof time === 'number' && isNaN(time))) {
+            return 'NaN';
+        }
+        const ts = Number(time);
+        const tz = timezone || this.context.pine?.syminfo?.timezone || 'UTC';
+        const parts = getDatePartsInTimezone(ts, tz);
+
+        // Compute timezone offset (for Z token) by comparing tz-local recomposed UTC ms to actual ts
+        const tzAsUtc = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+        const offsetMin = Math.round((tzAsUtc - ts) / 60000);
+
+        // Day of year (in target tz)
+        const startOfYearUtc = Date.UTC(parts.year, 0, 1);
+        const dayOfYear = Math.floor((tzAsUtc - startOfYearUtc) / 86400000) + 1;
+
+        const hour12 = parts.hour % 12 === 0 ? 12 : parts.hour % 12;
+
+        let result = '';
+        let i = 0;
+        while (i < format.length) {
+            const ch = format[i];
+
+            // Single-quoted literal
+            if (ch === "'") {
+                if (format[i + 1] === "'") { result += "'"; i += 2; continue; }
+                const end = format.indexOf("'", i + 1);
+                if (end === -1) { result += format.substring(i + 1); break; }
+                result += format.substring(i + 1, end);
+                i = end + 1;
+                continue;
+            }
+
+            // Pattern token: count consecutive same-letter chars
+            if ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+                let count = 1;
+                while (format[i + count] === ch) count++;
+                i += count;
+
+                switch (ch) {
+                    case 'y':
+                        result += count === 2 ? pad(parts.year % 100, 2) : count >= 4 ? pad(parts.year, 4) : String(parts.year);
+                        break;
+                    case 'M':
+                        if (count >= 4) result += MONTH_LONG[parts.month - 1];
+                        else if (count === 3) result += MONTH_SHORT[parts.month - 1];
+                        else if (count === 2) result += pad(parts.month, 2);
+                        else result += String(parts.month);
+                        break;
+                    case 'd':
+                        result += count === 2 ? pad(parts.day, 2) : String(parts.day);
+                        break;
+                    case 'D':
+                        result += count >= 3 ? pad(dayOfYear, 3) : count === 2 ? pad(dayOfYear, 2) : String(dayOfYear);
+                        break;
+                    case 'E':
+                        result += count >= 4 ? DAY_LONG[parts.dayOfWeek] : DAY_SHORT[parts.dayOfWeek];
+                        break;
+                    case 'a':
+                        result += parts.hour < 12 ? 'AM' : 'PM';
+                        break;
+                    case 'h':
+                        result += count === 2 ? pad(hour12, 2) : String(hour12);
+                        break;
+                    case 'H':
+                        result += count === 2 ? pad(parts.hour, 2) : String(parts.hour);
+                        break;
+                    case 'm':
+                        result += count === 2 ? pad(parts.minute, 2) : String(parts.minute);
+                        break;
+                    case 's':
+                        result += count === 2 ? pad(parts.second, 2) : String(parts.second);
+                        break;
+                    case 'S': {
+                        const ms = ts - Math.floor(ts / 1000) * 1000;
+                        result += pad(ms, 3).substring(0, count);
+                        break;
+                    }
+                    case 'Z': {
+                        const sign = offsetMin >= 0 ? '+' : '-';
+                        const absMin = Math.abs(offsetMin);
+                        result += `${sign}${pad(Math.floor(absMin / 60), 2)}${pad(absMin % 60, 2)}`;
+                        break;
+                    }
+                    default:
+                        // Unknown letter token — leave as-is
+                        result += ch.repeat(count);
+                }
+                continue;
+            }
+
+            // Literal char
+            result += ch;
+            i++;
+        }
+        return result;
     }
 
     format(message: string, ...args: any[]) {

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -91,13 +91,15 @@ export class BoxHelper {
     }
 
     /**
-     * Resolve a color value, preserving NaN (na) so renderers can detect "no color".
-     * The regular `_resolve(val) || fallback` pattern treats NaN as falsy and replaces
-     * it with the default, losing the explicit `border_color = na` intent.
+     * Resolve a color value, preserving na markers so renderers can detect "no color".
+     * Pine emits na either as NaN (from `bgcolor = na`) or as null (from
+     * `bgcolor = color(na)` — `color(na)` returns null per PineColor.any). Both
+     * must survive — replacing them with a default would force renderers to paint
+     * a visible color where the script asked for none.
      */
     private _resolveColor(val: any, fallback: string): any {
         const resolved = this._resolve(val);
-        // NaN means `na` in Pine Script — preserve it so renderers can detect it
+        if (resolved === null || resolved === undefined) return resolved;
         if (typeof resolved === 'number' && isNaN(resolved)) return NaN;
         return resolved || fallback;
     }

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -45,7 +45,7 @@ export class BoxHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._boxes.map(bx => bx.toPlotData());
+        const allPlotData = this._boxes.filter(bx => !bx._deleted).map(bx => bx.toPlotData());
 
         // Split force_overlay objects into a separate overlay plot (renders on main chart pane)
         const regular = allPlotData.filter((b: any) => !b.force_overlay);

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -202,7 +202,25 @@ export class BoxHelper {
         );
     }
 
-    any(...args: any[]): BoxObject {
+    any(...args: any[]): BoxObject | null {
+        // Pine `box(arg)` is a type cast / typed-na, NOT a constructor:
+        //   box bx = box(na)         → typed-na (na(bx) is true)
+        //   box bx = box(some_box)   → no-op cast (bx === some_box)
+        // The constructor is `box.new(...)`. Multi-arg calls fall through to
+        // .new() to preserve any incidental usage.
+        if (args.length === 1) {
+            const arg = args[0];
+            if (arg === null || arg === undefined) return null;
+            if (arg instanceof NAHelper) return null;
+            if (typeof arg === 'number' && isNaN(arg)) return null;
+            if (arg instanceof BoxObject) return arg;
+            if (arg instanceof Series) {
+                const v = arg.get(0);
+                if (v === null || v === undefined || (typeof v === 'number' && isNaN(v))) return null;
+                if (v instanceof BoxObject) return v;
+            }
+            return null;
+        }
         return this.new(...args);
     }
 

--- a/src/namespaces/label/LabelHelper.ts
+++ b/src/namespaces/label/LabelHelper.ts
@@ -44,7 +44,7 @@ export class LabelHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._labels.map(lbl => lbl.toPlotData());
+        const allPlotData = this._labels.filter(lbl => !lbl._deleted).map(lbl => lbl.toPlotData());
 
         // Split force_overlay objects into a separate overlay plot (renders on main chart pane)
         const regular = allPlotData.filter((l: any) => !l.force_overlay);

--- a/src/namespaces/label/LabelHelper.ts
+++ b/src/namespaces/label/LabelHelper.ts
@@ -184,7 +184,21 @@ export class LabelHelper {
     }
 
     // label() direct call — mapped via NAMESPACES_LIKE → label.any()
-    any(...args: any[]): LabelObject {
+    // Pine `label(arg)` is a type cast / typed-na, NOT a constructor.
+    any(...args: any[]): LabelObject | null {
+        if (args.length === 1) {
+            const arg = args[0];
+            if (arg === null || arg === undefined) return null;
+            if (arg instanceof NAHelper) return null;
+            if (typeof arg === 'number' && isNaN(arg)) return null;
+            if (arg instanceof LabelObject) return arg;
+            if (arg instanceof Series) {
+                const v = arg.get(0);
+                if (v === null || v === undefined || (typeof v === 'number' && isNaN(v))) return null;
+                if (v instanceof LabelObject) return v;
+            }
+            return null;
+        }
         return this.new(...args);
     }
 

--- a/src/namespaces/line/LineHelper.ts
+++ b/src/namespaces/line/LineHelper.ts
@@ -42,7 +42,7 @@ export class LineHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._lines.map(ln => ln.toPlotData());
+        const allPlotData = this._lines.filter(ln => !ln._deleted).map(ln => ln.toPlotData());
 
         // Split force_overlay objects into a separate overlay plot (renders on main chart pane)
         const regular = allPlotData.filter((l: any) => !l.force_overlay);

--- a/src/namespaces/line/LineHelper.ts
+++ b/src/namespaces/line/LineHelper.ts
@@ -183,7 +183,21 @@ export class LineHelper {
     }
 
     // line() direct call — mapped via NAMESPACES_LIKE → line.any()
-    any(...args: any[]): LineObject {
+    // Pine `line(arg)` is a type cast / typed-na, NOT a constructor.
+    any(...args: any[]): LineObject | null {
+        if (args.length === 1) {
+            const arg = args[0];
+            if (arg === null || arg === undefined) return null;
+            if (arg instanceof NAHelper) return null;
+            if (typeof arg === 'number' && isNaN(arg)) return null;
+            if (arg instanceof LineObject) return arg;
+            if (arg instanceof Series) {
+                const v = arg.get(0);
+                if (v === null || v === undefined || (typeof v === 'number' && isNaN(v))) return null;
+                if (v instanceof LineObject) return v;
+            }
+            return null;
+        }
         return this.new(...args);
     }
 

--- a/src/namespaces/linefill/LinefillHelper.ts
+++ b/src/namespaces/linefill/LinefillHelper.ts
@@ -27,7 +27,7 @@ export class LinefillHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._linefills.map(lf => lf.toPlotData());
+        const allPlotData = this._linefills.filter(lf => !lf._deleted).map(lf => lf.toPlotData());
 
         // Split force_overlay linefills into a separate overlay plot
         const regular = allPlotData.filter((lf: any) => !lf.force_overlay);

--- a/src/namespaces/linefill/LinefillHelper.ts
+++ b/src/namespaces/linefill/LinefillHelper.ts
@@ -111,7 +111,16 @@ export class LinefillHelper {
     }
 
     // linefill() direct call — mapped via NAMESPACES_LIKE → linefill.any()
-    any(...args: any[]): LinefillObject {
+    // Pine `linefill(arg)` with a single arg is a type cast / typed-na.
+    any(...args: any[]): LinefillObject | null {
+        if (args.length === 1) {
+            const arg = args[0];
+            if (arg === null || arg === undefined) return null;
+            if (arg instanceof NAHelper) return null;
+            if (typeof arg === 'number' && isNaN(arg)) return null;
+            if (arg instanceof LinefillObject) return arg;
+            return null;
+        }
         return this.new(args[0], args[1], args[2]);
     }
 

--- a/src/namespaces/polyline/PolylineHelper.ts
+++ b/src/namespaces/polyline/PolylineHelper.ts
@@ -32,7 +32,7 @@ export class PolylineHelper {
         const time = this.context.marketData[0]?.openTime || 0;
         this.context.plots['__polylines__'].data = [{
             time,
-            value: this._polylines.map(pl => pl.toPlotData()),
+            value: this._polylines.filter(pl => !pl._deleted).map(pl => pl.toPlotData()),
             options: { style: 'drawing_polyline' },
         }];
     }

--- a/src/namespaces/polyline/PolylineHelper.ts
+++ b/src/namespaces/polyline/PolylineHelper.ts
@@ -174,7 +174,21 @@ export class PolylineHelper {
     }
 
     // polyline() direct call — mapped via NAMESPACES_LIKE → polyline.any()
-    any(...args: any[]): PolylineObject {
+    // Pine `polyline(arg)` is a type cast / typed-na, NOT a constructor.
+    any(...args: any[]): PolylineObject | null {
+        if (args.length === 1) {
+            const arg = args[0];
+            if (arg === null || arg === undefined) return null;
+            if (arg instanceof NAHelper) return null;
+            if (typeof arg === 'number' && isNaN(arg)) return null;
+            if (arg instanceof PolylineObject) return arg;
+            if (arg instanceof Series) {
+                const v = arg.get(0);
+                if (v === null || v === undefined || (typeof v === 'number' && isNaN(v))) return null;
+                if (v instanceof PolylineObject) return v;
+            }
+            return null;
+        }
         return this.new(...args);
     }
 

--- a/src/namespaces/polyline/PolylineHelper.ts
+++ b/src/namespaces/polyline/PolylineHelper.ts
@@ -54,11 +54,13 @@ export class PolylineHelper {
     }
 
     /**
-     * Resolve a color value, preserving NaN (na = no color) instead of
-     * letting it fall through to a default via the || operator.
+     * Resolve a color value, preserving na markers (NaN from `na`, null from
+     * `color(na)`) so renderers can detect "no color" instead of forcing a
+     * default via the `||` operator.
      */
     private _resolveColor(val: any, fallback: string): any {
         const resolved = this._resolve(val);
+        if (resolved === null || resolved === undefined) return resolved;
         if (typeof resolved === 'number' && isNaN(resolved)) return NaN;
         return resolved || fallback;
     }

--- a/src/namespaces/request/methods/security.ts
+++ b/src/namespaces/request/methods/security.ts
@@ -5,6 +5,86 @@ import { Series } from '../../../Series';
 import { TIMEFRAMES, normalizeTimeframe } from '../utils/TIMEFRAMES';
 import { findSecContextIdx } from '../utils/findSecContextIdx';
 import { findLTFContextIdx } from '../utils/findLTFContextIdx';
+import { parseArgsForPineParams } from '../../utils';
+
+// Pine signature (v5/v6):
+//   request.security(symbol, timeframe, expression, gaps, lookahead, ignore_invalid_symbol, currency, calc_bars_count)
+// Multiple sub-signatures cover progressive truncation when later positional args
+// are absent — required so a single named arg (e.g. `lookahead = …`) doesn't
+// invalidate matching just because trailing positional slots are unfilled.
+const SECURITY_SIGNATURES = [
+    ['symbol', 'timeframe', 'expression'],
+    ['symbol', 'timeframe', 'expression', 'gaps'],
+    ['symbol', 'timeframe', 'expression', 'gaps', 'lookahead'],
+    ['symbol', 'timeframe', 'expression', 'gaps', 'lookahead', 'ignore_invalid_symbol'],
+    ['symbol', 'timeframe', 'expression', 'gaps', 'lookahead', 'ignore_invalid_symbol', 'currency'],
+    ['symbol', 'timeframe', 'expression', 'gaps', 'lookahead', 'ignore_invalid_symbol', 'currency', 'calc_bars_count'],
+];
+const SECURITY_TYPES = {
+    symbol: 'series',
+    timeframe: 'series',
+    // `expression` accepts anything: primitive, tuple, object, Series, etc.
+    expression: 'any',
+    gaps: 'series',
+    lookahead: 'series',
+    ignore_invalid_symbol: 'series',
+    currency: 'series',
+    calc_bars_count: 'series',
+};
+
+/**
+ * Detect a request.param wrapper tuple `[value, name]`.
+ * Tuple shape: 2-element array whose [1] is a string param name.
+ * (Tuple expressions like `[o, c]` are 2 elements but [1] is a Series, not a string.)
+ */
+function isParamTuple(v: any): v is [any, string] {
+    return Array.isArray(v) && v.length === 2 && typeof v[1] === 'string';
+}
+
+/**
+ * Unwrap a request.param `[value, name]` tuple into just the value, and capture
+ * its name into `outNames` at the same index. Other arg shapes pass through.
+ */
+function unwrapParamTuples(rawArgs: any[], outNames: (string | undefined)[]): any[] {
+    return rawArgs.map((a) => {
+        if (isParamTuple(a)) {
+            outNames.push(a[1]);
+            return a[0];
+        }
+        outNames.push(undefined);
+        return a;
+    });
+}
+
+/**
+ * Resolve the value of a parsed slot — handles values that are themselves
+ * request.param wrapper tuples. This happens when the slot was filled via
+ * the named-args bag (e.g. `lookahead: p54` where p54 is a wrapper).
+ */
+function resolveSlotValue(v: any): any {
+    return isParamTuple(v) ? v[0] : v;
+}
+
+/**
+ * Resolve the request.param name attached to a slot. Checks two sources:
+ *  1. The positional argName captured at parse time (slot filled positionally).
+ *  2. The wrapper tuple inside the options bag (slot filled via named args).
+ */
+function resolveSlotName(
+    slotName: string,
+    signatures: string[][],
+    argNames: (string | undefined)[],
+    parsedSlot: any,
+): string | undefined {
+    // Pick the longest signature — others are prefixes of it.
+    const fullSig = signatures[signatures.length - 1];
+    const idx = fullSig.indexOf(slotName);
+    if (idx >= 0 && idx < argNames.length && argNames[idx] !== undefined) {
+        return argNames[idx];
+    }
+    if (isParamTuple(parsedSlot)) return parsedSlot[1];
+    return undefined;
+}
 
 /**
  * Resolve raw expression values that may contain helper objects
@@ -25,33 +105,53 @@ function resolveExprValue(v: any): any {
 }
 
 export function security(context: any) {
-    return async (
-        symbol: any,
-        timeframe: any,
-        expression: any,
-        gaps: boolean | any[] = false,
-        lookahead: boolean | any[] = false,
-        ignore_invalid_symbol: boolean = false,
-        currency: any = null,
-        calc_bars_count: any = null
-    ) => {
+    return async (...rawArgs: any[]) => {
+        // Pine named-arg semantics: bind to the function's known signature by name,
+        // not by position. The transpiler emits a trailing options object; we let
+        // parseArgsForPineParams (which already handles `remaining_options`) merge
+        // it into the right named slots. This is required so that calls like
+        //   request.security(symbol, tf, expr, lookahead = barmerge.lookahead_on)
+        // correctly set lookahead — previously the options bag was landing in the
+        // `gaps` positional slot.
+        const argNames: (string | undefined)[] = [];
+        const args = unwrapParamTuples(rawArgs, argNames);
+        const parsed = parseArgsForPineParams<any>(args, SECURITY_SIGNATURES, SECURITY_TYPES);
+
+        // Slots filled via named-args bag may still contain wrapped [val, name] tuples
+        // (e.g. `lookahead: p54` where p54 is a request.param wrapper). Unwrap each.
+        const symbolSlot = resolveSlotValue(parsed.symbol);
+        const timeframeSlot = resolveSlotValue(parsed.timeframe);
+        const expressionSlot = resolveSlotValue(parsed.expression);
+        const gapsSlot = resolveSlotValue(parsed.gaps);
+        const lookaheadSlot = resolveSlotValue(parsed.lookahead);
+
         // Strip exchange prefix (e.g. "BINANCE:BTCUSDC" → "BTCUSDC") so the
         // provider receives a clean ticker when creating a secondary context.
-        const rawSymbol = symbol[0] instanceof Series ? (symbol[0] as Series).get(0) : symbol[0];
+        const rawSymbol = symbolSlot instanceof Series ? symbolSlot.get(0) : symbolSlot;
         // Empty string "" means "use chart's symbol" (Pine Script spec)
         const resolvedSymbol = rawSymbol === '' ? context.tickerId : rawSymbol;
         const _symbol = typeof resolvedSymbol === 'string' && resolvedSymbol.includes(':') ? resolvedSymbol.split(':')[1] : resolvedSymbol;
-        const rawTimeframe = timeframe[0] instanceof Series ? (timeframe[0] as Series).get(0) : timeframe[0];
+        const rawTimeframe = timeframeSlot instanceof Series ? timeframeSlot.get(0) : timeframeSlot;
         // Empty string "" means "use chart's timeframe" (Pine Script spec)
         const _timeframe = rawTimeframe === '' ? context.timeframe : (typeof rawTimeframe === 'string' ? rawTimeframe : String(rawTimeframe ?? ''));
-        const _expression = expression[0];
-        const _expression_name = expression[1];
-        const _gapsRaw = Array.isArray(gaps) ? gaps[0] : gaps;
-        const _lookaheadRaw = Array.isArray(lookahead) ? lookahead[0] : lookahead;
+        const _expression = expressionSlot;
+        // Cache key uses the request.param name attached to the expression wrapper.
+        // It identifies the expression's call-site so that secContext.params lookup
+        // can find the per-bar evaluated values.
+        const _expression_name = resolveSlotName('expression', SECURITY_SIGNATURES, argNames, parsed.expression);
+        const _gapsRaw = gapsSlot;
+        const _lookaheadRaw = lookaheadSlot;
         // barmerge.gaps_off/on and barmerge.lookahead_off/on are string enums ('gaps_off', 'gaps_on', etc.)
         // Convert to boolean for correct behavior in findLTFContextIdx/findSecContextIdx
         const _gaps = _gapsRaw === true || _gapsRaw === 'gaps_on';
         const _lookahead = _lookaheadRaw === true || _lookaheadRaw === 'lookahead_on';
+        // calc_bars_count gives the secondary the requested historical depth at the
+        // security TF — important when chart TF is much smaller than security TF
+        // (e.g. 15m chart, daily security where 500 chart bars cover only ~5 daily bars).
+        const _calc_bars_count = (() => {
+            const v = resolveSlotValue(parsed.calc_bars_count);
+            return typeof v === 'number' && v > 0 ? v : undefined;
+        })();
 
         // CRITICAL: Prevent infinite recursion in secondary contexts
         // If this is a secondary context (created by another request.security),
@@ -151,24 +251,39 @@ export function security(context: any) {
         // Determine start date for secondary context.
         // Use context.sDate if available, otherwise derive from the earliest bar's
         // openTime to ensure the secondary context covers the same time range as the main chart.
+        //
+        // When calc_bars_count is set, leave sDate unbounded so the provider returns
+        // the requested number of bars ending at secEDate — the chart's date range
+        // alone may not cover enough HTF bars (e.g. 500 bars at 15m = ~5 days, but a
+        // request for 500 daily bars needs ~500 days of history).
         const effectiveSDate = context.sDate
             || (context.marketData?.length > 0 ? context.marketData[0].openTime : undefined);
-        const adjustedSDate = effectiveSDate ? effectiveSDate - buffer : undefined;
+        const adjustedSDate = _calc_bars_count
+            ? undefined
+            : (effectiveSDate ? effectiveSDate - buffer : undefined);
 
         // Determine end date for secondary context.
-        // The last chart bar's intrabars may extend beyond context.eDate (e.g., a weekly
-        // bar that opens before eDate but whose daily intrabars close after eDate).
-        // Use lastBarCloseTime to cover the full range of the last bar's intrabars.
-        // When eDate is undefined (live/streaming mode), derive from the last bar's
-        // closeTime or current time, adding a buffer for partial/current bars.
+        //
+        // The secondary's data range must align with the chart's actual data range so
+        // that `barstate.islast` in the secondary fires at the same temporal point as
+        // the chart's `barstate.islast`. This matters for scripts that gate their
+        // expression on barstate.islast (e.g. `barstate.islast ? data : na`) and rely
+        // on lookahead to read it from the security at the chart's last bar.
+        //
+        // Use the chart's actual lastBarCloseTime (NOT eDate, which can be a future
+        // ceiling that the chart's data hasn't reached yet, and NOT a generous buffer,
+        // which would extend the secondary into future bars where barstate.islast
+        // would fire AFTER the chart's last temporal point).
+        //
+        // Falls back to context.eDate or Date.now() if marketData isn't populated yet.
         const lastBarCloseTime = context.marketData?.length > 0
             ? context.marketData[context.marketData.length - 1].closeTime
             : 0;
-        const secEDate = context.eDate
-            ? Math.max(context.eDate, lastBarCloseTime)
-            : (lastBarCloseTime || Date.now()) + buffer;
+        const secEDate = lastBarCloseTime || context.eDate || Date.now();
 
-        const pineTS = new PineTS(context.source, _symbol, _timeframe, undefined, adjustedSDate, secEDate);
+        // Pass calc_bars_count as `periods` so the secondary fetches that many bars
+        // ending at secEDate — gives the script the historical depth it asked for.
+        const pineTS = new PineTS(context.source, _symbol, _timeframe, _calc_bars_count, adjustedSDate, secEDate);
 
         // Mark as secondary context to prevent infinite recursion
         pineTS.markAsSecondary();

--- a/src/namespaces/request/methods/security_lower_tf.ts
+++ b/src/namespaces/request/methods/security_lower_tf.ts
@@ -4,6 +4,61 @@ import { PineTS } from '../../../PineTS.class';
 import { Series } from '../../../Series';
 import { TIMEFRAMES, normalizeTimeframe } from '../utils/TIMEFRAMES';
 import { PineArrayObject, PineArrayType } from '../../array/PineArrayObject';
+import { parseArgsForPineParams } from '../../utils';
+
+// Pine signature (v5/v6):
+//   request.security_lower_tf(symbol, timeframe, expression, ignore_invalid_symbol, currency, ignore_invalid_timeframe, calc_bars_count)
+// Note: no `gaps`/`lookahead` for security_lower_tf — different surface than security.
+const SECURITY_LOWER_TF_SIGNATURES = [
+    ['symbol', 'timeframe', 'expression'],
+    ['symbol', 'timeframe', 'expression', 'ignore_invalid_symbol'],
+    ['symbol', 'timeframe', 'expression', 'ignore_invalid_symbol', 'currency'],
+    ['symbol', 'timeframe', 'expression', 'ignore_invalid_symbol', 'currency', 'ignore_invalid_timeframe'],
+    ['symbol', 'timeframe', 'expression', 'ignore_invalid_symbol', 'currency', 'ignore_invalid_timeframe', 'calc_bars_count'],
+];
+const SECURITY_LOWER_TF_TYPES = {
+    symbol: 'series',
+    timeframe: 'series',
+    expression: 'any',
+    ignore_invalid_symbol: 'series',
+    currency: 'series',
+    ignore_invalid_timeframe: 'series',
+    calc_bars_count: 'series',
+};
+
+function isParamTuple(v: any): v is [any, string] {
+    return Array.isArray(v) && v.length === 2 && typeof v[1] === 'string';
+}
+
+function unwrapParamTuples(rawArgs: any[], outNames: (string | undefined)[]): any[] {
+    return rawArgs.map((a) => {
+        if (isParamTuple(a)) {
+            outNames.push(a[1]);
+            return a[0];
+        }
+        outNames.push(undefined);
+        return a;
+    });
+}
+
+function resolveSlotValue(v: any): any {
+    return isParamTuple(v) ? v[0] : v;
+}
+
+function resolveSlotName(
+    slotName: string,
+    signatures: string[][],
+    argNames: (string | undefined)[],
+    parsedSlot: any,
+): string | undefined {
+    const fullSig = signatures[signatures.length - 1];
+    const idx = fullSig.indexOf(slotName);
+    if (idx >= 0 && idx < argNames.length && argNames[idx] !== undefined) {
+        return argNames[idx];
+    }
+    if (isParamTuple(parsedSlot)) return parsedSlot[1];
+    return undefined;
+}
 
 /**
  * Detect the PineArrayType from a runtime value.
@@ -24,27 +79,32 @@ function detectArrayType(value: any): PineArrayType {
  * @returns
  */
 export function security_lower_tf(context: any) {
-    return async (
-        symbol: any,
-        timeframe: any,
-        expression: any,
-        ignore_invalid_symbol: boolean | any[] = false,
-        currency: any = null,
-        ignore_invalid_timeframe: boolean | any[] = false,
-        calc_bars_count: number | any[] = 0
-    ) => {
-        const rawSymbol = symbol[0] instanceof Series ? (symbol[0] as Series).get(0) : symbol[0];
+    return async (...rawArgs: any[]) => {
+        // Same Pine named-args resolution as request.security — bind by name to the
+        // documented signature, with the trailing options bag merged into named slots.
+        const argNames: (string | undefined)[] = [];
+        const args = unwrapParamTuples(rawArgs, argNames);
+        const parsed = parseArgsForPineParams<any>(args, SECURITY_LOWER_TF_SIGNATURES, SECURITY_LOWER_TF_TYPES);
+
+        const symbolSlot = resolveSlotValue(parsed.symbol);
+        const timeframeSlot = resolveSlotValue(parsed.timeframe);
+        const expressionSlot = resolveSlotValue(parsed.expression);
+
+        const rawSymbol = symbolSlot instanceof Series ? symbolSlot.get(0) : symbolSlot;
         // Empty string "" means "use chart's symbol" (Pine Script spec)
         const resolvedSymbol = rawSymbol === '' ? context.tickerId : rawSymbol;
         const _symbol = typeof resolvedSymbol === 'string' && resolvedSymbol.includes(':') ? resolvedSymbol.split(':')[1] : resolvedSymbol;
-        const rawTimeframe = timeframe[0] instanceof Series ? (timeframe[0] as Series).get(0) : timeframe[0];
+        const rawTimeframe = timeframeSlot instanceof Series ? timeframeSlot.get(0) : timeframeSlot;
         // Empty string "" means "use chart's timeframe" (Pine Script spec)
         const _timeframe = rawTimeframe === '' ? context.timeframe : (typeof rawTimeframe === 'string' ? rawTimeframe : String(rawTimeframe ?? ''));
-        const _expression = expression[0];
-        const _expression_name = expression[1];
-        const _ignore_invalid_symbol = Array.isArray(ignore_invalid_symbol) ? ignore_invalid_symbol[0] : ignore_invalid_symbol;
-        const _ignore_invalid_timeframe = Array.isArray(ignore_invalid_timeframe) ? ignore_invalid_timeframe[0] : ignore_invalid_timeframe;
-        // const _calc_bars_count = Array.isArray(calc_bars_count) ? calc_bars_count[0] : calc_bars_count;
+        const _expression = expressionSlot;
+        const _expression_name = resolveSlotName('expression', SECURITY_LOWER_TF_SIGNATURES, argNames, parsed.expression);
+        const _ignore_invalid_symbol = resolveSlotValue(parsed.ignore_invalid_symbol);
+        const _ignore_invalid_timeframe = resolveSlotValue(parsed.ignore_invalid_timeframe);
+        const _calc_bars_count = (() => {
+            const v = resolveSlotValue(parsed.calc_bars_count);
+            return typeof v === 'number' && v > 0 ? v : undefined;
+        })();
 
         // CRITICAL: Prevent infinite recursion in secondary contexts
         // Still wrap in PineArrayObject so array.size() etc. work in the secondary script
@@ -95,15 +155,15 @@ export function security_lower_tf(context: any) {
                 || (context.marketData?.length > 0 ? context.marketData[0].openTime : undefined);
             const adjustedSDate = effectiveSDate ? effectiveSDate - buffer : undefined;
 
-            // Determine end date: cover last bar's intrabars without overshooting
+            // Align secondary's end date with the chart's actual data so that
+            // `barstate.islast` in the secondary fires at the same temporal point as
+            // the chart's `barstate.islast`. See security.ts for full rationale.
             const lastBarCloseTime = context.marketData?.length > 0
                 ? context.marketData[context.marketData.length - 1].closeTime
                 : 0;
-            const secEDate = context.eDate
-                ? Math.max(context.eDate, lastBarCloseTime)
-                : (lastBarCloseTime || Date.now()) + buffer;
+            const secEDate = lastBarCloseTime || context.eDate || Date.now();
 
-            const pineTS = new PineTS(context.source, _symbol, _timeframe, undefined, adjustedSDate, secEDate);
+            const pineTS = new PineTS(context.source, _symbol, _timeframe, _calc_bars_count, adjustedSDate, secEDate);
             pineTS.markAsSecondary();
 
             const secContext = await pineTS.run(context.pineTSCode);

--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -27,7 +27,7 @@ export class TableHelper {
         const time = this.context.marketData[0]?.openTime || 0;
         this.context.plots['__tables__'].data = [{
             time,
-            value: this._tables.map(tbl => tbl.toPlotData()),
+            value: this._tables.filter(tbl => !tbl._deleted).map(tbl => tbl.toPlotData()),
             options: { style: 'table' },
         }];
     }

--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -110,7 +110,16 @@ export class TableHelper {
         return tbl;
     }
 
-    any(...args: any[]): TableObject {
+    // Pine `table(arg)` is a type cast / typed-na, NOT a constructor.
+    any(...args: any[]): TableObject | null {
+        if (args.length === 1) {
+            const arg = args[0];
+            if (arg === null || arg === undefined) return null;
+            if (typeof arg === 'object' && '__value' in arg) return null;  // NAHelper-like
+            if (typeof arg === 'number' && isNaN(arg)) return null;
+            if (arg instanceof TableObject) return arg;
+            return null;
+        }
         return this.new(...args);
     }
 

--- a/src/namespaces/utils.ts
+++ b/src/namespaces/utils.ts
@@ -21,8 +21,16 @@ const TYPE_CHECK = {
     undefined: (arg) => arg === undefined,
     null: (arg) => arg === null,
     NaN: (arg) => isNaN(arg),
+    // Permissive type: matches any value. Use sparingly — for slots like
+    // request.security's `expression` that legitimately accept anything
+    // (primitives, tuples, objects, Series, ...).
+    any: () => true,
 
-    remaining_options: (arg) => arg !== null && typeof arg === 'object' && !(arg instanceof Series) && !(arg instanceof ChartPointObject) && !isPlot(arg),
+    // Named-args bags emitted by the transpiler are always plain `{key: val}`
+    // objects — never arrays. Excluding arrays here lets functions like
+    // request.security accept tuple expressions (e.g. `[o, c]`) as a positional
+    // arg without misinterpreting them as the options bag.
+    remaining_options: (arg) => arg !== null && typeof arg === 'object' && !Array.isArray(arg) && !(arg instanceof Series) && !(arg instanceof ChartPointObject) && !isPlot(arg),
 };
 
 export type PineTypeMap<T> = {

--- a/src/transpiler/analysis/AnalysisPass.ts
+++ b/src/transpiler/analysis/AnalysisPass.ts
@@ -55,6 +55,73 @@ export function transformNestedArrowFunctions(ast: any): void {
     });
 }
 
+/**
+ * Pre-walk the AST to populate the UDT registry on the ScopeManager.
+ *
+ * Two registries are populated:
+ *   1. UDT type names — collected from `const X = Type({field: ['type', default], ...})`
+ *      which pine2js emits from Pine `type X` declarations. The field-type metadata
+ *      is stored alongside (V2 data model) for future use-site type-aware rewrites.
+ *
+ *   2. UDT instance variables — variables initialized via `<X>.new(...)` or
+ *      `<X>.copy(...)` where X ∈ udtTypeNames. Each instance is tagged with its
+ *      UDT type name (V2 shape).
+ *
+ * The instance check intentionally consults `isUdtTypeName(X)` rather than just
+ * "X is an Identifier", so built-in factory calls like `array.from(...)`,
+ * `polyline.new(...)`, `chart.point.from_index(...)` are excluded — those are
+ * handled by their own runtime layers and must NOT be treated as UDT instances.
+ */
+export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): void {
+    // Pass 1: collect UDT type names (and their field metadata) from `Type({...})` calls.
+    walk.simple(ast, {
+        VariableDeclaration(node: any) {
+            for (const decl of node.declarations) {
+                if (decl.id?.type !== 'Identifier' || !decl.init) continue;
+                if (
+                    decl.init.type === 'CallExpression' &&
+                    decl.init.callee?.type === 'Identifier' &&
+                    decl.init.callee.name === 'Type' &&
+                    decl.init.arguments?.length === 1 &&
+                    decl.init.arguments[0]?.type === 'ObjectExpression'
+                ) {
+                    const fields: Record<string, string> = {};
+                    for (const prop of decl.init.arguments[0].properties) {
+                        if (prop.type !== 'Property' || prop.key?.type !== 'Identifier') continue;
+                        // Each value is `['type', default]` (ArrayExpression) or `'type'` (Literal).
+                        if (prop.value?.type === 'ArrayExpression' && prop.value.elements?.[0]?.type === 'Literal') {
+                            fields[prop.key.name] = String(prop.value.elements[0].value);
+                        } else if (prop.value?.type === 'Literal') {
+                            fields[prop.key.name] = String(prop.value.value);
+                        }
+                    }
+                    scopeManager.addUdtTypeName(decl.id.name, fields);
+                }
+            }
+        },
+    });
+
+    // Pass 2: collect variables initialized via `<UDT>.new(...)` or `<UDT>.copy(...)`.
+    walk.simple(ast, {
+        VariableDeclaration(node: any) {
+            for (const decl of node.declarations) {
+                if (decl.id?.type !== 'Identifier' || !decl.init) continue;
+                if (
+                    decl.init.type === 'CallExpression' &&
+                    decl.init.callee?.type === 'MemberExpression' &&
+                    !decl.init.callee.computed &&
+                    decl.init.callee.object?.type === 'Identifier' &&
+                    decl.init.callee.property?.type === 'Identifier' &&
+                    (decl.init.callee.property.name === 'new' || decl.init.callee.property.name === 'copy') &&
+                    scopeManager.isUdtTypeName(decl.init.callee.object.name)
+                ) {
+                    scopeManager.markVariableAsUdtInstance(decl.id.name, decl.init.callee.object.name);
+                }
+            }
+        },
+    });
+}
+
 export function preProcessContextBoundVars(ast: any, scopeManager: ScopeManager): void {
     walk.simple(ast, {
         VariableDeclaration(node: any) {

--- a/src/transpiler/analysis/AnalysisPass.ts
+++ b/src/transpiler/analysis/AnalysisPass.ts
@@ -201,6 +201,28 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
                 }
             }
         },
+        // Pass 2b: pick up explicit Pine type annotations preserved by codegen
+        // as bare string-literal markers (`"__pineUdtVar:<varName>=<TypeName>"`).
+        // This covers cases the expression-based inference can't reach — e.g.
+        // `Holder r = arr.get(0)`, `Holder r = map.get(key)`, etc. — where the
+        // Pine type is stated explicitly but the initializer is not directly
+        // recognisable as UDT-producing.
+        ExpressionStatement(node: any) {
+            const expr = node.expression;
+            if (
+                expr?.type === 'Literal' &&
+                typeof expr.value === 'string' &&
+                expr.value.startsWith('__pineUdtVar:')
+            ) {
+                const m = expr.value.match(/^__pineUdtVar:([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)$/);
+                if (m) {
+                    const [, varName, typeName] = m;
+                    if (scopeManager.isUdtTypeName(typeName)) {
+                        scopeManager.markVariableAsUdtInstance(varName, typeName);
+                    }
+                }
+            }
+        },
     });
 
     // Pass 3: collect UDT-typed function parameters from the

--- a/src/transpiler/analysis/AnalysisPass.ts
+++ b/src/transpiler/analysis/AnalysisPass.ts
@@ -101,25 +101,237 @@ export function preProcessUdtRegistry(ast: any, scopeManager: ScopeManager): voi
         },
     });
 
-    // Pass 2: collect variables initialized via `<UDT>.new(...)` or `<UDT>.copy(...)`.
+    // Pass 1.5: infer user-function return types iteratively.
+    //
+    // A function is recorded as returning a UDT when ALL of its return-path
+    // expressions resolve (via `inferUdtTypeFromInit`) to the SAME UDT type.
+    // It is recorded as returning a tuple when ALL return paths are
+    // ArrayExpressions of the same length and each slot resolves to the
+    // same UDT type (or undefined for non-UDT slots).
+    //
+    // Iteration handles call chains where one helper calls another:
+    //   makeBarHelper() => BAR.new()
+    //   makeBar()       => makeBarHelper()
+    // The first iteration registers `makeBarHelper`; the second uses that
+    // result to register `makeBar`. Loop until no new entries are added.
+    let changed = true;
+    while (changed) {
+        changed = false;
+        walk.simple(ast, {
+            FunctionDeclaration(node: any) {
+                if (!node.id?.name) return;
+                const fnName = node.id.name;
+                const alreadyKnown =
+                    scopeManager.getFunctionReturnType(fnName) ||
+                    scopeManager.getFunctionReturnTupleType(fnName);
+                if (alreadyKnown) return;
+                const returns = collectReturnArguments(node.body);
+                if (returns.length === 0) return;
+
+                // Tuple return: every return path is an ArrayExpression of the
+                // same length, and each slot independently produces the same
+                // UDT (or consistently non-UDT → undefined).
+                if (returns.every((r: any) => r.type === 'ArrayExpression')) {
+                    const len = returns[0].elements.length;
+                    if (len > 0 && returns.every((r: any) => r.elements.length === len)) {
+                        const slotTypes: (string | undefined)[] = [];
+                        let ok = true;
+                        for (let i = 0; i < len; i++) {
+                            const slotPerReturn = returns.map((r: any) =>
+                                inferUdtTypeFromInit(r.elements[i], scopeManager),
+                            );
+                            const first = slotPerReturn[0];
+                            if (!slotPerReturn.every((t) => t === first)) {
+                                ok = false;
+                                break;
+                            }
+                            slotTypes.push(first);
+                        }
+                        // Only register if at least one slot is a UDT — otherwise
+                        // there's nothing to gain.
+                        if (ok && slotTypes.some((t) => !!t)) {
+                            scopeManager.setFunctionReturnTupleType(fnName, slotTypes);
+                            changed = true;
+                            return;
+                        }
+                    }
+                }
+
+                // Scalar UDT return.
+                const types = returns.map((arg: any) => inferUdtTypeFromInit(arg, scopeManager));
+                const first = types[0];
+                if (!first || !types.every((t) => t === first)) return;
+                scopeManager.setFunctionReturnType(fnName, first);
+                changed = true;
+            },
+        });
+    }
+
+    // Pass 2: collect variables initialized to a UDT instance.
     walk.simple(ast, {
         VariableDeclaration(node: any) {
             for (const decl of node.declarations) {
-                if (decl.id?.type !== 'Identifier' || !decl.init) continue;
-                if (
+                if (!decl.init) continue;
+
+                // Scalar binding: `let bar = <init>`.
+                if (decl.id?.type === 'Identifier') {
+                    const typeName = inferUdtTypeFromInit(decl.init, scopeManager);
+                    if (typeName) {
+                        scopeManager.markVariableAsUdtInstance(decl.id.name, typeName);
+                    }
+                    continue;
+                }
+
+                // Tuple destructuring: `let [a, b] = <userFunc>(...)` where the
+                // user function has an inferred tuple return shape. Per-slot
+                // UDT types from the tuple registry register each ArrayPattern
+                // element independently — slots without a UDT are skipped.
+                if (decl.id?.type === 'ArrayPattern' &&
                     decl.init.type === 'CallExpression' &&
-                    decl.init.callee?.type === 'MemberExpression' &&
-                    !decl.init.callee.computed &&
-                    decl.init.callee.object?.type === 'Identifier' &&
-                    decl.init.callee.property?.type === 'Identifier' &&
-                    (decl.init.callee.property.name === 'new' || decl.init.callee.property.name === 'copy') &&
-                    scopeManager.isUdtTypeName(decl.init.callee.object.name)
-                ) {
-                    scopeManager.markVariableAsUdtInstance(decl.id.name, decl.init.callee.object.name);
+                    decl.init.callee?.type === 'Identifier') {
+                    const tupleTypes = scopeManager.getFunctionReturnTupleType(decl.init.callee.name);
+                    if (!tupleTypes) continue;
+                    decl.id.elements?.forEach((el: any, i: number) => {
+                        if (!el || el.type !== 'Identifier') return;
+                        const slotType = tupleTypes[i];
+                        if (slotType) {
+                            scopeManager.markVariableAsUdtInstance(el.name, slotType);
+                        }
+                    });
                 }
             }
         },
     });
+
+    // Pass 3: collect UDT-typed function parameters from the
+    // `funcName.__pineParamTypes__ = {paramName: 'TypeName', ...}` markers
+    // emitted by pine2js codegen. Only types that are themselves in the UDT
+    // type registry are kept — primitives / qualifiers like `int`, `series
+    // float` etc. are silently dropped. The registration tells
+    // `transformFunctionDeclaration` which params to flag as UDT instances
+    // (scope-locally) when entering the function body.
+    walk.simple(ast, {
+        ExpressionStatement(node: any) {
+            const expr = node.expression;
+            if (!expr || expr.type !== 'AssignmentExpression' || expr.operator !== '=') return;
+            const left = expr.left;
+            if (left?.type !== 'MemberExpression' ||
+                left.computed ||
+                left.property?.type !== 'Identifier' ||
+                left.property.name !== '__pineParamTypes__' ||
+                left.object?.type !== 'Identifier') return;
+            if (expr.right?.type !== 'ObjectExpression') return;
+            // Methods carry a `$M_` JS-name prefix; strip it so the registry
+            // is keyed by the Pine name `transformFunctionDeclaration` will
+            // look up at call time.
+            const rawName = left.object.name;
+            const funcName = rawName.startsWith('$M_') ? rawName.slice(3) : rawName;
+            const paramTypes: Record<string, string> = {};
+            for (const prop of expr.right.properties) {
+                if (prop.type !== 'Property') continue;
+                // Codegen emits JSON-quoted keys (`"b"`) which acorn parses as
+                // `Literal`; tolerate `Identifier` too in case the marker shape
+                // ever changes.
+                let paramName: string | undefined;
+                if (prop.key?.type === 'Identifier') paramName = prop.key.name;
+                else if (prop.key?.type === 'Literal' && typeof prop.key.value === 'string') paramName = prop.key.value;
+                if (!paramName) continue;
+                if (prop.value?.type !== 'Literal' || typeof prop.value.value !== 'string') continue;
+                // varType may include qualifiers like 'series BAR' — the type
+                // name is the last whitespace-delimited token.
+                const typeName = prop.value.value.split(/\s+/).pop()!;
+                if (scopeManager.isUdtTypeName(typeName)) {
+                    paramTypes[paramName] = typeName;
+                }
+            }
+            if (Object.keys(paramTypes).length > 0) {
+                scopeManager.setFunctionParamUdtTypes(funcName, paramTypes);
+            }
+        },
+    });
+}
+
+/**
+ * Collect every ReturnStatement.argument inside a function body, but do NOT
+ * descend into nested function declarations (those have their own returns).
+ */
+function collectReturnArguments(body: any): any[] {
+    const out: any[] = [];
+    if (!body) return out;
+    function visit(node: any) {
+        if (!node || typeof node !== 'object') return;
+        // Don't descend into nested function bodies.
+        if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+            return;
+        }
+        if (node.type === 'ReturnStatement' && node.argument) {
+            out.push(node.argument);
+            return;
+        }
+        for (const key of Object.keys(node)) {
+            if (key === 'type') continue;
+            const val = (node as any)[key];
+            if (Array.isArray(val)) val.forEach(visit);
+            else if (val && typeof val === 'object' && val.type) visit(val);
+        }
+    }
+    visit(body);
+    return out;
+}
+
+/**
+ * Inspect an initializer expression and return the UDT type name if it
+ * unambiguously resolves to a UDT instance — otherwise undefined.
+ *
+ * Recognized shapes:
+ *   - `<UDT>.new(...)`           — direct constructor call
+ *   - `<UDT>.copy(...)`          — direct copy call
+ *   - `cond ? <UDT-init> : <UDT-init>`  — ternary where BOTH branches
+ *                                          resolve to the SAME UDT type
+ *
+ * The ternary case recurses, so nested conditionals like
+ * `c1 ? BAR.new() : (c2 ? BAR.copy(s) : BAR.new())` are also recognized.
+ *
+ * Branches that don't unambiguously produce the same UDT (different types,
+ * non-UDT calls, etc.) → undefined → variable not registered as UDT instance
+ * (safer to skip than to misclassify).
+ */
+function inferUdtTypeFromInit(init: any, scopeManager: ScopeManager): string | undefined {
+    if (!init) return undefined;
+
+    // `<UDT>.new(...)` / `<UDT>.copy(...)`
+    if (
+        init.type === 'CallExpression' &&
+        init.callee?.type === 'MemberExpression' &&
+        !init.callee.computed &&
+        init.callee.object?.type === 'Identifier' &&
+        init.callee.property?.type === 'Identifier' &&
+        (init.callee.property.name === 'new' || init.callee.property.name === 'copy') &&
+        scopeManager.isUdtTypeName(init.callee.object.name)
+    ) {
+        return init.callee.object.name;
+    }
+
+    // `<userFunc>(...)` — when the function's return type has been inferred
+    // as a UDT (see Pass 1.5 in preProcessUdtRegistry).
+    if (
+        init.type === 'CallExpression' &&
+        init.callee?.type === 'Identifier'
+    ) {
+        const fnRetType = scopeManager.getFunctionReturnType(init.callee.name);
+        if (fnRetType) return fnRetType;
+    }
+
+    // Conditional / ternary: both branches must resolve to the same UDT type.
+    if (init.type === 'ConditionalExpression') {
+        const consequentType = inferUdtTypeFromInit(init.consequent, scopeManager);
+        const alternateType = inferUdtTypeFromInit(init.alternate, scopeManager);
+        if (consequentType && consequentType === alternateType) {
+            return consequentType;
+        }
+    }
+
+    return undefined;
 }
 
 export function preProcessContextBoundVars(ast: any, scopeManager: ScopeManager): void {
@@ -194,6 +406,12 @@ export function runAnalysisPass(ast: any, scopeManager: ScopeManager): string | 
         // These mark user functions declared with the `method` keyword, which ARE
         // allowed to be called with obj.method() dot-notation.  Regular functions
         // (without `method`) must NOT be callable via dot-notation.
+        //
+        // Methods are emitted with a `$M_` prefix on their JS identifier so they
+        // never collide with a regular function of the same Pine name. The
+        // marker is on the prefixed name; we strip it to register the Pine name
+        // in `userMethods` and `userFunctions` so the call-site lookup
+        // (`obj.methodName(...)`) resolves cleanly.
         ExpressionStatement(node: any) {
             const expr = node.expression;
             if (expr && expr.type === 'AssignmentExpression' && expr.operator === '=' &&
@@ -201,7 +419,14 @@ export function runAnalysisPass(ast: any, scopeManager: ScopeManager): string | 
                 expr.left.property?.name === '__pineMethod__' &&
                 expr.left.object?.type === 'Identifier' &&
                 expr.right?.value === true) {
-                scopeManager.addUserMethod(expr.left.object.name);
+                const jsName = expr.left.object.name;
+                const pineName = jsName.startsWith('$M_') ? jsName.slice(3) : jsName;
+                scopeManager.addUserMethod(pineName);
+                // Also expose the Pine name as a "user function" so the call-site
+                // check `isUserFunction(methodName) && isUserMethod(methodName)`
+                // passes for methods that exist only in `method` form (no
+                // sibling regular function).
+                scopeManager.addUserFunction(pineName);
             }
         },
         ArrowFunctionExpression(node: any) {

--- a/src/transpiler/analysis/AnalysisPass.ts
+++ b/src/transpiler/analysis/AnalysisPass.ts
@@ -400,6 +400,15 @@ export function runAnalysisPass(ast: any, scopeManager: ScopeManager): string | 
             if (node.id && node.id.name) {
                 scopeManager.addReservedName(node.id.name);
                 scopeManager.addUserFunction(node.id.name);
+                // Track regular (non-method) user functions separately so
+                // UFCS-style direct calls to method-only Pine declarations
+                // (`foo(receiver, args)` where `foo` was declared as
+                // `method foo(...)`) can be retargeted to the `$M_` JS name.
+                // Methods are emitted with a `$M_` JS prefix; absence of
+                // that prefix means it's a regular function.
+                if (!node.id.name.startsWith('$M_')) {
+                    scopeManager.addRegularUserFunction(node.id.name);
+                }
             }
         },
         // Detect Pine `method` markers emitted by codegen: name.__pineMethod__ = true;

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -64,6 +64,17 @@ export class ScopeManager {
     private reservedNames: Set<string> = new Set();
     private userFunctions: Set<string> = new Set();
     private userMethods: Set<string> = new Set();
+    /**
+     * Regular user-declared functions (i.e. NOT methods). Tracked separately
+     * from `userFunctions` so a UFCS-style direct call to a method-only
+     * declaration (`foo(receiver, args)` where `foo` was declared as
+     * `method foo(...)`) can be retargeted to the prefixed JS name.
+     *
+     * If a Pine name has both a regular function and a method form, the
+     * regular function takes precedence for direct `name(args)` calls and
+     * the method is reachable via dot-syntax `obj.name(args)`.
+     */
+    private regularUserFunctions: Set<string> = new Set();
 
     /**
      * Registry of user-defined UDT type names → their field map (fieldName → fieldType).
@@ -375,6 +386,14 @@ export class ScopeManager {
 
     isUserMethod(name: string): boolean {
         return this.userMethods.has(name);
+    }
+
+    addRegularUserFunction(name: string): void {
+        this.regularUserFunctions.add(name);
+    }
+
+    isRegularUserFunction(name: string): boolean {
+        return this.regularUserFunctions.has(name);
     }
 
     addVariable(name: string, kind: string): string {

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -85,6 +85,46 @@ export class ScopeManager {
      */
     private udtInstances: Map<string, string> = new Map();
 
+    /**
+     * Registry of user-defined function names → UDT type they return.
+     * Populated by inspecting each FunctionDeclaration's return paths during
+     * the UDT pre-pass. A function is registered only when ALL return paths
+     * unambiguously produce the SAME UDT type.
+     *
+     * Used by the instance populator so that `bar = makeBar()` registers
+     * `bar` as a UDT instance when `makeBar` is known to return one.
+     */
+    private functionReturnTypes: Map<string, string> = new Map();
+
+    /**
+     * Registry of user-defined function names → tuple of UDT type names they
+     * return. Each slot holds either the UDT type name at that position, or
+     * `undefined` when that position is not (unambiguously) a UDT instance.
+     *
+     * Populated when ALL return paths of a function are ArrayExpressions of
+     * the SAME length and each position resolves to the SAME UDT (or to
+     * something non-UDT, which becomes `undefined`).
+     *
+     * Used by the instance populator so that `[a, b] = makeBars()` registers
+     * `a` and `b` as UDT instances at their respective tuple positions.
+     */
+    private functionReturnTupleTypes: Map<string, (string | undefined)[]> = new Map();
+
+    /**
+     * Registry of user-defined function names → map of {paramName → UDT type}.
+     * Populated from `<funcName>.__pineParamTypes__ = {...}` markers emitted
+     * by pine2js codegen for parameters that carried a Pine type annotation
+     * (e.g. `readField(BAR b)`). Filtered to UDT-known types so non-UDT
+     * annotations like `int` / `float` / `string` never enter the map.
+     *
+     * Consumed by `transformFunctionDeclaration`: when entering a function's
+     * body, each typed param is temporarily registered as a UDT instance
+     * (`markVariableAsUdtInstance`) so the use-site rewrite for `b.field[N]`
+     * fires inside the body. The registration is removed when leaving the
+     * function scope, keeping the global registry clean.
+     */
+    private functionParamUdtTypes: Map<string, Record<string, string>> = new Map();
+
     public get nextParamIdArg(): any {
         return {
             type: 'Identifier',
@@ -195,6 +235,69 @@ export class ScopeManager {
 
     isUdtInstance(varName: string): boolean {
         return this.udtInstances.has(varName);
+    }
+
+    /**
+     * Record a user-defined function as returning a specific UDT type.
+     * Idempotent — re-registering with the same type is a no-op; conflicting
+     * registrations (different type) drop back to "unknown" by removing the
+     * entry, so an ambiguous function never falsely promotes a caller.
+     */
+    setFunctionReturnType(funcName: string, typeName: string): void {
+        const existing = this.functionReturnTypes.get(funcName);
+        if (existing && existing !== typeName) {
+            this.functionReturnTypes.delete(funcName);
+            return;
+        }
+        this.functionReturnTypes.set(funcName, typeName);
+    }
+
+    getFunctionReturnType(funcName: string): string | undefined {
+        return this.functionReturnTypes.get(funcName);
+    }
+
+    /**
+     * Record a user-defined function as returning a tuple whose positions
+     * carry specific UDT types (or `undefined` for non-UDT positions).
+     * Idempotent — re-registering with the same shape is a no-op; conflicting
+     * registrations (different length OR different type at any position) drop
+     * the entry, so an ambiguous function never falsely promotes a caller.
+     */
+    setFunctionReturnTupleType(funcName: string, tupleTypes: (string | undefined)[]): void {
+        const existing = this.functionReturnTupleTypes.get(funcName);
+        if (existing) {
+            if (existing.length !== tupleTypes.length ||
+                existing.some((t, i) => t !== tupleTypes[i])) {
+                this.functionReturnTupleTypes.delete(funcName);
+                return;
+            }
+        }
+        this.functionReturnTupleTypes.set(funcName, tupleTypes);
+    }
+
+    getFunctionReturnTupleType(funcName: string): (string | undefined)[] | undefined {
+        return this.functionReturnTupleTypes.get(funcName);
+    }
+
+    /**
+     * Record a user-defined function's UDT-typed parameters. The argument
+     * is a `paramName → UDT type` map filtered down to UDT-known types only.
+     */
+    setFunctionParamUdtTypes(funcName: string, paramTypes: Record<string, string>): void {
+        this.functionParamUdtTypes.set(funcName, paramTypes);
+    }
+
+    getFunctionParamUdtTypes(funcName: string): Record<string, string> | undefined {
+        return this.functionParamUdtTypes.get(funcName);
+    }
+
+    /**
+     * Remove a previously-registered UDT instance entry. Used to roll back
+     * scope-local registrations (e.g. UDT-typed function parameters) when
+     * leaving the function body, so the global registry stays clean.
+     */
+    unmarkVariableAsUdtInstance(varName: string): void {
+        this.udtInstances.delete(varName);
     }
 
     addContextBoundVar(name: string, isRootParam: boolean = false): void {

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -65,6 +65,26 @@ export class ScopeManager {
     private userFunctions: Set<string> = new Set();
     private userMethods: Set<string> = new Set();
 
+    /**
+     * Registry of user-defined UDT type names → their field map (fieldName → fieldType).
+     * Populated from `const X = Type({fieldA: ['type', default], ...})` declarations
+     * (which pine2js emits from Pine `type X` declarations).
+     *
+     * V2 data model: stores field-type metadata. V1 logic only consults
+     * `isUdtTypeName` for now; field metadata is ready for future use-site
+     * type-aware rewrites (nested UDT chains, mixed scalar/array fields, etc.).
+     */
+    private udtTypeNames: Map<string, Record<string, string>> = new Map();
+
+    /**
+     * Registry of user variables that hold UDT instances → the UDT type name.
+     * Populated from `let bar = X.new(...)` / `bar = X.copy(...)` where
+     * `X ∈ udtTypeNames`. Stores the type name (V2 shape) so future passes
+     * can do typed-field lookups via `getUdtTypeFields(typeName)` without
+     * a refactor. V1 logic only consults `isUdtInstance`.
+     */
+    private udtInstances: Map<string, string> = new Map();
+
     public get nextParamIdArg(): any {
         return {
             type: 'Identifier',
@@ -145,6 +165,36 @@ export class ScopeManager {
 
     isLocalSeriesVar(name: string): boolean {
         return this.localSeriesVars.has(name);
+    }
+
+    // ── UDT registry ────────────────────────────────────────────────────
+    // V2-shape data model populated up-front; V1 logic only uses the
+    // boolean checks (`isUdtTypeName`, `isUdtInstance`) at use sites.
+    // Field-type metadata and per-variable UDT-type lookups are ready
+    // for future use (nested-field type discrimination, etc.).
+
+    addUdtTypeName(typeName: string, fields: Record<string, string> = {}): void {
+        this.udtTypeNames.set(typeName, fields);
+    }
+
+    isUdtTypeName(name: string): boolean {
+        return this.udtTypeNames.has(name);
+    }
+
+    getUdtTypeFields(typeName: string): Record<string, string> | undefined {
+        return this.udtTypeNames.get(typeName);
+    }
+
+    markVariableAsUdtInstance(varName: string, typeName: string): void {
+        this.udtInstances.set(varName, typeName);
+    }
+
+    getVariableUdtType(varName: string): string | undefined {
+        return this.udtInstances.get(varName);
+    }
+
+    isUdtInstance(varName: string): boolean {
+        return this.udtInstances.has(varName);
     }
 
     addContextBoundVar(name: string, isRootParam: boolean = false): void {

--- a/src/transpiler/index.ts
+++ b/src/transpiler/index.ts
@@ -52,7 +52,7 @@ import ScopeManager from './analysis/ScopeManager';
 import { injectImplicitImports } from './transformers/InjectionTransformer';
 import { normalizeNativeImports } from './transformers/NormalizationTransformer';
 import { wrapInContextFunction } from './transformers/WrapperTransformer';
-import { transformNestedArrowFunctions, preProcessContextBoundVars, runAnalysisPass } from './analysis/AnalysisPass';
+import { transformNestedArrowFunctions, preProcessContextBoundVars, preProcessUdtRegistry, runAnalysisPass } from './analysis/AnalysisPass';
 import { runTransformationPass, transformEqualityChecks, propagateAsyncAwait } from './transformers/MainTransformer';
 import { extractPineScriptVersion, pineToJS } from './pineToJS/pineToJS.index';
 
@@ -114,6 +114,12 @@ export function transpile(source: string | Function, options: { debug: boolean; 
 
     // Pre-process: Identify context-bound variables
     preProcessContextBoundVars(ast, scopeManager);
+
+    // Pre-process: Build the UDT registry (type names + their field maps,
+    // and user variables that hold UDT instances). Enables type-aware
+    // rewrites at use sites — e.g. distinguishing Pine series-lookback
+    // (`bar.field[N]` on a UDT instance) from JS array indexing.
+    preProcessUdtRegistry(ast, scopeManager);
 
     // First pass: register all function declarations and their parameters
     // Returns the original parameter name of the root function if any

--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -392,7 +392,9 @@ export class CodeGenerator {
     }
 
     // Rename Identifier nodes in an AST subtree (simple, non-context-aware).
-    // Used for function parameter renaming. Stops at FunctionDeclaration boundaries.
+    // Used for the `this → self` rewrite where every `this` refers to the
+    // method receiver and must be rewritten unconditionally. Stops at
+    // FunctionDeclaration boundaries.
     private renameIdentifiersInAST(node: any, renameMap: Map<string, string>) {
         if (!node || typeof node !== 'object') return;
 
@@ -419,58 +421,163 @@ export class CodeGenerator {
         }
     }
 
+    // Rename Identifier nodes belonging to a function's parameters, when the
+    // param name shadows a Pine namespace or built-in (e.g. param `color`
+    // shadows the `color.new(...)` namespace). Context-aware:
+    //   - MemberExpression objects with non-computed access (`color.new(...)`)
+    //     are LEFT ALONE — those are namespace accesses, not the renamed param.
+    //   - CallExpression callees that match the renamed name are LEFT ALONE
+    //     for the same reason (`color(arg)` calls the namespace function).
+    //   - Object literal property keys (`{ color: value }`) are LEFT ALONE.
+    //   - Bare reads (`x = color`) and arguments (`color.new(color, 73)` —
+    //     the inner one) ARE renamed.
+    // Stops at nested FunctionDeclaration boundaries.
+    private renameParamRefsInBody(node: any, renameMap: Map<string, string>) {
+        if (!node || typeof node !== 'object') return;
+
+        // Don't descend into nested functions — they have their own scope.
+        if (node.type === 'FunctionDeclaration') return;
+
+        // CallExpression: skip the callee Identifier when it matches a
+        // renamed param (namespace function call: `color(arg)`).
+        if (node.type === 'CallExpression') {
+            if (node.callee?.type === 'Identifier' && renameMap.has(node.callee.name)) {
+                // Skip callee — leave as namespace function reference.
+            } else {
+                this.renameParamRefsInBody(node.callee, renameMap);
+            }
+            if (node.arguments) {
+                for (const arg of node.arguments) {
+                    this.renameParamRefsInBody(arg, renameMap);
+                }
+            }
+            return;
+        }
+
+        // MemberExpression: skip the object when it matches a renamed param
+        // and the access is non-computed (namespace member access:
+        // `color.new(...)`, `size.tiny`).
+        if (node.type === 'MemberExpression') {
+            if (!node.computed && node.object?.type === 'Identifier' && renameMap.has(node.object.name)) {
+                // Skip the object; nothing else to rename here (property is
+                // a static name on a namespace).
+                return;
+            }
+            this.renameParamRefsInBody(node.object, renameMap);
+            if (node.computed) this.renameParamRefsInBody(node.property, renameMap);
+            return;
+        }
+
+        // Property: rename the value, never the key.
+        if (node.type === 'Property') {
+            this.renameParamRefsInBody(node.value, renameMap);
+            return;
+        }
+
+        // Leaf: rename matching Identifier.
+        if (node.type === 'Identifier' && renameMap.has(node.name)) {
+            node.name = renameMap.get(node.name);
+            return;
+        }
+
+        // Recurse into all children.
+        for (const key of Object.keys(node)) {
+            if (key === 'type') continue;
+            const val = node[key];
+            if (Array.isArray(val)) {
+                for (const child of val) {
+                    if (child && typeof child === 'object') {
+                        this.renameParamRefsInBody(child, renameMap);
+                    }
+                }
+            } else if (val && typeof val === 'object' && val.type) {
+                this.renameParamRefsInBody(val, renameMap);
+            }
+        }
+    }
+
     // Generate FunctionDeclaration
     generateFunctionDeclaration(node) {
         this.write(this.indentStr.repeat(this.indent));
 
-        // Don't output methods as standalone functions - they'll be attached to objects at runtime
-        // Just generate them as regular functions for now, skipping first 'this' param
+        // Methods are emitted as regular JS functions; the receiver is passed
+        // explicitly as the first positional arg by the call-site rewrite
+        // (see ExpressionTransformer's `obj.method(args)` → `$.call(method, id, obj, args)`).
         const isMethod = node.id.isMethod;
 
         // Detect function params that collide with Pine context names (namespaces, builtins, etc.)
         // and rename them to avoid Phase 2 transpiler misinterpreting them as namespace references.
         // e.g., parameter 'color' would be renamed to 'color_$0' to avoid color.__value() injection.
-        const renameMap = new Map<string, string>();
+        // These renames must be applied context-aware in the body so namespace
+        // usage (`color.new(...)`) is preserved while bare reads of the param
+        // are rewritten.
+        const paramRenameMap = new Map<string, string>();
         for (const param of node.params) {
             const paramName = param.type === 'AssignmentPattern' ? param.left.name : param.name;
             if (paramName && CONFLICTING_NAMES.has(paramName)) {
                 const newName = `${paramName}_$${this.paramRenameCounter++}`;
-                renameMap.set(paramName, newName);
+                paramRenameMap.set(paramName, newName);
             }
         }
 
-        // Apply renaming to param nodes and function body before generating code
-        if (renameMap.size > 0) {
+        // For methods whose first Pine param is `this` (the receiver), rename
+        // it to `self` everywhere — `this` cannot survive as a JS param name
+        // and the body's `this.x := y` mutations would otherwise leak onto
+        // `globalThis` instead of the actual receiver. The call-site already
+        // passes the receiver as the first positional arg, so renaming the
+        // param keeps the calling convention consistent.
+        // This rename is context-FREE (every `this` is the receiver), unlike
+        // the param renames above.
+        const isThisParam = (p: any) =>
+            (p.type === 'Identifier' && p.name === 'this') ||
+            (p.type === 'AssignmentPattern' && p.left?.name === 'this');
+        const thisRenameMap = new Map<string, string>();
+        if (isMethod && node.params.length > 0 && isThisParam(node.params[0])) {
+            thisRenameMap.set('this', 'self');
+        }
+
+        // Apply renames to param nodes and function body.
+        if (paramRenameMap.size > 0 || thisRenameMap.size > 0) {
             for (const param of node.params) {
-                if (param.type === 'AssignmentPattern') {
-                    if (renameMap.has(param.left.name)) {
-                        param.left.name = renameMap.get(param.left.name);
-                    }
-                    // Also rename identifiers in default value expressions
-                    this.renameIdentifiersInAST(param.right, renameMap);
-                } else if (param.type === 'Identifier' && renameMap.has(param.name)) {
-                    param.name = renameMap.get(param.name);
+                const target = param.type === 'AssignmentPattern' ? param.left : param;
+                if (target?.type === 'Identifier') {
+                    const newName = paramRenameMap.get(target.name) ?? thisRenameMap.get(target.name);
+                    if (newName) target.name = newName;
+                }
+                if (param.type === 'AssignmentPattern' && param.right) {
+                    // Default value expressions get the same treatment as the body.
+                    if (paramRenameMap.size > 0) this.renameParamRefsInBody(param.right, paramRenameMap);
+                    if (thisRenameMap.size > 0) this.renameIdentifiersInAST(param.right, thisRenameMap);
                 }
             }
-            this.renameIdentifiersInAST(node.body, renameMap);
+            // Body: namespace-shadowing param renames first (context-aware),
+            // then the unconditional `this → self` rewrite.
+            if (paramRenameMap.size > 0) this.renameParamRefsInBody(node.body, paramRenameMap);
+            if (thisRenameMap.size > 0) this.renameIdentifiersInAST(node.body, thisRenameMap);
         }
 
+        // Methods get a `$M_` prefix on their JS identifier so they can't
+        // collide with a regular function of the same Pine name. Pine does
+        // not allow `$` in identifiers, so this prefix is collision-proof.
+        // The call-site rewrite (ExpressionTransformer) and the marker reader
+        // (AnalysisPass) both know about the prefix.
+        const jsFnName = isMethod ? `$M_${node.id.name}` : node.id.name;
+
         this.write('function ');
-        this.write(node.id.name);
+        this.write(jsFnName);
         this.write('(');
 
-        // Parameters (skip first param if it's a method and first param is 'this')
+        // Parameters — render all of them, including the (now-renamed) `self`
+        // receiver for methods. The receiver is passed explicitly by the
+        // call-site rewrite, so it must appear in the param list.
         const params = node.params;
-        const startIdx = isMethod && params.length > 0 && params[0].type === 'Identifier' && params[0].name === 'this' ? 1 : 0;
 
-        for (let i = startIdx; i < params.length; i++) {
+        for (let i = 0; i < params.length; i++) {
             const param = params[i];
             if (param.type === 'Identifier') {
                 this.write(param.name);
             } else if (param.type === 'AssignmentPattern') {
-                // Handle 'this' in AssignmentPattern
-                const leftName = param.left.name === 'this' && isMethod ? 'self' : param.left.name;
-                this.write(leftName);
+                this.write(param.left.name);
                 this.write(' = ');
                 this.generateExpression(param.right);
             }
@@ -488,7 +595,33 @@ export class CodeGenerator {
         // callable via obj.func() dot-notation — only `method` declarations can.
         if (isMethod) {
             this.write(this.indentStr.repeat(this.indent));
-            this.write(`${node.id.name}.__pineMethod__ = true;\n`);
+            this.write(`${jsFnName}.__pineMethod__ = true;\n`);
+        }
+
+        // Emit param-type marker for any params that carried a Pine type
+        // annotation (e.g. `readField(BAR b)`). The transpile phase reads
+        // these to know which params are UDT instances, enabling correct
+        // `b.field[N]` series-lookback rewriting inside the function body.
+        // Inert at runtime; AnalysisPass filters to known UDT types.
+        // Skip the method receiver (now renamed to `self`) — it's passed by
+        // the caller, never a Series of UDT instances, so the rewrite would
+        // be incorrect for it.
+        const typedParams: Array<[string, string]> = [];
+        for (let i = 0; i < node.params.length; i++) {
+            const p = node.params[i];
+            const paramName = p.type === 'AssignmentPattern' ? p.left?.name : p.name;
+            if (isMethod && i === 0 && paramName === 'self') continue;
+            const varType = p.type === 'AssignmentPattern' ? p.left?.varType : p.varType;
+            if (paramName && varType) {
+                typedParams.push([paramName, varType]);
+            }
+        }
+        if (typedParams.length > 0) {
+            this.write(this.indentStr.repeat(this.indent));
+            const entries = typedParams
+                .map(([n, t]) => `${JSON.stringify(n)}: ${JSON.stringify(t)}`)
+                .join(', ');
+            this.write(`${jsFnName}.__pineParamTypes__ = {${entries}};\n`);
         }
     }
 

--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -4,7 +4,7 @@
 // JavaScript Code Generator for PineScript AST
 // Transforms ESTree-compatible AST into JavaScript code
 
-import { CONTEXT_PINE_VARS, NAMESPACE_COLLISION_NAMES } from '../settings';
+import { CONTEXT_PINE_VARS, NAMESPACE_COLLISION_NAMES, JS_RESERVED_WORDS } from '../settings';
 
 // Set of names that conflict with Pine context variables/namespaces.
 // Function parameters with these names must be renamed to avoid Phase 2
@@ -61,22 +61,33 @@ export class CodeGenerator {
     }
 
     /**
-     * Scan the program body for variable declarations and assignments whose
-     * names collide with Pine namespace/built-in names (e.g., `fill`, `size`,
-     * `color`, `line`). Rename them with a `_$N` suffix so they don't shadow
-     * the namespace destructured from `$.pine`.
+     * Scan the program body for declarations whose names would collide with
+     * either Pine namespaces or JavaScript reserved keywords. Rename them
+     * with a `_$N` suffix.
      *
-     * Only renames **user variables** — function parameters are handled
-     * separately in generateFunctionDeclaration().
+     * Two collision classes, one rename pass:
      *
-     * Renaming rules:
-     * - Variable declaration target (let fill = ...) → renamed
-     * - Assignment target (fill := ...) → renamed
-     * - Bare identifier read (return fill) → renamed
-     * - Call callee (fill(...)) → NOT renamed (namespace call)
-     * - MemberExpression object (size.tiny) → NOT renamed (namespace access)
-     * - MemberExpression property (array.size) → NOT renamed (method name)
-     * - Object property key ({size: ...}) → NOT renamed (named arg key)
+     *  1. Pine namespace collisions (NAMESPACE_COLLISION_NAMES — e.g. `fill`,
+     *     `size`, `color`, `line`): user variable would shadow the namespace
+     *     destructured from `$.pine`. The CALL SITE `fill(...)` is the
+     *     namespace, NOT the renamed variable, so callees are NOT renamed.
+     *
+     *  2. JS reserved keyword collisions (JS_RESERVED_WORDS — e.g. `delete`,
+     *     `super`, `static`): the generated JS would fail to parse
+     *     (`function delete()` → "Unexpected keyword 'delete'"). The CALL SITE
+     *     `delete(arg)` IS the user function, so callees MUST be renamed.
+     *
+     * The walker checks the original name's source list at each call site to
+     * pick the right behavior.
+     *
+     * Renaming rules (common):
+     * - Variable declaration target (let fill = ...)  → renamed
+     * - Function declaration name (function delete()) → renamed (class 2 only)
+     * - Assignment target (fill := ...)               → renamed
+     * - Bare identifier read (return fill)            → renamed
+     * - MemberExpression object (size.tiny)           → NOT renamed
+     * - MemberExpression property (obj.delete)        → NOT renamed
+     * - Object property key ({size: ...})             → NOT renamed
      */
     private renameConflictingVariables(ast: any) {
         const renameMap = new Map<string, string>();
@@ -91,20 +102,30 @@ export class CodeGenerator {
     }
 
     /**
-     * Walk the AST and collect variable declarations / assignment targets
-     * whose names conflict with CONFLICTING_NAMES.
+     * True if `name` requires renaming — either a Pine namespace collision
+     * or a JS reserved keyword (which would make the generated JS invalid).
+     */
+    private isReservedName(name: string | undefined): boolean {
+        return !!name && (NAMESPACE_COLLISION_NAMES.has(name) || JS_RESERVED_WORDS.has(name));
+    }
+
+    /**
+     * Walk the AST and collect declarations whose names conflict with either
+     * Pine namespaces (NAMESPACE_COLLISION_NAMES) or JS reserved keywords
+     * (JS_RESERVED_WORDS). Both collision classes are renamed with the same
+     * `_$N` suffix scheme.
      */
     private collectConflictingVarNames(node: any, renameMap: Map<string, string>) {
         if (!node || typeof node !== 'object') return;
 
         if (node.type === 'VariableDeclaration') {
             for (const decl of node.declarations) {
-                if (decl.id?.type === 'Identifier' && NAMESPACE_COLLISION_NAMES.has(decl.id.name) && !renameMap.has(decl.id.name)) {
+                if (decl.id?.type === 'Identifier' && this.isReservedName(decl.id.name) && !renameMap.has(decl.id.name)) {
                     renameMap.set(decl.id.name, `${decl.id.name}_$${this.paramRenameCounter++}`);
                 }
                 if (decl.id?.type === 'ArrayPattern') {
                     for (const el of decl.id.elements) {
-                        if (el?.type === 'Identifier' && NAMESPACE_COLLISION_NAMES.has(el.name) && !renameMap.has(el.name)) {
+                        if (el?.type === 'Identifier' && this.isReservedName(el.name) && !renameMap.has(el.name)) {
                             renameMap.set(el.name, `${el.name}_$${this.paramRenameCounter++}`);
                         }
                     }
@@ -113,8 +134,16 @@ export class CodeGenerator {
         }
 
         if (node.type === 'AssignmentExpression' || node.type === 'ReassignmentExpression') {
-            if (node.left?.type === 'Identifier' && NAMESPACE_COLLISION_NAMES.has(node.left.name) && !renameMap.has(node.left.name)) {
+            if (node.left?.type === 'Identifier' && this.isReservedName(node.left.name) && !renameMap.has(node.left.name)) {
                 renameMap.set(node.left.name, `${node.left.name}_$${this.paramRenameCounter++}`);
+            }
+        }
+
+        // User-defined function/method names that collide with reserved identifiers.
+        // The function body inherits the rename via the same renameMap pass.
+        if (node.type === 'FunctionDeclaration') {
+            if (node.id?.type === 'Identifier' && this.isReservedName(node.id.name) && !renameMap.has(node.id.name)) {
+                renameMap.set(node.id.name, `${node.id.name}_$${this.paramRenameCounter++}`);
             }
         }
 
@@ -144,12 +173,19 @@ export class CodeGenerator {
     private renameVariableRefsInAST(node: any, renameMap: Map<string, string>) {
         if (!node || typeof node !== 'object') return;
 
-        // CallExpression: skip callee if it's a matching Identifier, rename args
+        // CallExpression: handle direct-Identifier callees specially.
         if (node.type === 'CallExpression') {
-            // For callee: if it's a MemberExpression (like array.size), handle normally via recursion
-            // If it's a direct Identifier (like fill()), skip it — it's a namespace call
             if (node.callee?.type === 'Identifier' && renameMap.has(node.callee.name)) {
-                // Skip callee, only process arguments
+                // Two cases:
+                //   - JS_RESERVED_WORDS rename (e.g. user `method delete` → `delete_$N`):
+                //     the callee IS the user function — must be renamed.
+                //   - NAMESPACE_COLLISION_NAMES rename (e.g. user `var fill = ...` while
+                //     also calling the built-in `fill(...)`): the callee here refers to
+                //     the namespace, not the renamed user variable — leave it alone.
+                if (JS_RESERVED_WORDS.has(node.callee.name)) {
+                    node.callee.name = renameMap.get(node.callee.name)!;
+                }
+                // else: skip callee
             } else {
                 this.renameVariableRefsInAST(node.callee, renameMap);
             }

--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -141,8 +141,17 @@ export class CodeGenerator {
 
         // User-defined function/method names that collide with reserved identifiers.
         // The function body inherits the rename via the same renameMap pass.
+        //
+        // Skip methods (`method foo(...) =>`): their JS identifier already gets
+        // a `$M_` prefix in `generateFunctionDeclaration` which is collision-
+        // proof by construction. Adding `_$N` on top would change the Pine
+        // name visible at the call site (`obj.delete()` looks up `delete`,
+        // not `delete_$0`), breaking UFCS retargeting in ExpressionTransformer.
         if (node.type === 'FunctionDeclaration') {
-            if (node.id?.type === 'Identifier' && this.isReservedName(node.id.name) && !renameMap.has(node.id.name)) {
+            if (node.id?.type === 'Identifier' &&
+                !node.id.isMethod &&
+                this.isReservedName(node.id.name) &&
+                !renameMap.has(node.id.name)) {
                 renameMap.set(node.id.name, `${node.id.name}_$${this.paramRenameCounter++}`);
             }
         }
@@ -688,6 +697,24 @@ export class CodeGenerator {
             }
 
             this.write(';\n');
+
+            // Preserve the explicit Pine type annotation so the AnalysisPass
+            // can register the variable as a UDT instance even when the
+            // initializer's type cannot be inferred from the expression alone
+            // (e.g. `Holder r = arr.get(0)` or `Holder r = map.get(key)`).
+            // Emit a bare string-literal expression statement — acorn keeps it
+            // as `ExpressionStatement(Literal)` and it is a no-op at runtime.
+            const declaredType = decl.id?.varType;
+            const declaredName = decl.id?.type === 'Identifier' ? decl.id.name : null;
+            if (
+                declaredName &&
+                typeof declaredType === 'string' &&
+                /^[A-Za-z_$][\w$]*$/.test(declaredType) &&
+                declaredType[0] === declaredType[0].toUpperCase()
+            ) {
+                this.write(this.indentStr.repeat(this.indent));
+                this.write(`"__pineUdtVar:${declaredName}=${declaredType}";\n`);
+            }
         }
     }
 

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -706,7 +706,31 @@ export class Parser {
         const id = new Identifier(name);
         id.varType = varType;
 
-        return new VariableDeclaration([new VariableDeclarator(id, init, varType)], VariableDeclarationKind.LET);
+        const declarators = [new VariableDeclarator(id, init, varType)];
+
+        // Handle comma-separated typed declarations sharing the same type:
+        //   float a = 0.0, b = 1.0, c = 2.0
+        //   int x = 1, y = 2
+        //   array<float> p = na, q = na
+        // Each subsequent segment is `name = expr` with the leading type reapplied.
+        // Guard with peek(1)===IDENTIFIER so commas belonging to outer constructs
+        // (tuple destructuring, function args, etc.) aren't accidentally consumed.
+        while (this.match(TokenType.COMMA) && this.peek(1).type === TokenType.IDENTIFIER) {
+            this.advance(); // consume ','
+            this.skipNewlines(true);
+            let nextName = this.expect(TokenType.IDENTIFIER).value;
+            if (this.functionNames.has(nextName)) {
+                nextName = nextName + '_var';
+            }
+            this.expect(TokenType.OPERATOR, '=');
+            this.skipNewlines(true);
+            const nextInit = this.parseExpression();
+            const nextId = new Identifier(nextName);
+            nextId.varType = varType;
+            declarators.push(new VariableDeclarator(nextId, nextInit, varType));
+        }
+
+        return new VariableDeclaration(declarators, VariableDeclarationKind.LET);
     }
 
     // Parse function declaration

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -41,6 +41,12 @@ export class Parser {
     private tokens: Token[];
     private pos: number;
     private functionNames: Set<string> = new Set();
+    // Stack of parameter-name sets for currently-being-parsed function bodies.
+    // When the body of fn `f(x, y) =>` is being parsed, the top frame is {x, y}.
+    // Used to suppress the `name → name_var` rewrite for identifiers that are
+    // really parameters of the enclosing function and just happen to share a
+    // name with some other user function.
+    private paramScopes: Set<string>[] = [];
     // When true, peekOperatorEx does NOT cross NEWLINE boundaries at all.
     // Used inside single-line switch case bodies to prevent binary operator
     // continuation from absorbing the next case's negative test value.
@@ -53,6 +59,16 @@ export class Parser {
     // Utility methods
     peek(offset = 0) {
         return this.tokens[this.pos + offset] || this.tokens[this.tokens.length - 1];
+    }
+
+    // True if `name` is a parameter of any function whose body we're currently
+    // parsing. Used to suppress the global `name → name_var` rewrite for
+    // parameters that just happen to share a name with a user function.
+    private isCurrentFunctionParam(name: string): boolean {
+        for (const frame of this.paramScopes) {
+            if (frame.has(name)) return true;
+        }
+        return false;
     }
 
     advance() {
@@ -832,7 +848,18 @@ export class Parser {
         this.expect(TokenType.OPERATOR, '=>');
         this.skipNewlines();
 
-        const body = this.parseFunctionBody();
+        const paramFrame = new Set<string>();
+        for (const p of params) {
+            const ident = p.type === 'AssignmentPattern' ? (p as any).left : p;
+            if (ident && ident.name) paramFrame.add(ident.name);
+        }
+        this.paramScopes.push(paramFrame);
+        let body: BlockStatement;
+        try {
+            body = this.parseFunctionBody();
+        } finally {
+            this.paramScopes.pop();
+        }
         const id = new Identifier(name);
         if (returnType) id.returnType = returnType;
 
@@ -913,7 +940,18 @@ export class Parser {
         this.expect(TokenType.OPERATOR, '=>');
         this.skipNewlines();
 
-        const body = this.parseFunctionBody();
+        const paramFrame = new Set<string>();
+        for (const p of params) {
+            const ident = p.type === 'AssignmentPattern' ? (p as any).left : p;
+            if (ident && ident.name) paramFrame.add(ident.name);
+        }
+        this.paramScopes.push(paramFrame);
+        let body: BlockStatement;
+        try {
+            body = this.parseFunctionBody();
+        } finally {
+            this.paramScopes.pop();
+        }
         const id = new Identifier(name);
         if (returnType) id.returnType = returnType;
         id.isMethod = true; // Mark as method
@@ -1677,7 +1715,11 @@ export class Parser {
         if (this.match(TokenType.IDENTIFIER)) {
             const id = this.advance();
             let name = id.value;
-            if (this.functionNames.has(name) && this.peek().type !== TokenType.LPAREN) {
+            if (
+                this.functionNames.has(name) &&
+                this.peek().type !== TokenType.LPAREN &&
+                !this.isCurrentFunctionParam(name)
+            ) {
                 name = name + '_var';
             }
             return new Identifier(name);

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -77,6 +77,29 @@ export class Parser {
         return this.advance();
     }
 
+    // Pine v5/v6 contextual keywords — reserved only in their declaration-introducing
+    // position (e.g. `type Foo`, `method bar(...)`, `enum E`), but valid as identifiers
+    // anywhere else (e.g. as a UDT field name, function parameter, variable).
+    private static readonly CONTEXTUAL_KEYWORDS = new Set([
+        'type', 'method', 'enum',
+    ]);
+
+    /**
+     * Consume an identifier OR a contextual keyword used as an identifier.
+     * Used in positions where Pine permits soft keywords as names — most notably
+     * UDT field names like `int type = 0`.
+     */
+    expectIdentifierOrContextual(): Token {
+        const token = this.peek();
+        if (token.type === TokenType.IDENTIFIER) {
+            return this.advance();
+        }
+        if (token.type === TokenType.KEYWORD && Parser.CONTEXTUAL_KEYWORDS.has(token.value)) {
+            return this.advance();
+        }
+        throw new Error(`Expected ${TokenType.IDENTIFIER} but got ${token.type} at ${token.line}:${token.column}`);
+    }
+
     // Match a token, optionally ignoring NEWLINE and INDENT (for line continuation)
     matchEx(type, value = null, allowLineContinuation = false) {
         if (!allowLineContinuation) {
@@ -451,7 +474,9 @@ export class Parser {
 
             // Parse field: type name [= defaultValue]
             const fieldType = this.parseTypeExpression(); // Now handles generics
-            const fieldName = this.expect(TokenType.IDENTIFIER).value;
+            // Field names may be contextual keywords (e.g. `int type = 0`) — Pine
+            // treats `type`/`method`/`enum` as identifiers outside their declaration context.
+            const fieldName = this.expectIdentifierOrContextual().value;
 
             let defaultValue = null;
             if (this.match(TokenType.OPERATOR, '=')) {

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -754,9 +754,17 @@ export class Parser {
         //   int x = 1, y = 2
         //   array<float> p = na, q = na
         // Each subsequent segment is `name = expr` with the leading type reapplied.
-        // Guard with peek(1)===IDENTIFIER so commas belonging to outer constructs
-        // (tuple destructuring, function args, etc.) aren't accidentally consumed.
-        while (this.match(TokenType.COMMA) && this.peek(1).type === TokenType.IDENTIFIER) {
+        // The guard requires `, IDENT =` so we don't greedily swallow commas
+        // that belong to a separate full declaration on the same line, e.g.
+        //   chart.point[] a = ..., chart.point[] b = ...
+        // (`peek(2)` would be DOT/LBRACKET/IDENT, not `=`). Those flow up to
+        // the multi-statement handler in parseStatement (Layer 2).
+        while (
+            this.match(TokenType.COMMA) &&
+            this.peek(1).type === TokenType.IDENTIFIER &&
+            this.peek(2).type === TokenType.OPERATOR &&
+            this.peek(2).value === '='
+        ) {
             this.advance(); // consume ','
             this.skipNewlines(true);
             let nextName = this.expect(TokenType.IDENTIFIER).value;

--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -3,12 +3,21 @@ export const KNOWN_NAMESPACES = ['ta', 'math', 'request', 'array', 'input', 'col
 
 // This is used to transform ns() calls to ns.any() calls
 // Entries with a __value property also support dual-use as variables (e.g. time, na)
+//
+// Pine v6 type-cast pattern: `<TypeName>(value)` — most commonly `box(na)`,
+// `line(na)` etc. inside UDT initializers — needs the namespace to be listed
+// here so the call gets rewritten to `<TypeName>.any(value)` (each helper's
+// `any` delegates to `new`, producing a typed-na/passthrough value).
 export const NAMESPACES_LIKE = [
     'hline',
     'plot',
     'fill',
     'label',
     'line',
+    'box',
+    'linefill',
+    'polyline',
+    'table',
     'na',
     'alert',
     'time',

--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -65,6 +65,24 @@ export const NAMESPACE_COLLISION_NAMES = new Set([
     'alert', 'barstate', 'syminfo', 'timeframe', 'strategy', 'log', 'str',
 ]);
 
+// JavaScript reserved keywords that ARE valid Pine identifiers but invalid as
+// JS identifiers. When a user names a function/method/variable using one of
+// these, we must rename it during codegen — otherwise the generated JS fails
+// to parse (e.g. `function delete() {}` → `Unexpected keyword 'delete'`).
+//
+// Excludes words reserved in BOTH languages (break, case, class, const, continue,
+// do, else, enum, export, for, if, import, in, return, switch, try, var, while)
+// — those can't be Pine identifiers in the first place.
+//
+// Excludes `this` — special-cased elsewhere as the implicit first parameter
+// of Pine `method` declarations.
+export const JS_RESERVED_WORDS = new Set([
+    'await', 'debugger', 'default', 'delete', 'extends', 'finally',
+    'function', 'implements', 'instanceof', 'interface', 'let', 'new',
+    'package', 'private', 'protected', 'public', 'static', 'super',
+    'throw', 'typeof', 'void', 'with', 'yield',
+]);
+
 // All known data variables in the context
 export const CONTEXT_DATA_VARS = ['open', 'high', 'low', 'close', 'volume', 'hl2', 'hlc3', 'ohlc4', 'hlcc4', 'openTime', 'closeTime'];
 

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -1533,7 +1533,17 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
         // method call on the object, never a call to a user-defined function.
         const isUserMethod = scopeManager.isUserMethod(methodName);
 
-        if (isUserFunction && isUserMethod && !scopeManager.isContextBound(methodName) && !isBuiltinMethodOnParam && !isChainedPropertyMethod) {
+        // Receiver-type guard: only retarget `obj.method()` when `obj` is a known
+        // UDT instance. Without this guard, names that collide with user methods
+        // would also retarget for built-in receivers — e.g. a `method delete(...)`
+        // declared on a UDT would hijack `someLine.delete()` calls. Narrowing on
+        // `isUdtInstance` keeps built-in calls intact.
+        // The receiver may have already been wrapped into a `$.get(...)` call by
+        // an earlier pass — but the original Identifier name is preserved on
+        // the wrapper as `.name`, so a single lookup covers both shapes.
+        const isReceiverUdtInstance = !!_obj.name && scopeManager.isUdtInstance(_obj.name);
+
+        if (isUserFunction && isUserMethod && !scopeManager.isContextBound(methodName) && !isBuiltinMethodOnParam && !isChainedPropertyMethod && isReceiverUdtInstance) {
             // It's a user variable/function.
             // Transform obj.method(args) -> method(obj, args)
             // 1. Get the object (first arg)

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -944,6 +944,47 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
     const isPropertyAccess = arg.type === 'MemberExpression' && !arg.computed;
 
     if (isArrayAccess) {
+        // UDT field subscript: `bar.field[N]` (and chained `bar.outer.inner[N]`)
+        // where the leaf base is a registered UDT instance. Pine semantics:
+        // `bar = BAR.new()` runs every bar, so `$.let.glb1_bar` is a Series of
+        // PineTypeObject instances; `$.get(<scoped-bar>, N).field` returns the
+        // field value at N bars ago.
+        //
+        // The default `$.param(scalar, N, name)` wrapping is WRONG for this
+        // pattern when the call site is inside a conditional block — the
+        // accumulated history is per-call, not per-bar, so lookback skips
+        // over bars where the if-branch didn't fire and returns stale values
+        // from the *previous firing* instead of from N bars ago in time.
+        // Direct lookback on the bar series bypasses the param machinery
+        // entirely and works correctly regardless of call-site conditionality.
+        if (arg.object && arg.object.type === 'MemberExpression') {
+            let cursor: any = arg.object;
+            while (cursor.object && cursor.object.type === 'MemberExpression') {
+                cursor = cursor.object;
+            }
+            if (cursor.object?.type === 'Identifier' &&
+                scopeManager.isUdtInstance(cursor.object.name)) {
+                const baseName = cursor.object.name;
+                // Function-parameter UDT (Case 2): leaf must stay a plain
+                // identifier — the param is already bound to the Series of
+                // UDT instances passed in by the caller.
+                const baseRef = scopeManager.isLocalSeriesVar(baseName)
+                    ? (() => {
+                          const id = ASTFactory.createIdentifier(baseName);
+                          id._skipTransformation = true;
+                          return id;
+                      })()
+                    : createScopedVariableReference(baseName, scopeManager);
+                cursor.object = ASTFactory.createGetCall(baseRef, arg.property);
+                // `arg.object` is now the rewritten `$.get(<base>, N).field…`
+                // chain; it replaces the whole `arg` expression. The outer
+                // `$.param(...)` wrapper that the rest of this branch would
+                // have applied is intentionally skipped — the lookback is
+                // already baked into `$.get(...)`.
+                return arg.object;
+            }
+        }
+
         // Ensure complex objects are transformed before being used as array source
         if (arg.object.type === 'CallExpression') {
             transformCallExpression(arg.object, scopeManager);
@@ -1444,8 +1485,21 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
             // Create $.call access
             const contextCall = ASTFactory.createMemberExpression(ASTFactory.createContextIdentifier(), ASTFactory.createIdentifier('call'));
 
+            // Pine UFCS: a method `method foo(X this, ...)` can be called via
+            // `foo(receiver, args)` as well as `obj.foo(args)`. When the Pine
+            // name has NO regular function form (only the method), retarget
+            // the direct-call callee to the `$M_` JS identifier — otherwise
+            // `foo` is unbound at runtime ("foo is not defined"). When both
+            // forms exist, the regular function takes precedence.
+            const calleeName = node.callee.name;
+            let fnRef: any = node.callee;
+            if (scopeManager.isUserMethod(calleeName) && !scopeManager.isRegularUserFunction(calleeName)) {
+                fnRef = ASTFactory.createIdentifier(`$M_${calleeName}`);
+                fnRef._skipTransformation = true;
+            }
+
             // Construct new arguments list: [originalFn, callId, ...originalArgs]
-            const newArgs = [node.callee, callId, ...node.arguments];
+            const newArgs = [fnRef, callId, ...node.arguments];
 
             // Update node
             node.callee = contextCall;

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -496,13 +496,21 @@ export function transformMemberExpression(memberNode: any, originalParamName: st
             scopeManager.isUdtInstance(cursor.object.name)
         ) {
             const baseName = cursor.object.name;
-            // Replace leaf `bar` with `$.get(<scoped-bar>, lookback)` and drop
+            // For UDT-typed function parameters (Case 2), the leaf must stay a
+            // plain identifier — the parameter is bound directly to the Series
+            // of UDT instances passed in by the caller. For globally-scoped
+            // UDT instances, fall through to the standard scoped reference.
+            const baseRef = scopeManager.isLocalSeriesVar(baseName)
+                ? (() => {
+                      const id = ASTFactory.createIdentifier(baseName);
+                      id._skipTransformation = true;
+                      return id;
+                  })()
+                : createScopedVariableReference(baseName, scopeManager);
+            // Replace leaf `bar` with `$.get(<base-ref>, lookback)` and drop
             // the outer `[N]` — the chain (`.low`) now reads from the previous
             // bar's UDT instance.
-            cursor.object = ASTFactory.createGetCall(
-                createScopedVariableReference(baseName, scopeManager),
-                memberNode.property,
-            );
+            cursor.object = ASTFactory.createGetCall(baseRef, memberNode.property);
             // Re-anchor memberNode to the (now-rewritten) inner MemberExpression.
             const inner = memberNode.object;
             Object.assign(memberNode, inner);
@@ -1508,11 +1516,12 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
 
             // The method identifier needs to be transformed to its scoped name if necessary
             // But here 'method' is just the property name node. We need an Identifier for the function.
-            // Since function declarations are not renamed in transformFunctionDeclaration and are local identifiers,
-            // we should use the identifier directly.
+            // Methods are emitted with a `$M_` prefix on their JS name to avoid
+            // collision with regular functions of the same Pine name. Resolve
+            // the call against the prefixed JS identifier.
             // Mark with _skipTransformation to prevent the identifier from being resolved
             // to a same-named variable (e.g. `isSame2` function vs `isSame2` variable).
-            const functionRef = ASTFactory.createIdentifier(methodName);
+            const functionRef = ASTFactory.createIdentifier(`$M_${methodName}`);
             functionRef._skipTransformation = true;
 
             const newArgs = [functionRef, callId, transformedObj, ...transformedArgs];

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -471,6 +471,44 @@ export function transformMemberExpression(memberNode: any, originalParamName: st
         delete memberNode.object;
         delete memberNode.property;
         delete memberNode.computed;
+        return;
+    }
+
+    // Subscript on a UDT-field chain: `bar.low[N]` where `bar` is a user
+    // variable known to hold a UDT instance.
+    //
+    // Pine semantics: `bar.low[N]` reads bar's `.low` from N bars ago.
+    // Since `bar = BAR.new()` runs every bar, `$.let.glb1_bar` is a Series
+    // of PineTypeObject instances → `$.get(glb1_bar, N).low` is correct.
+    //
+    // The rewrite is gated by `scopeManager.isUdtInstance(leafBaseName)` so it
+    // does NOT fire for JS-style array indexing (e.g. `pl.points[0]` where
+    // `pl` is initialized via `polyline.new(...)` — a built-in, not in the
+    // UDT registry).
+    if (memberNode.computed && memberNode.object && memberNode.object.type === 'MemberExpression') {
+        // Walk down to find the leaf base of the chain.
+        let cursor: any = memberNode.object;
+        while (cursor.object && cursor.object.type === 'MemberExpression') {
+            cursor = cursor.object;
+        }
+        if (
+            cursor.object && cursor.object.type === 'Identifier' &&
+            scopeManager.isUdtInstance(cursor.object.name)
+        ) {
+            const baseName = cursor.object.name;
+            // Replace leaf `bar` with `$.get(<scoped-bar>, lookback)` and drop
+            // the outer `[N]` — the chain (`.low`) now reads from the previous
+            // bar's UDT instance.
+            cursor.object = ASTFactory.createGetCall(
+                createScopedVariableReference(baseName, scopeManager),
+                memberNode.property,
+            );
+            // Re-anchor memberNode to the (now-rewritten) inner MemberExpression.
+            const inner = memberNode.object;
+            Object.assign(memberNode, inner);
+            delete memberNode.computed;
+            return;
+        }
     }
 }
 
@@ -903,6 +941,36 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
             transformCallExpression(arg.object, scopeManager);
         } else if (arg.object.type === 'MemberExpression') {
             transformMemberExpression(arg.object, '', scopeManager);
+            // Regression: `transformMemberExpression` early-returns for non-computed
+            // access on context-bound user variables (relying on a later top-level
+            // identifier walker to scope the base). But here the result is about to
+            // be wrapped in `$.param(...)` immediately, so the later walker never
+            // runs and the base identifier ends up bare in the emitted code.
+            // Pattern that hits this:  `bar.low[1]` where `bar` is a UDT instance.
+            // Walk into the MemberExpression chain and scope the leaf base when it
+            // is a user-declared variable (not a built-in / namespace / loop var /
+            // function param / local series).
+            let baseHolder: any = arg.object;
+            while (baseHolder && baseHolder.type === 'MemberExpression' && baseHolder.object) {
+                if (baseHolder.object.type === 'Identifier') {
+                    const base = baseHolder.object;
+                    const [scopedName] = scopeManager.getVariable(base.name);
+                    const isUserVariable = scopedName !== base.name;
+                    if (
+                        isUserVariable &&
+                        !scopeManager.isContextBound(base.name) &&
+                        !scopeManager.isRootParam(base.name) &&
+                        !scopeManager.isLoopVariable(base.name) &&
+                        !scopeManager.isLocalSeriesVar(base.name) &&
+                        !NAMESPACES_LIKE.includes(base.name) &&
+                        !KNOWN_NAMESPACES.includes(base.name)
+                    ) {
+                        baseHolder.object = createScopedVariableAccess(base.name, scopeManager);
+                    }
+                    break;
+                }
+                baseHolder = baseHolder.object;
+            }
         } else if (arg.object.type === 'BinaryExpression') {
             arg.object = getParamFromBinaryExpression(arg.object, scopeManager, namespace);
         } else if (arg.object.type === 'LogicalExpression') {

--- a/src/transpiler/transformers/MainTransformer.ts
+++ b/src/transpiler/transformers/MainTransformer.ts
@@ -322,7 +322,14 @@ export function runTransformationPass(
                     });
                 }
             }
-            // Transform the right (iterable expression) - build <expr>.array (or .array.entries() for destructuring)
+            // Transform the right (iterable expression) and wrap it with a runtime helper that
+            // resolves Pine collection iteration uniformly:
+            //   for x in coll       → for (const x of $.iter(coll))
+            //   for [i, x] in coll  → for (const [i, x] of $.entries(coll))
+            // $.iter / $.entries handle PineArrayObject (.array unwrap), plain JS arrays
+            // (built-ins like box.all), and pass-through for already-iterable values.
+            // Centralizing the resolution avoids special-casing the codegen for each iterable
+            // shape and removes the static-typing guesswork.
             if (node.right) {
                 if (node.right.type === 'Identifier') {
                     // transformIdentifier may already wrap user variables in $.get($.var.X, 0).
@@ -335,35 +342,27 @@ export function runTransformationPass(
                         addArrayAccess(node.right, state);
                     }
                 } else {
-                    // MemberExpression (e.g. eachDay.prices) or any other expression — recurse so
-                    // nested identifiers get transformed properly, then wrap with .array below.
+                    // MemberExpression / CallExpression / etc. — recurse so nested identifiers
+                    // get transformed before we wrap the whole expression below.
                     c(node.right, state);
                 }
 
-                // Access .array for iteration over Pine Script arrays (PineArrayObject wraps
-                // the underlying JS array as .array). Build: <expr>.array
+                const isDestructuring = node.left && node.left.type === 'VariableDeclaration' &&
+                    node.left.declarations[0].id.type === 'ArrayPattern';
+                const helperName = isDestructuring ? 'entries' : 'iter';
+
+                // Build: $.<helperName>(<currentRight>)
                 const currentRight = { ...node.right };
-                let arrayAccess = ASTFactory.createMemberExpression(
-                    currentRight,
-                    ASTFactory.createIdentifier('array'),
-                    false
+                const wrapped = ASTFactory.createCallExpression(
+                    ASTFactory.createMemberExpression(
+                        ASTFactory.createIdentifier('$'),
+                        ASTFactory.createIdentifier(helperName),
+                        false
+                    ),
+                    [currentRight]
                 );
 
-                // If destructuring, add .entries() so iteration yields [index, value] tuples
-                if (node.left && node.left.type === 'VariableDeclaration' &&
-                    node.left.declarations[0].id.type === 'ArrayPattern') {
-                    arrayAccess = ASTFactory.createCallExpression(
-                        ASTFactory.createMemberExpression(
-                            arrayAccess,
-                            ASTFactory.createIdentifier('entries'),
-                            false
-                        ),
-                        []
-                    );
-                }
-
-                // Replace node.right with the new MemberExpression/CallExpression
-                Object.assign(node.right, arrayAccess);
+                Object.assign(node.right, wrapped);
             }
             // Inject loop guard: hoist counter declaration before the loop
             const forOfGuardName = state.getNextLoopGuardName();

--- a/src/transpiler/transformers/MainTransformer.ts
+++ b/src/transpiler/transformers/MainTransformer.ts
@@ -322,31 +322,35 @@ export function runTransformationPass(
                     });
                 }
             }
-            // Transform the right (iterable expression) - build $.get(scopedRef, 0).array
-            if (node.right && node.right.type === 'Identifier') {
-                // transformIdentifier may already wrap user variables in $.get($.var.X, 0).
-                // addArrayAccess reads the (stale) node.name and overwrites the result.
-                // Fix: call transformIdentifier, then only call addArrayAccess if the node
-                // wasn't already transformed (i.e. it's still an Identifier).
-                transformIdentifier(node.right, state);
+            // Transform the right (iterable expression) - build <expr>.array (or .array.entries() for destructuring)
+            if (node.right) {
                 if (node.right.type === 'Identifier') {
-                    // transformIdentifier didn't rename this (context-bound / built-in var)
-                    addArrayAccess(node.right, state);
+                    // transformIdentifier may already wrap user variables in $.get($.var.X, 0).
+                    // addArrayAccess reads the (stale) node.name and overwrites the result.
+                    // Fix: call transformIdentifier, then only call addArrayAccess if the node
+                    // wasn't already transformed (i.e. it's still an Identifier).
+                    transformIdentifier(node.right, state);
+                    if (node.right.type === 'Identifier') {
+                        // transformIdentifier didn't rename this (context-bound / built-in var)
+                        addArrayAccess(node.right, state);
+                    }
+                } else {
+                    // MemberExpression (e.g. eachDay.prices) or any other expression — recurse so
+                    // nested identifiers get transformed properly, then wrap with .array below.
+                    c(node.right, state);
                 }
 
-                // Access .array property for iteration over Pine Script arrays
-                // Build: $.get(X, 0).array
+                // Access .array for iteration over Pine Script arrays (PineArrayObject wraps
+                // the underlying JS array as .array). Build: <expr>.array
                 const currentRight = { ...node.right };
-                
-                // Create MemberExpression: currentRight.array
                 let arrayAccess = ASTFactory.createMemberExpression(
                     currentRight,
                     ASTFactory.createIdentifier('array'),
                     false
                 );
 
-                // If destructuring, add .entries()
-                if (node.left && node.left.type === 'VariableDeclaration' && 
+                // If destructuring, add .entries() so iteration yields [index, value] tuples
+                if (node.left && node.left.type === 'VariableDeclaration' &&
                     node.left.declarations[0].id.type === 'ArrayPattern') {
                     arrayAccess = ASTFactory.createCallExpression(
                         ASTFactory.createMemberExpression(
@@ -357,12 +361,9 @@ export function runTransformationPass(
                         []
                     );
                 }
-                
+
                 // Replace node.right with the new MemberExpression/CallExpression
                 Object.assign(node.right, arrayAccess);
-                
-            } else if (node.right) {
-                c(node.right, state);
             }
             // Inject loop guard: hoist counter declaration before the loop
             const forOfGuardName = state.getNextLoopGuardName();

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -1157,6 +1157,23 @@ export function transformReturnStatement(node: any, scopeManager: ScopeManager):
             ) {
                 transformIdentifier(node.argument.object, scopeManager);
             }
+            // UDT-field subscript on a function parameter: `return b.field[N]`
+            // where `b` is a UDT-typed parameter. The chain's leaf must be a
+            // registered UDT instance for the rewrite to fire — see
+            // `transformFunctionDeclaration` for scope-local registration.
+            else if (
+                node.argument.computed &&
+                node.argument.object.type === 'MemberExpression'
+            ) {
+                let cursor: any = node.argument.object;
+                while (cursor.object && cursor.object.type === 'MemberExpression') {
+                    cursor = cursor.object;
+                }
+                if (cursor.object?.type === 'Identifier' &&
+                    scopeManager.isUdtInstance(cursor.object.name)) {
+                    transformMemberExpression(node.argument, '', scopeManager);
+                }
+            }
         }
 
         if (curScope === 'fn') {
@@ -1320,7 +1337,7 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
         node.body.body.unshift(callIdDecl);
 
         scopeManager.pushScope('fn');
-        
+
         // Register function parameters as local series variables
         // This ensures they:
         // 1. Stay as plain identifiers (no renaming to $.let.scoped_name)
@@ -1330,17 +1347,37 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
                 scopeManager.addLocalSeriesVar(param.name);
             }
         });
-        
+
+        // Scope-locally register any UDT-typed parameters (per
+        // `funcName.__pineParamTypes__` markers populated by AnalysisPass)
+        // so the use-site rewrite for `b.field[N]` fires inside the body.
+        // The names get unmarked when leaving function scope below.
+        // Methods carry a `$M_` JS-name prefix that's not used in the registry
+        // (which is keyed by the Pine name) — strip it before lookup.
+        const rawFnName = node.id?.name as string | undefined;
+        const fnName = rawFnName?.startsWith('$M_') ? rawFnName.slice(3) : rawFnName;
+        const paramTypes = fnName ? scopeManager.getFunctionParamUdtTypes(fnName) : undefined;
+        if (paramTypes) {
+            for (const [paramName, typeName] of Object.entries(paramTypes)) {
+                scopeManager.markVariableAsUdtInstance(paramName, typeName);
+            }
+        }
+
         // Just delegate to the callback to continue the recursion
         c(node.body, scopeManager);
-        
+
         // Clean up: remove function parameters from local series vars after exiting function scope
         node.params.forEach((param: any) => {
             if (param.type === 'Identifier') {
                 scopeManager.removeLocalSeriesVar(param.name);
             }
         });
-        
+        if (paramTypes) {
+            for (const paramName of Object.keys(paramTypes)) {
+                scopeManager.unmarkVariableAsUdtInstance(paramName);
+            }
+        }
+
         scopeManager.popScope();
     }
 }

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -1357,8 +1357,15 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
         const rawFnName = node.id?.name as string | undefined;
         const fnName = rawFnName?.startsWith('$M_') ? rawFnName.slice(3) : rawFnName;
         const paramTypes = fnName ? scopeManager.getFunctionParamUdtTypes(fnName) : undefined;
+        // Snapshot prior bindings for parameter names that shadow outer-scope
+        // UDT instances (e.g. `method touch(ZZ aZZ)` where `aZZ` is also a
+        // global UDT variable). Without this, the unmark on function exit
+        // would wipe the outer registration too, breaking later `aZZ.foo()`
+        // dispatches at the call site.
+        const savedUdtBindings: Record<string, string | undefined> = {};
         if (paramTypes) {
             for (const [paramName, typeName] of Object.entries(paramTypes)) {
+                savedUdtBindings[paramName] = scopeManager.getVariableUdtType(paramName);
                 scopeManager.markVariableAsUdtInstance(paramName, typeName);
             }
         }
@@ -1375,6 +1382,10 @@ export function transformFunctionDeclaration(node: any, scopeManager: ScopeManag
         if (paramTypes) {
             for (const paramName of Object.keys(paramTypes)) {
                 scopeManager.unmarkVariableAsUdtInstance(paramName);
+                const prev = savedUdtBindings[paramName];
+                if (prev !== undefined) {
+                    scopeManager.markVariableAsUdtInstance(paramName, prev);
+                }
             }
         }
 

--- a/tests/core/na.test.ts
+++ b/tests/core/na.test.ts
@@ -74,4 +74,47 @@ plot(check ? 1 : 0, "check")
         // close is a valid number, so na(close) = false, plot = 0
         expect(plots['check'].data[0].value).toBe(0);
     });
+
+    it('na as a default parameter value is detected by na(x) inside the function', async () => {
+        // Regression for a bug where Pine functions declaring `param = na`
+        // would have the parameter hold the NAHelper instance when the caller
+        // omitted the argument. `na(param)` returned false on the helper
+        // object — letting subsequent code overwrite valid values with the
+        // helper itself.
+        // The Range-Average-Retest indicator hits this pattern via:
+        //   updateAreaValues(area a_rea, float areaHigh, float areaLow) =>
+        //       if not na(areaHigh)
+        //           a_rea.areaHigh := areaHigh
+        //       if not na(areaLow)
+        //           a_rea.areaLow := areaLow
+        //   updateLastArea(float areaHigh = na, float areaLow = na) =>
+        //       updateAreaValues(a_rea, areaHigh, areaLow)
+        //   // caller passes only areaHigh → areaLow must remain unchanged
+        const code = `
+//@version=5
+indicator("NA Default Param")
+
+type holder
+    float h
+    float l
+
+setBoth(holder x, float a = na, float b = na) =>
+    if not na(a)
+        x.h := a
+    if not na(b)
+        x.l := b
+
+obj = holder.new(100.0, 200.0)
+setBoth(obj, 999.0)        // only \`a\` provided — \`b\` defaults to na, l must stay 200
+plot(obj.h, "h")
+plot(obj.l, "l")
+plot(na(obj.l) ? 1 : 0, "l_is_na")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['h'].data[0].value).toBe(999);
+        // l was 200 before the call. It must stay 200 — must NOT be clobbered
+        // by the NAHelper instance from the default value of `b`.
+        expect(plots['l'].data[0].value).toBe(200);
+        expect(plots['l_is_na'].data[0].value).toBe(0);
+    });
 });

--- a/tests/core/na.test.ts
+++ b/tests/core/na.test.ts
@@ -117,4 +117,34 @@ plot(na(obj.l) ? 1 : 0, "l_is_na")
         expect(plots['l'].data[0].value).toBe(200);
         expect(plots['l_is_na'].data[0].value).toBe(0);
     });
+
+    // ── Regression: built-in type-name calls are typed-na, not constructors ──
+    // Pine `box(na)`, `line(na)`, `label(na)` etc. are TYPE CASTS that produce
+    // a typed-na value — they do NOT call the constructor.
+    // PineTS used to alias `box.any(...)` directly to `box.new(...)`, so
+    // `box(na)` would create an empty BoxObject with NaN coordinates instead
+    // of a na value. This polluted the helper with placeholder objects that
+    // showed up on the chart at NaN positions.
+    it('box(na), line(na), label(na) are typed-na, not constructor calls', async () => {
+        const code = `
+//@version=5
+indicator("typed-na test", overlay=true)
+box bx = box(na)
+line ln = line(na)
+label lb = label(na)
+plot(na(bx) ? 1 : 0, "bx_na")
+plot(na(ln) ? 1 : 0, "ln_na")
+plot(na(lb) ? 1 : 0, "lb_na")
+`;
+        const r = await pineTS.run(code);
+        // All three should be na — no actual drawings should be created.
+        expect(r.plots['bx_na'].data[0].value).toBe(1);
+        expect(r.plots['ln_na'].data[0].value).toBe(1);
+        expect(r.plots['lb_na'].data[0].value).toBe(1);
+        // Also verify the helpers contain no objects
+        const [labelH, lineH, boxH] = r._drawingHelpers || [];
+        expect(boxH._boxes.length).toBe(0);
+        expect(lineH._lines.length).toBe(0);
+        expect(labelH._labels.length).toBe(0);
+    });
 });

--- a/tests/core/udt-field-defaults.test.ts
+++ b/tests/core/udt-field-defaults.test.ts
@@ -92,4 +92,166 @@ plot(obj.perf, "perf")
         // Second bar: perf was 1, incremented to 2
         expect(plots['perf'].data[1].value).toBe(2);
     });
+
+    // ---- Named-args regression baseline ------------------------------------
+    // These tests cover the WORKING shapes of UDT.new() so that any future
+    // change to the named-args detection in Core.ts does not silently regress
+    // the cases that already work. The mixed-positional+named shape is not
+    // covered here on purpose — that case is broken today and is tracked
+    // separately.
+    it('all-named args fill all fields', async () => {
+        const code = `
+//@version=5
+indicator("UDT All Named")
+
+type mytype
+    float perf = 0
+    int trend = 0
+
+obj = mytype.new(perf = 42.5, trend = 7)
+plot(obj.perf, "perf")
+plot(obj.trend, "trend")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['perf'].data[0].value).toBe(42.5);
+        expect(plots['trend'].data[0].value).toBe(7);
+    });
+
+    it('all-named args in non-declaration order fill correctly', async () => {
+        const code = `
+//@version=5
+indicator("UDT Named Reordered")
+
+type mytype
+    float perf = 0
+    int trend = 0
+    bool active = false
+
+// Names in reverse order vs the type declaration
+obj = mytype.new(active = true, trend = 5, perf = 1.5)
+plot(obj.perf, "perf")
+plot(obj.trend, "trend")
+plot(obj.active ? 1 : 0, "active")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['perf'].data[0].value).toBe(1.5);
+        expect(plots['trend'].data[0].value).toBe(5);
+        expect(plots['active'].data[0].value).toBe(1);
+    });
+
+    it('partial named args fall back to defaults', async () => {
+        const code = `
+//@version=5
+indicator("UDT Partial Named")
+
+type mytype
+    float perf = 9.9
+    int trend = 3
+    bool active = true
+
+// Override only one field — the others should keep their declared defaults
+obj = mytype.new(perf = 1.0)
+plot(obj.perf, "perf")
+plot(obj.trend, "trend")
+plot(obj.active ? 1 : 0, "active")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['perf'].data[0].value).toBe(1.0);
+        expect(plots['trend'].data[0].value).toBe(3);
+        expect(plots['active'].data[0].value).toBe(1);
+    });
+
+    it('all-positional args (existing behavior baseline)', async () => {
+        const code = `
+//@version=5
+indicator("UDT All Positional")
+
+type mytype
+    float perf = 0
+    int trend = 0
+    bool active = false
+
+obj = mytype.new(2.5, 8, true)
+plot(obj.perf, "perf")
+plot(obj.trend, "trend")
+plot(obj.active ? 1 : 0, "active")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['perf'].data[0].value).toBe(2.5);
+        expect(plots['trend'].data[0].value).toBe(8);
+        expect(plots['active'].data[0].value).toBe(1);
+    });
+
+    it('mixed positional + named args (Range-Average-Retest pattern)', async () => {
+        // This is the exact shape that motivated the fix:
+        //   trade.new(p1, p2, ..., tradeColor = ..., dir = -1)
+        // Two positional args, then one or more named args. The trailing
+        // named-args object must NOT be assigned to the third field — it
+        // should be split out and applied by name.
+        const code = `
+//@version=5
+indicator("UDT Mixed Positional Named")
+
+type mytype
+    float perf = 0
+    int trend = 0
+    bool active = false
+    int dir
+
+obj = mytype.new(2.5, 8, dir = -1)
+plot(obj.perf, "perf")
+plot(obj.trend, "trend")
+plot(obj.active ? 1 : 0, "active")
+plot(obj.dir, "dir")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['perf'].data[0].value).toBe(2.5);
+        expect(plots['trend'].data[0].value).toBe(8);
+        // active was skipped — falls back to declared default `false`
+        expect(plots['active'].data[0].value).toBe(0);
+        // dir was passed as a named arg AFTER positionals — must be -1, not undefined
+        expect(plots['dir'].data[0].value).toBe(-1);
+    });
+
+    it('mixed positional + multiple named args', async () => {
+        // 8 positional + 2 named args (the actual shape from
+        // Range-Average-Retest's trade.new call).
+        const code = `
+//@version=5
+indicator("UDT Mixed 8+2")
+
+type trade
+    float entry
+    float top
+    float bottom
+    int   topColor
+    int   bottomColor
+    int   startTime
+    int   endTime
+    int   startLineTime
+    int   tradeColor
+    bool  openTrade = true
+    int   dir
+
+t = trade.new(100.0, 110.0, 90.0, 1, 2, 1000, 1000, 500, tradeColor = 99, dir = -1)
+plot(t.entry, "entry")
+plot(t.top, "top")
+plot(t.bottom, "bottom")
+plot(t.startLineTime, "startLineTime")
+plot(t.tradeColor, "tradeColor")
+plot(t.openTrade ? 1 : 0, "openTrade")
+plot(t.dir, "dir")
+`;
+        const { plots } = await pineTS.run(code);
+        expect(plots['entry'].data[0].value).toBe(100);
+        expect(plots['top'].data[0].value).toBe(110);
+        expect(plots['bottom'].data[0].value).toBe(90);
+        expect(plots['startLineTime'].data[0].value).toBe(500);
+        // tradeColor must be the named value 99, NOT a {tradeColor:..., dir:...} object
+        expect(plots['tradeColor'].data[0].value).toBe(99);
+        // openTrade was skipped — falls back to declared default `true`
+        expect(plots['openTrade'].data[0].value).toBe(1);
+        // dir must be -1
+        expect(plots['dir'].data[0].value).toBe(-1);
+    });
 });

--- a/tests/core/udt-field-subscript.test.ts
+++ b/tests/core/udt-field-subscript.test.ts
@@ -355,9 +355,17 @@ plot(close)
         expect(jsCode).not.toMatch(/\$\.init\([^,]+,\s*\$\.get\(\$\.let\.glb1_bar,\s*0\)\.low_v,\s*1\)/);
     });
 
-    it('rewrites `bar.field[N]` inside a function-call arg to `$.param($.get(<scoped-bar>, 0).field, N, ...)`', () => {
-        // Bug 2: previously emitted `$.param(bar.field, N, ...)` with bare `bar`,
-        // throwing "bar is not defined" at runtime.
+    it('rewrites `bar.field[N]` inside a function-call arg to `$.get(<scoped-bar>, N).field` (no $.param wrap)', () => {
+        // Bug 2 (original fix): previously emitted `$.param(bar.field, N, ...)`
+        // with bare `bar`, throwing "bar is not defined".
+        // Bug 4 (newer fix): even after scoping the leaf, wrapping the SCALAR
+        // result in `$.param(scalar, N, name)` produced wrong values when the
+        // call site was inside a conditional block — `$.param`'s history is
+        // per-call, not per-bar, so lookback returned values from the previous
+        // firing instead of from N bars earlier in time.
+        // Correct shape: bypass `$.param` and lookback directly on the bar
+        // series, which IS populated every bar. The arg becomes a raw
+        // `$.get(<scoped-bar>, N).field` MemberExpression.
         const code = `
 //@version=6
 indicator("udt subscript function arg")
@@ -371,9 +379,12 @@ plot(close)
         const result = transpile(code);
         const jsCode = result.toString();
 
-        // The leaf base must be scoped; the lookback can live in $.param.
-        expect(jsCode).toMatch(/\$\.param\(\$\.get\(\$\.let\.glb1_bar,\s*0\)\.low_v,\s*1,/);
-        // Must NOT regress to bare `bar.low_v` in the param arg
+        // The arg passed to `identity` (via `$.call(...)`) must be the direct
+        // lookback expression with `N` baked into `$.get(...)` itself.
+        expect(jsCode).toMatch(/\$\.get\(\$\.let\.glb1_bar,\s*1\)\.low_v/);
+        // The buggy `$.param(scalar, N, ...)` wrapper must NOT appear.
+        expect(jsCode).not.toMatch(/\$\.param\(\$\.get\(\$\.let\.glb1_bar,\s*0\)\.low_v,\s*1\b/);
+        // Must NOT regress to bare `bar.low_v` either.
         expect(jsCode).not.toMatch(/\$\.param\(bar\.low_v,/);
     });
 

--- a/tests/core/udt-field-subscript.test.ts
+++ b/tests/core/udt-field-subscript.test.ts
@@ -68,6 +68,249 @@ describe('UDT registry pre-pass (preProcessUdtRegistry)', () => {
         expect(sm.getVariableUdtType('copy')).toBe('BAR');
     });
 
+    it('registers UDT instances initialized via a conditional / ternary expression', () => {
+        // Case 3 fix: when both branches of a ternary resolve to the same UDT,
+        // the variable is registered with that UDT type.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            let seed = BAR.new();
+            let bar = (1 > 0) ? BAR.new() : BAR.copy(seed);
+        `);
+        expect(sm.isUdtInstance('bar')).toBe(true);
+        expect(sm.getVariableUdtType('bar')).toBe('BAR');
+    });
+
+    it('handles nested ternaries — recursion through both branches', () => {
+        // c1 ? BAR.new() : (c2 ? BAR.copy(seed) : BAR.new())
+        // The recursive helper walks both branches at every level.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            let seed = BAR.new();
+            let bar = (1 > 0) ? BAR.new() : ((2 > 0) ? BAR.copy(seed) : BAR.new());
+        `);
+        expect(sm.isUdtInstance('bar')).toBe(true);
+        expect(sm.getVariableUdtType('bar')).toBe('BAR');
+    });
+
+    it('does NOT register a ternary whose branches have DIFFERENT UDT types', () => {
+        // Safety check: if the branches resolve to different types, we can't
+        // unambiguously assign one — skip rather than misclassify.
+        const sm = buildUdtRegistry(`
+            const FOO = Type({ a: ['float', 0] });
+            const BAR = Type({ b: ['float', 0] });
+            let either = (1 > 0) ? FOO.new() : BAR.new();
+        `);
+        expect(sm.isUdtInstance('either')).toBe(false);
+    });
+
+    it('does NOT register a ternary whose branches mix UDT and non-UDT', () => {
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ b: ['float', 0] });
+            let arr = array.from(1, 2);
+            let mixed = (1 > 0) ? BAR.new() : arr;
+        `);
+        expect(sm.isUdtInstance('mixed')).toBe(false);
+    });
+
+    it('infers UDT return type of a user function whose body returns `<UDT>.new(...)`', () => {
+        // `function makeBar() { return BAR.new(); }` — the function's return
+        // type is recorded so callers can flow the type through.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function makeBar() { return BAR.new(); }
+        `);
+        expect(sm.getFunctionReturnType('makeBar')).toBe('BAR');
+    });
+
+    it('registers `bar = userFunc()` as a UDT instance when the function returns one', () => {
+        // The Case 1 fix in action — `bar` initialized via a user-function
+        // call gets registered with the function's inferred return type.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function makeBar() { return BAR.new(); }
+            let bar = makeBar();
+        `);
+        expect(sm.isUdtInstance('bar')).toBe(true);
+        expect(sm.getVariableUdtType('bar')).toBe('BAR');
+    });
+
+    it('iteratively resolves chained user-function returns (helper → wrapper)', () => {
+        // makeBar() calls makeBarHelper() — the inference loop must run
+        // multiple passes to register both functions, then `bar`.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function makeBarHelper() { return BAR.new(); }
+            function makeBar() { return makeBarHelper(); }
+            let bar = makeBar();
+        `);
+        expect(sm.getFunctionReturnType('makeBarHelper')).toBe('BAR');
+        expect(sm.getFunctionReturnType('makeBar')).toBe('BAR');
+        expect(sm.isUdtInstance('bar')).toBe(true);
+    });
+
+    it('does NOT register a function whose return paths produce DIFFERENT UDT types', () => {
+        // Safety: if some return paths produce FOO and others BAR, the
+        // function is not unambiguously typed — skip rather than misclassify.
+        const sm = buildUdtRegistry(`
+            const FOO = Type({ a: ['float', 0] });
+            const BAR = Type({ b: ['float', 0] });
+            function ambiguous(c) { if (c) { return FOO.new(); } else { return BAR.new(); } }
+        `);
+        expect(sm.getFunctionReturnType('ambiguous')).toBeUndefined();
+    });
+
+    it('does NOT register a function with a non-UDT return path', () => {
+        // If even one return produces a non-UDT (or unrecognized) value,
+        // the function's return type stays unknown.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ b: ['float', 0] });
+            function maybe(c) { if (c) { return BAR.new(); } else { return 0; } }
+        `);
+        expect(sm.getFunctionReturnType('maybe')).toBeUndefined();
+    });
+
+    it('does NOT descend into nested function bodies when collecting returns', () => {
+        // The outer function's `return` paths must not be polluted by an
+        // inner closure's `return BAR.new()`. Outer returns 1 (a number),
+        // so it shouldn't be registered as a UDT-returning function.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ b: ['float', 0] });
+            function outer() {
+                function inner() { return BAR.new(); }
+                return 1;
+            }
+        `);
+        expect(sm.getFunctionReturnType('outer')).toBeUndefined();
+        expect(sm.getFunctionReturnType('inner')).toBe('BAR');
+    });
+
+    it('infers tuple return type when a function returns `[<UDT>.new(), <UDT>.new()]`', () => {
+        // Case 4 — `makeBars() => [BAR.new(), BAR.new()]` is recorded so that
+        // tuple-destructuring at the call site can register each binding.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function makeBars() { return [BAR.new(), BAR.new()]; }
+        `);
+        expect(sm.getFunctionReturnTupleType('makeBars')).toEqual(['BAR', 'BAR']);
+        // Scalar-return registry must remain empty for tuple-returning fns.
+        expect(sm.getFunctionReturnType('makeBars')).toBeUndefined();
+    });
+
+    it('infers heterogeneous tuple return types (mixed UDT slots)', () => {
+        // Distinct UDT types per slot should be preserved verbatim.
+        const sm = buildUdtRegistry(`
+            const FOO = Type({ a: ['float', 0] });
+            const BAR = Type({ b: ['float', 0] });
+            function makePair() { return [FOO.new(), BAR.new()]; }
+        `);
+        expect(sm.getFunctionReturnTupleType('makePair')).toEqual(['FOO', 'BAR']);
+    });
+
+    it('registers ArrayPattern destructuring elements as UDT instances per slot', () => {
+        // The Case 4 fix in action — `[a, b] = makeBars()` registers each
+        // element with its tuple slot's UDT type.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function makeBars() { return [BAR.new(), BAR.new()]; }
+            let [a, b] = makeBars();
+        `);
+        expect(sm.isUdtInstance('a')).toBe(true);
+        expect(sm.isUdtInstance('b')).toBe(true);
+        expect(sm.getVariableUdtType('a')).toBe('BAR');
+        expect(sm.getVariableUdtType('b')).toBe('BAR');
+    });
+
+    it('skips non-UDT slots when destructuring a partially-typed tuple', () => {
+        // If only some slots are UDT instances, only those positions register.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ b: ['float', 0] });
+            function makeMixed() { return [BAR.new(), 0]; }
+            let [u, n] = makeMixed();
+        `);
+        expect(sm.isUdtInstance('u')).toBe(true);
+        expect(sm.getVariableUdtType('u')).toBe('BAR');
+        expect(sm.isUdtInstance('n')).toBe(false);
+    });
+
+    it('does NOT register destructuring when tuple lengths differ across return paths', () => {
+        // Safety: if return paths produce tuples of different lengths the
+        // function's tuple shape is ambiguous → no registration.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ b: ['float', 0] });
+            function inconsistent(c) {
+                if (c) { return [BAR.new(), BAR.new()]; }
+                else   { return [BAR.new()]; }
+            }
+            let [a, b] = inconsistent(true);
+        `);
+        expect(sm.getFunctionReturnTupleType('inconsistent')).toBeUndefined();
+        expect(sm.isUdtInstance('a')).toBe(false);
+        expect(sm.isUdtInstance('b')).toBe(false);
+    });
+
+    it('does NOT register destructuring when a slot type disagrees across return paths', () => {
+        // Safety: slot 0 is FOO in one path and BAR in another → ambiguous.
+        const sm = buildUdtRegistry(`
+            const FOO = Type({ a: ['float', 0] });
+            const BAR = Type({ b: ['float', 0] });
+            function ambig(c) {
+                if (c) { return [FOO.new(), BAR.new()]; }
+                else   { return [BAR.new(), BAR.new()]; }
+            }
+            let [x, y] = ambig(true);
+        `);
+        expect(sm.getFunctionReturnTupleType('ambig')).toBeUndefined();
+        expect(sm.isUdtInstance('x')).toBe(false);
+        expect(sm.isUdtInstance('y')).toBe(false);
+    });
+
+    it('reads `__pineParamTypes__` markers and registers UDT-typed function parameters', () => {
+        // Case 2 — pine2js codegen emits a marker for each function whose
+        // parameters carry a Pine type annotation (e.g. `readField(BAR b)`).
+        // The pre-pass reads it and stores `funcName → { paramName: TypeName }`
+        // for `transformFunctionDeclaration` to consume scope-locally.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function readField(b) { return b.low_v[1]; }
+            readField.__pineParamTypes__ = { "b": "BAR" };
+        `);
+        expect(sm.getFunctionParamUdtTypes('readField')).toEqual({ b: 'BAR' });
+    });
+
+    it('strips Pine type qualifiers (`series BAR`) when resolving the type name', () => {
+        // Pine annotations can include qualifiers: `series BAR b`, `simple int x`.
+        // The pre-pass keeps only the trailing token and matches it against
+        // the UDT registry.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function readField(b) { return b.low_v[1]; }
+            readField.__pineParamTypes__ = { "b": "series BAR" };
+        `);
+        expect(sm.getFunctionParamUdtTypes('readField')).toEqual({ b: 'BAR' });
+    });
+
+    it('drops non-UDT parameter type annotations from the marker', () => {
+        // `int`, `float`, `string` etc. are never UDT type names. The marker
+        // emits them too, but the pre-pass filters them out.
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            function mixed(a, b, c) { return 0; }
+            mixed.__pineParamTypes__ = { "a": "int", "b": "BAR", "c": "float" };
+        `);
+        // Only `b: BAR` survives — primitives are filtered.
+        expect(sm.getFunctionParamUdtTypes('mixed')).toEqual({ b: 'BAR' });
+    });
+
+    it('skips marker registration entirely when no params resolve to a UDT', () => {
+        // Avoid polluting the registry with an empty entry for fully-untyped
+        // (or all-primitive) function signatures.
+        const sm = buildUdtRegistry(`
+            function plain(x, y) { return x + y; }
+            plain.__pineParamTypes__ = { "x": "int", "y": "float" };
+        `);
+        expect(sm.getFunctionParamUdtTypes('plain')).toBeUndefined();
+    });
+
     it('does NOT register built-in factory calls as UDT instances', () => {
         // These are critical: built-in factory methods like polyline.new(),
         // array.from(), chart.point.from_index() must NOT enter the UDT
@@ -226,6 +469,62 @@ type BAR
 bar = BAR.new()
 b = bar.low_v[1]
 plot(b, "out")
+            `),
+        ).resolves.toBeDefined();
+    });
+
+    it('Case 1 smoke — `bar = makeBar()` then `bar.field[N]` runs without error', async () => {
+        // Verifies that user-function-return type inference enables the rewrite
+        // for the indirect initialization pattern.
+        await expect(
+            mkPts().run(`
+//@version=5
+indicator("case1smoke")
+type BAR
+    float low_v = low
+makeBar() =>
+    BAR.new()
+bar = makeBar()
+b = bar.low_v[1]
+plot(b, "out")
+            `),
+        ).resolves.toBeDefined();
+    });
+
+    it('Case 2 smoke — `readField(BAR b) => b.field[N]` runs without "b is not defined"', async () => {
+        // Verifies the typed-parameter path: pine2js emits __pineParamTypes__,
+        // AnalysisPass populates the per-function registry, and
+        // transformFunctionDeclaration scope-locally registers `b` as a UDT
+        // instance for the duration of the body. Before the fix, `b.low_v[N]`
+        // inside the body either crashed or silently returned the wrong value.
+        await expect(
+            mkPts().run(`
+//@version=5
+indicator("case2smoke")
+type BAR
+    float low_v = low
+readField(BAR b) =>
+    b.low_v[1]
+bar = BAR.new()
+plot(readField(bar), "out")
+            `),
+        ).resolves.toBeDefined();
+    });
+
+    it('Case 4 smoke — `[a, b] = makeBars()` then `a.field[N]` runs without error', async () => {
+        // Verifies that tuple-return inference + ArrayPattern slot registration
+        // enable the rewrite for the destructuring pattern.
+        await expect(
+            mkPts().run(`
+//@version=5
+indicator("case4smoke")
+type BAR
+    float low_v = low
+makeBars() =>
+    [BAR.new(), BAR.new()]
+[a, b] = makeBars()
+plot(a.low_v[1], "outA")
+plot(b.low_v[2], "outB")
             `),
         ).resolves.toBeDefined();
     });

--- a/tests/core/udt-field-subscript.test.ts
+++ b/tests/core/udt-field-subscript.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+import { transpile } from '../../src/transpiler/index';
+import ScopeManager from '../../src/transpiler/analysis/ScopeManager';
+import { preProcessUdtRegistry } from '../../src/transpiler/analysis/AnalysisPass';
+import * as acorn from 'acorn';
+
+/**
+ * Regression suite for the two-bug "subscript on UDT field" issue.
+ *
+ * Pine semantics: when `bar` is a UDT instance reassigned every bar
+ * (`bar = SomeUDT.new()`), `bar.field[N]` reads the field's value from N
+ * bars ago — i.e. the same as `low[N]` if the field captures `low` at
+ * construction. The transpiler must:
+ *   1. Recognize `bar` as a UDT instance (not a built-in / array / namespace).
+ *   2. Apply the lookback to the leaf base (Series of UDT instances),
+ *      NOT to the field-access tail.
+ *
+ * The discrimination is non-trivial because `bar.field[N]` and
+ * `arr[N]` (on a JS array) have identical AST shapes. The fix uses a
+ * UDT registry populated from `const X = Type({...})` declarations
+ * (pine2js output) and `<X>.new(...)` / `<X>.copy(...)` initializers.
+ */
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/** Pre-process raw JS source into an AST and run only the UDT pre-pass.
+ *  Returns the populated ScopeManager so tests can introspect the registry. */
+function buildUdtRegistry(jsSource: string): ScopeManager {
+    const ast: any = acorn.parse(jsSource, { ecmaVersion: 'latest', sourceType: 'module' });
+    const sm = new ScopeManager();
+    preProcessUdtRegistry(ast, sm);
+    return sm;
+}
+
+// ── 1. UDT registry pre-pass ───────────────────────────────────────────
+
+describe('UDT registry pre-pass (preProcessUdtRegistry)', () => {
+    it('registers UDT type names from `const X = Type({...})` declarations', () => {
+        // pine2js output shape — what `type BAR { float low_v = low }` becomes
+        const sm = buildUdtRegistry(`const BAR = Type({ low_v: ['float', 0] });`);
+        expect(sm.isUdtTypeName('BAR')).toBe(true);
+        expect(sm.isUdtTypeName('SOMETHING_ELSE')).toBe(false);
+    });
+
+    it('captures field type metadata (V2 data model)', () => {
+        const sm = buildUdtRegistry(`const FOO = Type({ a: ['float', 0], b: ['int', 0], c: ['bool', false] });`);
+        const fields = sm.getUdtTypeFields('FOO');
+        expect(fields).toEqual({ a: 'float', b: 'int', c: 'bool' });
+    });
+
+    it('registers variables initialized via `<UDT>.new(...)` as UDT instances', () => {
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            let bar = BAR.new();
+        `);
+        expect(sm.isUdtInstance('bar')).toBe(true);
+        expect(sm.getVariableUdtType('bar')).toBe('BAR');
+    });
+
+    it('registers variables initialized via `<UDT>.copy(...)` as UDT instances', () => {
+        const sm = buildUdtRegistry(`
+            const BAR = Type({ low_v: ['float', 0] });
+            let original = BAR.new();
+            let copy = BAR.copy(original);
+        `);
+        expect(sm.isUdtInstance('copy')).toBe(true);
+        expect(sm.getVariableUdtType('copy')).toBe('BAR');
+    });
+
+    it('does NOT register built-in factory calls as UDT instances', () => {
+        // These are critical: built-in factory methods like polyline.new(),
+        // array.from(), chart.point.from_index() must NOT enter the UDT
+        // registry — otherwise their `field[N]` patterns get incorrectly
+        // rewritten as series lookback (regression on the polyline test).
+        const sm = buildUdtRegistry(`
+            let arr = array.from(1, 2, 3);
+            let pl = polyline.new(arr);
+            let pt = chart.point.from_index(0, 100);
+            let lbl = label.new(0, 0, "x");
+            let bx = box.new(0, 0, 1, 1);
+        `);
+        expect(sm.isUdtInstance('arr')).toBe(false);
+        expect(sm.isUdtInstance('pl')).toBe(false);
+        expect(sm.isUdtInstance('pt')).toBe(false);
+        expect(sm.isUdtInstance('lbl')).toBe(false);
+        expect(sm.isUdtInstance('bx')).toBe(false);
+    });
+});
+
+// ── 2. Codegen shape ───────────────────────────────────────────────────
+
+describe('UDT field subscript — transpiler codegen shape', () => {
+    it('rewrites `bar.field[N]` (top-level RHS) to `$.get(<scoped-bar>, N).field`', () => {
+        // Bug 1: previously emitted `$.init(target, $.get(bar, 0).field, N)`
+        // — the lookback as a stray third arg that `$.init` silently ignored
+        // for scalars. The correct shape applies the lookback at the leaf base.
+        const code = `
+//@version=6
+indicator("udt subscript top-level")
+type BAR
+    float low_v = low
+bar = BAR.new()
+b = bar.low_v[1]
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        expect(jsCode).toContain('$.get($.let.glb1_bar, 1).low_v');
+        // Must NOT regress to the broken stray-third-arg form
+        expect(jsCode).not.toMatch(/\$\.init\([^,]+,\s*\$\.get\(\$\.let\.glb1_bar,\s*0\)\.low_v,\s*1\)/);
+    });
+
+    it('rewrites `bar.field[N]` inside a function-call arg to `$.param($.get(<scoped-bar>, 0).field, N, ...)`', () => {
+        // Bug 2: previously emitted `$.param(bar.field, N, ...)` with bare `bar`,
+        // throwing "bar is not defined" at runtime.
+        const code = `
+//@version=6
+indicator("udt subscript function arg")
+type BAR
+    float low_v = low
+bar = BAR.new()
+identity(x) => x
+b = identity(bar.low_v[1])
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // The leaf base must be scoped; the lookback can live in $.param.
+        expect(jsCode).toMatch(/\$\.param\(\$\.get\(\$\.let\.glb1_bar,\s*0\)\.low_v,\s*1,/);
+        // Must NOT regress to bare `bar.low_v` in the param arg
+        expect(jsCode).not.toMatch(/\$\.param\(bar\.low_v,/);
+    });
+
+    it('does NOT rewrite `<member>[N]` when the leaf base is NOT a UDT instance', () => {
+        // Critical guard — JS-style `pl.points[0]` where `pl = polyline.new(...)`
+        // must remain a plain array index, not become `$.get(pl, 0).points`.
+        const code = `
+//@version=6
+indicator("not a UDT instance", overlay=true)
+plot(close)
+        `;
+        // The UDT registry is empty for this script (no `type X`).
+        // Even if we synthesize the AST shape that LOOKS like UDT subscript,
+        // the rewrite should not fire. Demonstrate via direct registry check:
+        const sm = buildUdtRegistry(`
+            let pts = array.from(1, 2, 3);
+            let pl = polyline.new(pts);
+        `);
+        expect(sm.isUdtInstance('pl')).toBe(false);
+        expect(sm.isUdtInstance('pts')).toBe(false);
+        // Smoke check transpile completes
+        expect(transpile(code).toString()).toBeDefined();
+    });
+
+    it('rewrites nested UDT field chains correctly (`outer.inner.field[N]`)', () => {
+        // The walker descends to the leaf identifier; rewrite anchors there.
+        const code = `
+//@version=6
+indicator("nested UDT chain")
+type INNER
+    float v = low
+type OUTER
+    INNER inner = INNER.new()
+bar = OUTER.new()
+b = bar.inner.v[1]
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // Lookback applied to `bar` (the leaf), then `.inner.v` chain follows
+        expect(jsCode).toContain('$.get($.let.glb1_bar, 1).inner.v');
+    });
+});
+
+// ── 3. Smoke tests — does-not-crash and output-shape integrity ────────
+
+// Note: full TV-vs-PineTS value equivalence is covered end-to-end by the
+// automated test at:
+//   Automations/PineTS/pinescripts/lang/udt_field_subscript.pine
+// The smoke tests below verify that the transpile + run pipeline doesn't
+// throw on the bug-triggering shapes — protecting against regressions in
+// the surrounding wiring (preProcessUdtRegistry registration, walker
+// short-circuits, etc.) that would silently re-break the behavior.
+
+describe('UDT field subscript — pipeline smoke tests', () => {
+    const mkPts = () =>
+        new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            'D',
+            null,
+            new Date('2019-04-01').getTime(),
+            new Date('2019-04-15').getTime(),
+        );
+
+    it('Bug 2 smoke — function-arg `f(bar.field[N])` does not crash', async () => {
+        // Before the surgical fix in transformFunctionArgument's isArrayAccess
+        // branch, this exact shape threw `ReferenceError: bar is not defined`
+        // because the leaf `bar` Identifier was never scoped to `glb1_bar`.
+        await expect(
+            mkPts().run(`
+//@version=5
+indicator("bug2smoke")
+type BAR
+    float low_v = low
+bar = BAR.new()
+f(x) => x
+plot(f(bar.low_v[1]), "out")
+            `),
+        ).resolves.toBeDefined();
+    });
+
+    it('Bug 1 smoke — top-level `b = bar.field[N]` does not crash', async () => {
+        // Before the rewrite in transformMemberExpression, this shape compiled
+        // but emitted `$.init(t, value, 1)` with the lookback as a stray third
+        // arg silently ignored. Verifies the script still runs end-to-end.
+        await expect(
+            mkPts().run(`
+//@version=5
+indicator("bug1smoke")
+type BAR
+    float low_v = low
+bar = BAR.new()
+b = bar.low_v[1]
+plot(b, "out")
+            `),
+        ).resolves.toBeDefined();
+    });
+
+    it('UDT-instance discrimination — script using polyline.new() does not crash', async () => {
+        // Sanity check that built-in factory calls (polyline.new, array.from,
+        // chart.point.from_index) are NOT registered as UDT instances. Before
+        // the discrimination check was added, an over-eager rewrite would
+        // misinterpret `pl.points[0]` as series lookback and crash.
+        await expect(
+            mkPts().run(`
+//@version=5
+indicator("polyline-discrim")
+var pt1 = chart.point.from_index(0, 50000)
+var pt2 = chart.point.from_index(5, 60000)
+var pts = array.from(pt1, pt2)
+var pl = polyline.new(pts)
+plot(close)
+            `),
+        ).resolves.toBeDefined();
+    });
+});

--- a/tests/core/udt-method-mutation.test.ts
+++ b/tests/core/udt-method-mutation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+import { transpile } from '../../src/transpiler/index';
+
+/**
+ * Regression suite for the three method-related bugs fixed together:
+ *
+ *  1. `this`-mutation persistence — Pine `method foo(BAR this, ...) => this.x := y`
+ *     used to lose the assignment because `this` was stripped from the JS
+ *     param list and the call site passed the receiver positionally with
+ *     `$.call(fn, id, obj, ...args)` (which doesn't bind `this`). Body writes
+ *     to `this.x` leaked onto `globalThis`. Fix: rename `this` to `self`
+ *     in both the param list and the body.
+ *
+ *  2. Function / method name collision — when a Pine script declared both a
+ *     regular function `foo()` and a `method foo()`, both compiled to a JS
+ *     function with the same identifier `foo`. The second declaration
+ *     shadowed the first, so direct calls `foo(args)` resolved to the
+ *     method instead of the regular function. Fix: methods get a `$M_`
+ *     prefix on their JS identifier.
+ *
+ *  3. Param namespace-rename clobbering — when a Pine method/fn param
+ *     shadows a Pine namespace (e.g. `color`), the param is renamed to
+ *     `color_$N`. The naive walker rewrote EVERY `Identifier('color')` in
+ *     the body, including namespace usages like `color.new(arg, 73)` →
+ *     `color_$N.new(color_$N, 73)` (broken). Fix: a context-aware walker
+ *     that skips MemberExpression objects (namespace member access),
+ *     CallExpression callees (namespace function calls), and Property keys.
+ */
+
+describe('UDT method this-mutation, naming, and param-shadowing', () => {
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', 'D', null,
+            new Date('2019-04-01').getTime(),
+            new Date('2019-04-15').getTime());
+
+    // ── Codegen shape ──────────────────────────────────────────────────
+
+    it('method receiver `this` is renamed to `self` in both param list and body', () => {
+        // Bug 1: previously emitted `function updatePattern(price, index)` with
+        // `this.x = ...` in body — `this` was `globalThis` at runtime.
+        const code = `
+//@version=6
+indicator("method this rename", overlay=true)
+type BAR
+    float lastPrice
+method updatePattern(BAR this, float price) =>
+    this.lastPrice := price
+bar = BAR.new()
+bar.updatePattern(close)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // Receiver appears as `self` in both param list and body. The body
+        // member access is wrapped as `$.get(self, 0).lastPrice` by the
+        // expression transformer (series-of-UDT unwrap), but the leaf
+        // identifier remains `self`.
+        expect(jsCode).toMatch(/function\s+\$M_updatePattern\s*\(\s*self\s*,/);
+        expect(jsCode).toMatch(/\$\.get\(\s*self\s*,\s*0\s*\)\.lastPrice/);
+        // No bare `this.x` references in method body (would be globalThis writes)
+        expect(jsCode).not.toMatch(/\bthis\.lastPrice\b/);
+    });
+
+    it('methods get a `$M_` JS prefix to avoid collision with regular functions', () => {
+        // Bug 2: previously the second declaration overwrote the first.
+        const code = `
+//@version=6
+indicator("fn vs method", overlay=true)
+type FOO
+    float x
+sameName(int a, int b) =>
+    a + b
+method sameName(FOO this, int a) =>
+    this.x := a
+bar = FOO.new()
+y = sameName(1, 2)
+bar.sameName(5)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // BOTH declarations must coexist
+        expect(jsCode).toMatch(/function\s+sameName\s*\(\s*a\s*,\s*b\s*\)/);
+        expect(jsCode).toMatch(/function\s+\$M_sameName\s*\(\s*self\s*,/);
+        // The marker should be on the prefixed identifier
+        expect(jsCode).toContain('$M_sameName.__pineMethod__ = true');
+    });
+
+    it('param shadowing a Pine namespace preserves namespace usage in the body', () => {
+        // Bug 3: param literally named `color` shadows the `color` namespace.
+        // The naive walker renamed every `Identifier('color')` in the body —
+        // including `color.new(...)` (namespace access), producing the
+        // invalid `color_$N.new(color_$N, 73)`. The context-aware walker
+        // skips MemberExpression objects (the namespace) but still renames
+        // bare identifier reads (the param value passed as an argument).
+        const code = `
+//@version=6
+indicator("param-namespace shadow", overlay=true)
+applyTransparency(color) =>
+    color.new(color, 73)
+c = applyTransparency(#ff0000)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // `color.new(` (namespace usage) must survive untouched
+        expect(jsCode).toMatch(/\bcolor\.new\(/);
+        // The renamed param IS used as the argument value (the expression
+        // transformer wraps it in a `color.param(...)` call before passing
+        // to `color.new`, so the param name appears inside `color.param(`).
+        expect(jsCode).toMatch(/color\.param\(\s*color_\$\d+\b/);
+        // The bare param identifier must NOT be wired as a namespace itself —
+        // i.e. no `color_$N.new(...)` (that was the broken form)
+        expect(jsCode).not.toMatch(/\bcolor_\$\d+\.new\b/);
+    });
+
+    // ── Runtime behavior ───────────────────────────────────────────────
+
+    it('method `this.x := y` mutations persist across the receiver instance', async () => {
+        // The most direct verification: call a method that mutates a field,
+        // then plot the field. If `this` was `globalThis`, the plotted value
+        // would be undefined / 0.
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("this mutation persistence", overlay=true)
+type Counter
+    int value = 0
+method increment(Counter this) =>
+    this.value := this.value + 1
+var Counter c = Counter.new()
+c.increment()
+c.increment()
+plot(c.value, "count")
+plot(close)
+        `;
+        const { plots } = await pineTS.run(code);
+        const counts = plots['count']?.data ?? [];
+        expect(counts.length).toBeGreaterThan(0);
+        // After two increments per bar, the value should be 2 on the very
+        // first bar and accumulate from there. Before the fix this stayed
+        // at 0 (or NaN) for all bars.
+        const lastValue = counts[counts.length - 1]?.value;
+        expect(lastValue).toBeGreaterThanOrEqual(2);
+    });
+
+    it('regular fn and method with the same name both work end-to-end', async () => {
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("dual-name", overlay=true)
+type Box
+    int n = 0
+add(int a, int b) =>
+    a + b
+method add(Box this, int a) =>
+    this.n := this.n + a
+var Box b = Box.new()
+sum = add(3, 4)
+b.add(10)
+plot(sum, "sum")
+plot(b.n, "boxN")
+        `;
+        const { plots } = await pineTS.run(code);
+        // Regular function must return 7
+        const sum = plots['sum']?.data?.[plots['sum'].data.length - 1]?.value;
+        expect(sum).toBe(7);
+        // Method must accumulate (10 per bar)
+        const boxN = plots['boxN']?.data?.[plots['boxN'].data.length - 1]?.value;
+        expect(boxN).toBeGreaterThanOrEqual(10);
+    });
+
+    it('positional `overlay=true` in indicator(...) is honored, not silently dropped', async () => {
+        // Bug: the transpiler wraps positional booleans/numbers in $.param,
+        // which promotes them to Series. parseArgsForPineParams then fails
+        // the `boolean` / `number` type checks — so `overlay`, `precision`,
+        // etc. quietly fell back to defaults.
+        const pineTS = makePineTS();
+        const code = `
+//@version=5
+indicator("title", "short", true, max_lines_count = 50)
+plot(close)
+        `;
+        const r = await pineTS.run(code);
+        expect(r.indicator?.overlay).toBe(true);
+        // Sanity: title and named-arg also survive
+        expect(r.indicator?.title).toBe('title');
+        expect(r.indicator?.max_lines_count).toBe(50);
+    });
+
+    it('method param shadowing the `color` namespace runs without throwing', async () => {
+        // Smoke: before the rename fix, this would crash with "fn is not a
+        // function" because `color.new(...)` got rewritten to
+        // `color_$N.new(...)` and `color_$N` was a string at runtime.
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("color shadow runtime", overlay=true)
+type Marker
+    color tone
+method setColor(Marker this, color color) =>
+    this.tone := color.new(color, 50)
+var Marker m = Marker.new()
+m.setColor(#ff8800)
+plot(close)
+        `;
+        await expect(pineTS.run(code)).resolves.toBeDefined();
+    });
+});

--- a/tests/core/udt-method-mutation.test.ts
+++ b/tests/core/udt-method-mutation.test.ts
@@ -174,6 +174,134 @@ plot(b.n, "boxN")
         expect(boxN).toBeGreaterThanOrEqual(10);
     });
 
+    it('UDT field subscript in a CONDITIONAL function-call arg returns per-bar lookback (not per-firing)', async () => {
+        // Regression: PineTS used to wrap UDT-field subscripts as
+        // `$.param(<scalar>, N, name)` for function args. `$.param`'s scalar
+        // history is keyed by call frequency — when the call site lived
+        // inside an `if`-block that only fired on some bars, lookback
+        // returned the value from the *previous firing*, not from N bars
+        // earlier in time. The correct rewrite emits `$.get(<scoped-bar>,
+        // N).field` directly so lookback rides the bar series (populated
+        // every bar) regardless of call-site conditionality.
+        //
+        // The smoking gun: feed the indicator a swing-low on every other
+        // bar; have the if-block call a function with `bar.low[1]` as arg.
+        // Each firing should see the IMMEDIATE prior bar's low. Without the
+        // fix, it sees the prior FIRING's bar low, which is two bars stale.
+        const pineTS = makePineTS();
+        const code = `
+//@version=6
+indicator("conditional UDT lookback", overlay=true)
+type BAR
+    float low = low
+
+capture(int idx, float v) =>
+    100000.0 + idx * 1.0 + v / 1000000.0   // pack idx and v into one float for inspection
+
+BAR bar = BAR.new()
+
+// Fire the if-block on every odd bar — testing whether bar.low[1] inside
+// the block resolves to "1 bar back in time" or "value from previous firing".
+captured = 0.0
+if bar_index % 2 == 1
+    captured := capture(bar_index, bar.low[1])
+
+plot(captured, "captured")
+plot(close, "close")
+        `;
+        const r = await pineTS.run(code);
+        const cap = r.plots['captured']?.data ?? [];
+        const closes = r.marketData.map(b => b.close);
+        // For each odd bar, the captured value should encode (current
+        // bar_index, low at bar_index-1). Since we only run on a Mock
+        // provider (synthetic data), just verify the encoded `idx` part of
+        // the value matches the bar_index where capture fired.
+        // The first non-zero capture is at bar 1 — its packed idx component
+        // should be exactly 1 (capture(1, low_at_bar_0)).
+        const firstFire = cap.find(d => d?.value !== 0 && d?.value !== undefined);
+        expect(firstFire).toBeDefined();
+        // Extract the integer "idx" component: floor(value - 100000) = idx.
+        const idxPart = Math.floor((firstFire.value as number) - 100000);
+        expect(idxPart).toBe(1);
+    });
+
+    it('UDT field subscript in a function-call arg uses direct $.get lookback (no $.param wrap)', () => {
+        // Codegen check for the same bug — the transpile output should NOT
+        // contain `$.param($.get(bar, 0).field, N, …)` for UDT subscripts in
+        // function-call args. It should emit `$.get(bar, N).field` directly.
+        const code = `
+//@version=6
+indicator("udt subscript codegen", overlay=true)
+type BAR
+    float low = low
+caller(float v) =>
+    v
+bar = BAR.new()
+if close > open
+    x = caller(bar.low[1])
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // The arg must be a direct `$.get(<scoped-bar>, 1).low` expression.
+        expect(jsCode).toMatch(/\$\.get\(\$\.let\.glb1_bar,\s*1\)\.low/);
+        // The buggy wrapper must NOT appear.
+        expect(jsCode).not.toMatch(/\$\.param\(\s*\$\.get\(\$\.let\.glb1_bar,\s*0\)\.low,\s*1\b/);
+    });
+
+    it('UFCS-style direct call to a method-only declaration resolves to the prefixed JS name', () => {
+        // Pine allows methods to be called via UFCS: `foo(receiver, args)` is
+        // equivalent to `receiver.foo(args)`. After the `$M_` prefix rename,
+        // a bare callee `isSame(receiver, ...)` was failing at runtime with
+        // "isSame is not defined" because the JS function is now $M_isSame.
+        // Reproduces the regression seen in Elliott-Wave.pine.
+        const code = `
+//@version=6
+indicator("UFCS direct call", overlay=true)
+type Wave
+    int x
+method same(Wave w, int x) =>
+    w.x == x
+ww = Wave.new(7)
+// Direct UFCS call (no dot syntax).
+y = same(ww, 7)
+plot(y ? 1 : 0)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // Direct call must target the prefixed JS name, not the bare Pine name.
+        expect(jsCode).toMatch(/\$\.call\(\s*\$M_same\s*,/);
+        // The bare `isSame` (without prefix) must not appear as a $.call target.
+        expect(jsCode).not.toMatch(/\$\.call\(\s*same\s*,/);
+    });
+
+    it('regular function with same name as a method takes precedence for direct calls', () => {
+        // When BOTH a regular function AND a method share a Pine name, Pine
+        // resolves direct `name(args)` to the regular function. The dot form
+        // `obj.name(args)` still resolves to the method. The transpiler must
+        // NOT retarget the direct call to `$M_name` in this case.
+        const code = `
+//@version=6
+indicator("regular wins over method", overlay=true)
+type Box
+    int n
+foo(int x) =>
+    x * 2
+method foo(Box this, int x) =>
+    this.n := x
+b = Box.new(0)
+y = foo(5)            // direct call → regular function
+b.foo(10)             // dot call → method
+plot(y)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // Direct `foo(5)` must call the regular function (no `$M_` prefix).
+        expect(jsCode).toMatch(/\$\.call\(\s*foo\s*,/);
+        // Dot `b.foo(10)` must call the prefixed method.
+        expect(jsCode).toMatch(/\$\.call\(\s*\$M_foo\s*,/);
+    });
+
     it('positional `overlay=true` in indicator(...) is honored, not silently dropped', async () => {
         // Bug: the transpiler wraps positional booleans/numbers in $.param,
         // which promotes them to Series. parseArgsForPineParams then fails

--- a/tests/core/udt-method-mutation.test.ts
+++ b/tests/core/udt-method-mutation.test.ts
@@ -338,4 +338,131 @@ plot(close)
         `;
         await expect(pineTS.run(code)).resolves.toBeDefined();
     });
+
+    // ── Regression: method named after a JS reserved word ─────────────
+    // `delete`, `class`, `return`, etc. collide with JS keywords. The
+    // codegen renames such identifiers with `_$N` to keep the generated
+    // JS valid — but for a Pine `method`, the JS name already gets a
+    // collision-proof `$M_` prefix, so adding `_$N` on top would change
+    // the Pine name visible at the call site (`obj.delete()` looks up
+    // `delete`, not `delete_$0`) and break the UFCS retargeting.
+    // Codegen must skip the reserved-name rename for methods.
+    it('codegen: method named `delete` keeps the bare $M_<name> identifier', () => {
+        const code = `
+//@version=6
+indicator("delete method", overlay=true)
+type Foo
+    int x
+method delete(Foo this) =>
+    this.x := 0
+
+f = Foo.new(1)
+f.delete()
+plot(close)
+        `;
+        const js = transpile(code).toString();
+        // Bare `delete(` must not appear (would be a JS parse error)
+        expect(js).not.toMatch(/function\s+delete\s*\(/);
+        // Method name must be the bare `$M_delete` form — no `_$N` suffix
+        expect(js).toMatch(/function\s+\$M_delete\s*\(/);
+        expect(js).not.toMatch(/function\s+\$M_delete_\$\d+\s*\(/);
+        // Call site `f.delete()` must retarget to `$.call($M_delete, ..., f)`.
+        expect(js).toMatch(/\$\.call\s*\(\s*\$M_delete\b/);
+    });
+
+    it('runtime: method named `delete` is dispatched via UFCS', async () => {
+        // Whole-pipeline check: define `method delete` on a UDT that wraps
+        // a built-in line, then call `obj.delete()` and verify the user
+        // method actually fired (cascading to the inner line.delete()).
+        // Before the fix, the user method registration was keyed by
+        // `delete_$0` while the call site looked up `delete`, so
+        // `obj.delete()` was a silent no-op and the inner line was never
+        // marked deleted.
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', '1W', null,
+            new Date('2018-12-15').getTime(),
+            new Date('2019-04-01').getTime());
+        const code = `
+//@version=6
+indicator("delete method runtime", overlay=true)
+type Holder
+    line ln
+method delete(Holder this) =>
+    this.ln.delete()
+
+if bar_index == 5
+    Holder h = Holder.new(line.new(0, 100, 5, 110))
+    h.delete()
+plot(close)
+`;
+        const r = await pineTS.run(code);
+        const lines = r.plots?.['__lines__']?.data?.[0]?.value || [];
+        // The single line created at bar 5 must have been deleted via
+        // h.delete() → user method → this.ln.delete().
+        expect(lines.length).toBe(0);
+    });
+
+    // ── Regression: explicit Pine type annotation must register UDT instance ──
+    // `Holder r = arr.get(0)` should register `r` as a Holder instance even
+    // though `inferUdtTypeFromInit` can't tell the type from `arr.get(0)`.
+    // Codegen preserves the type via a `"__pineUdtVar:r=Holder"` marker that
+    // the AnalysisPass picks up. Without this, `r.delete()` would fall back
+    // to the no-op direct property access on a PineTypeObject.
+    it('runtime: UDT retrieved from an array dispatches user methods correctly', async () => {
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', '1W', null,
+            new Date('2018-12-15').getTime(),
+            new Date('2019-04-01').getTime());
+        const code = `
+//@version=6
+indicator("udt from array", overlay=true)
+type Holder
+    line ln
+method clear(Holder this) =>
+    this.ln.delete()
+
+if bar_index == 5
+    Holder h = Holder.new(line.new(0, 100, 5, 110))
+    Holder[] arr = array.new<Holder>()
+    arr.push(h)
+    Holder r = arr.get(0)
+    r.clear()
+plot(close)
+`;
+        const r = await pineTS.run(code);
+        const lines = r.plots?.['__lines__']?.data?.[0]?.value || [];
+        // The line must have been deleted via r.clear() → $M_clear(r) →
+        // r.ln.delete(). r is a Holder via the explicit Pine annotation.
+        expect(lines.length).toBe(0);
+    });
+
+    // ── Regression: type-aware UFCS retargeting ─────────────────────────
+    // When a UDT method shares a name with a built-in (e.g. `delete`), the
+    // retargeting must only fire for UDT receivers. `someLine.delete()`
+    // must keep calling the built-in `LineHelper.delete`, not be hijacked
+    // into `$M_delete(someLine)` (which would try `someLine.ln.delete()`
+    // and fail silently because lines don't have an `ln` field).
+    it('runtime: UFCS retargeting is type-aware (built-in line.delete keeps working)', async () => {
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', '1W', null,
+            new Date('2018-12-15').getTime(),
+            new Date('2019-04-01').getTime());
+        const code = `
+//@version=6
+indicator("type-aware retarget", overlay=true)
+type Holder
+    line ln
+method delete(Holder this) =>
+    this.ln.delete()
+
+if bar_index == 5
+    // A bare line — NOT a UDT instance.
+    line bareLine = line.new(0, 200, 5, 210)
+    bareLine.delete()
+plot(close)
+`;
+        const r = await pineTS.run(code);
+        const lines = r.plots?.['__lines__']?.data?.[0]?.value || [];
+        // The bare line was deleted via the built-in line.delete() —
+        // because `bareLine` is a Line, not a UDT instance, the user
+        // method `$M_delete` must NOT have been called.
+        expect(lines.length).toBe(0);
+    });
 });

--- a/tests/core/udt-method-mutation.test.ts
+++ b/tests/core/udt-method-mutation.test.ts
@@ -465,4 +465,34 @@ plot(close)
         // method `$M_delete` must NOT have been called.
         expect(lines.length).toBe(0);
     });
+
+    // ── Regression: method param name shadows outer-scope UDT instance ──
+    // When a `method foo(MyUDT thing)` declares a parameter that shares a
+    // name with an outer-scope UDT variable (e.g. `var MyUDT thing = ...`),
+    // the per-function UDT-instance registration used to wipe the outer
+    // entry on function exit (blanket `unmark` instead of save/restore).
+    // Subsequent `thing.foo()` call sites then fell out of UFCS retargeting
+    // because `isUdtInstance('thing')` returned false at the call site.
+    it('runtime: param name that shadows outer UDT variable does not break dispatch', async () => {
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', '1W', null,
+            new Date('2018-12-15').getTime(),
+            new Date('2019-04-01').getTime());
+        const code = `
+//@version=6
+indicator("UDT param name shadow", overlay=true)
+type ZZ
+    int v
+method touch(ZZ aZZ) =>
+    aZZ.v := aZZ.v + 1
+var ZZ aZZ = ZZ.new(0)
+if bar_index == 5
+    aZZ.touch()
+plot(aZZ.v, "v")
+`;
+        const r = await pineTS.run(code);
+        const v = r.plots?.['v']?.data;
+        // After bar_index == 5 the touch() method must have incremented v
+        // from 0 to 1. The last bar's plot value is what we check.
+        expect(v?.[v.length - 1]?.value).toBe(1);
+    });
 });

--- a/tests/namespaces/box/box.test.ts
+++ b/tests/namespaces/box/box.test.ts
@@ -407,4 +407,40 @@ describe('BOX Namespace', () => {
         expect(Array.isArray(boxes)).toBe(true);
         expect(boxes.length).toBeGreaterThanOrEqual(3);
     });
+
+    // Regression: `bgcolor = color(na)` and `border_color = color(na)` must
+    // reach QFChart as a na marker (null), not be substituted with the
+    // default Pine blue (`#2962ff`) by the helper. `color(na)` returns null,
+    // and the helper used to drop null via `resolved || fallback`.
+    it('box.new() preserves na from color(na) — does not substitute default blue', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 50, new Date('2025-01-01').getTime(), new Date('2025-03-01').getTime());
+
+        const { plots } = await pineTS.run(`//@version=6
+indicator("probe", overlay = true)
+if barstate.isfirst
+    box bx = box.new(0, 100, 5, 50, bgcolor = color(na), border_color = color(na))
+`);
+        const bx = plots['__boxes__']?.data?.[0]?.value?.[0];
+        expect(bx).toBeDefined();
+        expect(bx.bgcolor).not.toBe('#2962ff');
+        expect(bx.border_color).not.toBe('#2962ff');
+        // Should be a na marker — null (from color(na)) or NaN
+        const isNa = (v: any) => v === null || v === undefined || (typeof v === 'number' && isNaN(v));
+        expect(isNa(bx.bgcolor)).toBe(true);
+        expect(isNa(bx.border_color)).toBe(true);
+    });
+
+    it('box.new() preserves NaN from `bgcolor = na` (direct na)', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 50, new Date('2025-01-01').getTime(), new Date('2025-03-01').getTime());
+
+        const { plots } = await pineTS.run(`//@version=6
+indicator("probe", overlay = true)
+if barstate.isfirst
+    box bx = box.new(0, 100, 5, 50, bgcolor = na, border_color = na)
+`);
+        const bx = plots['__boxes__']?.data?.[0]?.value?.[0];
+        expect(bx).toBeDefined();
+        expect(bx.bgcolor).not.toBe('#2962ff');
+        expect(bx.border_color).not.toBe('#2962ff');
+    });
 });

--- a/tests/namespaces/for-in-iteration.test.ts
+++ b/tests/namespaces/for-in-iteration.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '@pinets/marketData/Provider.class';
+
+/**
+ * End-to-end runtime tests for `for x in collection` and `for [i, x] in collection`
+ * codegen. Iteration must work uniformly across:
+ *   - PineArrayObject (var/let arrays, UDT array fields, function params)
+ *   - Plain JS arrays (built-ins like box.all, line.all, label.all)
+ * for both destructuring and non-destructuring forms.
+ *
+ * Regressions caught here:
+ *   - `for [i, x] in udt.field`  used to throw "is not iterable" (no .array.entries())
+ *   - `for el in box.all`        regressed when codegen unconditionally added .array
+ */
+describe('for-in iteration — runtime end-to-end', () => {
+    const mkPts = () =>
+        new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            'D',
+            null,
+            new Date('2024-01-01').getTime(),
+            new Date('2024-01-15').getTime(),
+        );
+
+    it('iterates a PineArrayObject identifier (non-destructuring)', async () => {
+        const code = `
+//@version=6
+indicator("for-in identifier")
+var arr = array.from(10.0, 20.0, 30.0, 40.0)
+sum = 0.0
+for v in arr
+    sum := sum + v
+plot(sum, "sum")
+        `;
+        const { plots } = await mkPts().run(code);
+        const last = (a: any[]) => a[a.length - 1].value;
+        expect(last(plots['sum'].data)).toBe(100);
+    });
+
+    it('iterates a PineArrayObject identifier with destructuring', async () => {
+        const code = `
+//@version=6
+indicator("for-in identifier destructured")
+var arr = array.from(10.0, 20.0, 30.0, 40.0)
+idxsum = 0
+valsum = 0.0
+for [i, v] in arr
+    idxsum := idxsum + i
+    valsum := valsum + v
+plot(idxsum, "idxsum")
+plot(valsum, "valsum")
+        `;
+        const { plots } = await mkPts().run(code);
+        const last = (a: any[]) => a[a.length - 1].value;
+        expect(last(plots['idxsum'].data)).toBe(0 + 1 + 2 + 3);
+        expect(last(plots['valsum'].data)).toBe(100);
+    });
+
+    it('iterates a UDT array field (non-destructuring) — member expression', async () => {
+        const code = `
+//@version=6
+indicator("for-in udt.field")
+type bucket
+    array<float> prices = na
+var b = bucket.new(array.from(1.5, 2.5, 3.5))
+sum = 0.0
+for p in b.prices
+    sum := sum + p
+plot(sum, "sum")
+        `;
+        const { plots } = await mkPts().run(code);
+        const last = (a: any[]) => a[a.length - 1].value;
+        expect(last(plots['sum'].data)).toBeCloseTo(7.5);
+    });
+
+    it('iterates a UDT array field with destructuring — member expression', async () => {
+        // Regression: was throwing "is not iterable" — destructuring a scalar yielded
+        // by PineArrayObject's [Symbol.iterator]
+        const code = `
+//@version=6
+indicator("for-in udt.field destructured")
+type bucket
+    array<float> prices = na
+var b = bucket.new(array.from(10.0, 20.0, 30.0))
+idxsum = 0
+valsum = 0.0
+for [i, p] in b.prices
+    idxsum := idxsum + i
+    valsum := valsum + p
+plot(idxsum, "idxsum")
+plot(valsum, "valsum")
+        `;
+        const { plots } = await mkPts().run(code);
+        const last = (a: any[]) => a[a.length - 1].value;
+        expect(last(plots['idxsum'].data)).toBe(0 + 1 + 2);
+        expect(last(plots['valsum'].data)).toBe(60);
+    });
+
+    it('iterates a built-in plain JS array (box.all) — non-destructuring', async () => {
+        // Regression: built-ins like box.all return plain JS arrays (no .array field).
+        // Previously codegen emitted `box.all.array` → undefined → "is not iterable".
+        const code = `
+//@version=6
+indicator("for-in box.all")
+if barstate.islast
+    box.new(0, 100, 1, 50)
+    box.new(2, 200, 3, 150)
+    box.new(4, 300, 5, 250)
+count = 0
+for el in box.all
+    count := count + 1
+plot(count, "count")
+        `;
+        const { plots } = await mkPts().run(code);
+        const last = (a: any[]) => a[a.length - 1].value;
+        expect(last(plots['count'].data)).toBe(3);
+    });
+
+    it('iterates a built-in plain JS array (box.all) — destructuring', async () => {
+        const code = `
+//@version=6
+indicator("for-in box.all destructured")
+if barstate.islast
+    box.new(0, 100, 1, 50)
+    box.new(2, 200, 3, 150)
+idxsum = 0
+for [i, el] in box.all
+    idxsum := idxsum + i
+plot(idxsum, "idxsum")
+        `;
+        const { plots } = await mkPts().run(code);
+        const last = (a: any[]) => a[a.length - 1].value;
+        expect(last(plots['idxsum'].data)).toBe(0 + 1);
+    });
+});

--- a/tests/namespaces/label/label.test.ts
+++ b/tests/namespaces/label/label.test.ts
@@ -279,8 +279,12 @@ describe('LABEL Namespace', () => {
     it('label data is pushed to __labels__ plot with correct structure', async () => {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-11-20').getTime());
 
+        // Use `var` so the label is created exactly once on bar 0; without it,
+        // a fresh label would be created every bar and `_enforceMaxCount`
+        // would silently retire older ones — making the assertions below
+        // dependent on bar count.
         const { plots } = await pineTS.run((context) => {
-            label.new(bar_index, 50000, 'PlotTest', xloc.bar_index, yloc.price, '#ff0000', label.style_label_down, '#ffffff');
+            var myLabel = label.new(bar_index, 50000, 'PlotTest', xloc.bar_index, yloc.price, '#ff0000', label.style_label_down, '#ffffff');
             return {};
         });
 
@@ -291,7 +295,6 @@ describe('LABEL Namespace', () => {
         // Labels are now stored as an aggregated array (like lines)
         const labels = labelEntry.value;
         expect(Array.isArray(labels)).toBe(true);
-        // Find our label (the first non-deleted one created on the first bar)
         const lbl = labels.find((l: any) => l.text === 'PlotTest');
         expect(lbl).toBeDefined();
         expect(lbl.x).toBe(0);

--- a/tests/namespaces/line/line.test.ts
+++ b/tests/namespaces/line/line.test.ts
@@ -426,4 +426,37 @@ plot(close)
         // The surviving one is the last one (bar_index = 4)
         expect(lines[0].x1).toBe(4);
     });
+
+    // Regression: `line.new(..., color = na)` and `color = color(na)` must
+    // serialize a na marker so QFChart can skip stroking. The QFChart-side
+    // fallback used to paint these lines as default Pine blue (#2962ff).
+    // Mirrors the invisible anchor lines in Range-Intelligence-Suite-LuxAlgo
+    // (`line uL = line.new(..., color = na)` used as linefill endpoints).
+    it('line.new(color = na) serialises na marker (not a colour string)', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 50, new Date('2025-01-01').getTime(), new Date('2025-03-01').getTime());
+        const { plots } = await pineTS.run(`//@version=6
+indicator("probe", overlay = true)
+if barstate.isfirst
+    line ln = line.new(0, 100, 5, 50, color = na)
+`);
+        const ln = plots['__lines__']?.data?.[0]?.value?.[0];
+        expect(ln).toBeDefined();
+        const isNa = (v: any) => v === null || v === undefined || (typeof v === 'number' && isNaN(v));
+        expect(isNa(ln.color)).toBe(true);
+        expect(ln.color).not.toBe('#2962ff');
+    });
+
+    it('line.new(color = color(na)) serialises na marker', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 50, new Date('2025-01-01').getTime(), new Date('2025-03-01').getTime());
+        const { plots } = await pineTS.run(`//@version=6
+indicator("probe", overlay = true)
+if barstate.isfirst
+    line ln = line.new(0, 100, 5, 50, color = color(na))
+`);
+        const ln = plots['__lines__']?.data?.[0]?.value?.[0];
+        expect(ln).toBeDefined();
+        const isNa = (v: any) => v === null || v === undefined || (typeof v === 'number' && isNaN(v));
+        expect(isNa(ln.color)).toBe(true);
+        expect(ln.color).not.toBe('#2962ff');
+    });
 });

--- a/tests/namespaces/line/line.test.ts
+++ b/tests/namespaces/line/line.test.ts
@@ -399,4 +399,31 @@ describe('LINE Namespace', () => {
         // At least 3 lines should exist (var creates on bar 0 only, let creates on every bar)
         expect(lines.length).toBeGreaterThanOrEqual(3);
     });
+
+    it('deleted lines are excluded from the __lines__ plot output', async () => {
+        // Regression: indicators that delete-and-recreate a line every bar
+        // (e.g. LuxAlgo Range Intelligence Suite refreshing the active POC line)
+        // were leaving every prior version in the rendered output. This test
+        // creates 5 lines while explicitly deleting all but the last, and
+        // asserts the published plot value contains only the surviving line.
+        const code = `
+//@version=5
+indicator("delete-then-render", overlay=true)
+var line ln = na
+if bar_index < 5
+    if not na(ln)
+        ln.delete()
+    ln := line.new(bar_index, 100, bar_index + 5, 200)
+plot(close)
+`;
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-01-15').getTime());
+        const { plots } = await pineTS.run(code);
+
+        const lines = plots['__lines__'].data[0].value;
+        expect(Array.isArray(lines)).toBe(true);
+        // 5 lines created, 4 explicitly deleted — only 1 must remain
+        expect(lines.length).toBe(1);
+        // The surviving one is the last one (bar_index = 4)
+        expect(lines[0].x1).toBe(4);
+    });
 });

--- a/tests/namespaces/request.test.ts
+++ b/tests/namespaces/request.test.ts
@@ -829,3 +829,165 @@ plot(volume, "_v")
         expect(secLow[0].value).toBeCloseTo(7441.21, 1);
     }, 30000);
 });
+
+/**
+ * Pine semantics: named arguments bind to the function's known parameter slots
+ * by name (like Python kwargs), not by position. The PineTS transpiler emits a
+ * trailing options object — request.security must merge that bag into the named
+ * slots, not stuff it into the next positional slot (`gaps`).
+ *
+ * Regression caught: previously `request.security(symbol, tf, expr, lookahead = …)`
+ * silently set `gaps` to the options object and `lookahead` to its default (false).
+ */
+describe('request.security — named-args resolution', () => {
+    it('binds named lookahead to the lookahead slot (not gaps)', async () => {
+        // Same-TF so the same-TF shortcut handles the call directly. We're just
+        // checking that the named-args wiring doesn't crash and returns the
+        // expected expression value (regardless of lookahead/gaps semantics
+        // which don't apply on same-TF).
+        const code = `
+//@version=6
+indicator("named-args lookahead")
+v = request.security(syminfo.tickerid, timeframe.period, close, lookahead = barmerge.lookahead_on, calc_bars_count = 500)
+plot(v, "v")
+        `;
+        const pineTS = new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            'D',
+            null,
+            new Date('2025-10-01').getTime(),
+            new Date('2025-10-05').getTime(),
+        );
+        const { plots } = await pineTS.run(code);
+        const data = plots['v'].data;
+        expect(data.length).toBeGreaterThan(0);
+        // Same-TF with `close` expression — every bar's value must equal close on that bar.
+        data.forEach((p: any) => {
+            expect(typeof p.value).toBe('number');
+            expect(isNaN(p.value)).toBe(false);
+        });
+    });
+
+    it('positional and named lookahead produce the same result (cross-TF, no gaps)', async () => {
+        // Cross-TF (D chart, W security) — exercises the lookahead path. Both
+        // call shapes must produce identical series; named arg must NOT collapse
+        // to gaps and zero-out lookahead.
+        const positionalCode = `
+//@version=6
+indicator("positional")
+v = request.security(syminfo.tickerid, 'W', close, false, true)
+plot(v, "v")
+        `;
+        const namedCode = `
+//@version=6
+indicator("named")
+v = request.security(syminfo.tickerid, 'W', close, lookahead = barmerge.lookahead_on)
+plot(v, "v")
+        `;
+        const mk = () =>
+            new PineTS(
+                Provider.Mock,
+                'BTCUSDC',
+                'D',
+                null,
+                new Date('2025-09-01').getTime(),
+                new Date('2025-10-15').getTime(),
+            );
+
+        const { plots: posPlots } = await mk().run(positionalCode);
+        const { plots: namPlots } = await mk().run(namedCode);
+
+        const pos = posPlots['v'].data;
+        const nam = namPlots['v'].data;
+        expect(pos.length).toBe(nam.length);
+        expect(pos.length).toBeGreaterThan(0);
+        for (let i = 0; i < pos.length; i++) {
+            // toEqual handles NaN==NaN as equal
+            expect(nam[i].value).toEqual(pos[i].value);
+        }
+    });
+
+    it('binds named gaps + named lookahead together', async () => {
+        // Both flags as named args (out-of-order named args are allowed in Pine).
+        // gaps_on + lookahead_on path must run without crashing.
+        const code = `
+//@version=6
+indicator("named both")
+v = request.security(syminfo.tickerid, 'W', close, lookahead = barmerge.lookahead_on, gaps = barmerge.gaps_on)
+plot(v, "v")
+        `;
+        const pineTS = new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            'D',
+            null,
+            new Date('2025-09-01').getTime(),
+            new Date('2025-10-15').getTime(),
+        );
+        const { plots } = await pineTS.run(code);
+        expect(plots['v'].data.length).toBeGreaterThan(0);
+    });
+
+    it('aligns secondary barstate.islast with chart barstate.islast', async () => {
+        // Regression: the secondary context's date range used to be over-extended
+        // (eDate + 30-day buffer when context.eDate was undefined), so
+        // `barstate.islast` in the secondary fired on a future bar — never on
+        // the daily bar containing the chart's last bar. Patterns like
+        // `barstate.islast ? value : na` would always read NaN.
+        //
+        // With the alignment fix, the secondary's last bar IS the daily bar that
+        // contains the chart's last bar, so the gated expression value is visible.
+        const code = `
+//@version=6
+indicator("barstate.islast alignment")
+gated() =>
+    barstate.islast ? 42.0 : na
+v = request.security(syminfo.tickerid, 'D', gated(), lookahead = barmerge.lookahead_on)
+plot(v, "v")
+        `;
+        const pineTS = new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            '60',
+            null,
+            new Date('2025-09-01').getTime(),
+            new Date('2025-10-15').getTime(),
+        );
+        const { plots } = await pineTS.run(code);
+        const data = plots['v'].data;
+        expect(data.length).toBeGreaterThan(0);
+        // The chart's last bar must read 42 (the gated value at the secondary's
+        // barstate.islast). If the secondary over-extends, this would be NaN.
+        const lastValue = data[data.length - 1].value;
+        expect(lastValue).toBe(42);
+    });
+
+    it('accepts a tuple expression (array) as positional, not as options bag', async () => {
+        // Regression: parseArgsForPineParams used to treat any plain object as
+        // the options bag — including JS arrays. A tuple expression like
+        // `[open, close]` was being misinterpreted, leaving `expression`
+        // undefined. Tuple destructuring on the result must work.
+        const code = `
+//@version=6
+indicator("tuple expr")
+[o, c] = request.security(syminfo.tickerid, 'D', [open, close])
+plot(o, "o")
+plot(c, "c")
+        `;
+        const pineTS = new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            'D',
+            null,
+            new Date('2025-10-01').getTime(),
+            new Date('2025-10-05').getTime(),
+        );
+        const { plots } = await pineTS.run(code);
+        expect(plots['o'].data.length).toBeGreaterThan(0);
+        expect(plots['c'].data.length).toBeGreaterThan(0);
+        // Both should be valid numbers (same-TF shortcut returns open/close as-is)
+        plots['o'].data.forEach((p: any) => expect(isNaN(p.value)).toBe(false));
+        plots['c'].data.forEach((p: any) => expect(isNaN(p.value)).toBe(false));
+    });
+});

--- a/tests/namespaces/str.test.ts
+++ b/tests/namespaces/str.test.ts
@@ -169,4 +169,50 @@ describe('Str Namespace', () => {
         expect(last(result.fmt_no_args)).toBe('hello'); // replace won't find placeholders
         expect(last(result.nan_num)).toBeNaN();
     });
+
+    it('should format timestamps via str.format_time', async () => {
+        const sDate = new Date('2019-01-01').getTime();
+        const eDate = new Date('2019-01-02').getTime();
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, sDate, eDate);
+
+        const sourceCode = (context: any) => {
+            const { str } = context.pine;
+
+            // Fixed UNIX ms timestamp: 2024-03-19 (Tuesday) 14:05:09 UTC.
+            // Inlined as a literal because the source is re-transpiled and locals
+            // aren't visible in the wrapper Function scope.
+            return {
+                date_only:  str.format_time(1710857109000, 'yyyy-MM-dd', 'UTC'),
+                dow_short:  str.format_time(1710857109000, "EEE (yyyy-MM-dd)", 'UTC'),
+                dow_long:   str.format_time(1710857109000, 'EEEE', 'UTC'),
+                month_long: str.format_time(1710857109000, 'MMMM d, yyyy', 'UTC'),
+                month_short:str.format_time(1710857109000, 'MMM d', 'UTC'),
+                time_24:    str.format_time(1710857109000, 'HH:mm:ss', 'UTC'),
+                time_12:    str.format_time(1710857109000, 'h:mm a', 'UTC'),
+                year_2:     str.format_time(1710857109000, 'yy', 'UTC'),
+                escaped:    str.format_time(1710857109000, "yyyy'T'HH:mm", 'UTC'),
+                tz_offset:  str.format_time(1710857109000, 'Z', 'UTC'),
+                tz_ny:      str.format_time(1710857109000, 'yyyy-MM-dd HH:mm Z', 'America/New_York'),
+                nan_input:  str.format_time(NaN, 'yyyy', 'UTC'),
+            };
+        };
+
+        const { result } = await pineTS.run(sourceCode);
+        const last = (arr: any[]) => arr[arr.length - 1];
+
+        expect(last(result.date_only)).toBe('2024-03-19');
+        expect(last(result.dow_short)).toBe('Tue (2024-03-19)');
+        expect(last(result.dow_long)).toBe('Tuesday');
+        expect(last(result.month_long)).toBe('March 19, 2024');
+        expect(last(result.month_short)).toBe('Mar 19');
+        expect(last(result.time_24)).toBe('14:05:09');
+        expect(last(result.time_12)).toBe('2:05 PM');
+        expect(last(result.year_2)).toBe('24');
+        // 'T' inside single quotes is a literal — must NOT be substituted
+        expect(last(result.escaped)).toBe('2024T14:05');
+        expect(last(result.tz_offset)).toBe('+0000');
+        // NY in March is on DST (EDT, UTC-04:00) → 14:05 UTC = 10:05 local
+        expect(last(result.tz_ny)).toBe('2024-03-19 10:05 -0400');
+        expect(last(result.nan_input)).toBe('NaN');
+    });
 });

--- a/tests/transpiler/dotted-types.test.ts
+++ b/tests/transpiler/dotted-types.test.ts
@@ -132,4 +132,54 @@ chart.point[] polyPoints = array.new<chart.point>()
         expect(jsCode).toBeDefined();
         expect(jsCode).toContain('polyPoints');
     });
+
+    // Two complete typed declarations on a single line, separated by a comma.
+    // The shared-type comma-decl path used to greedily swallow the comma when
+    // the next token was an IDENTIFIER, then fail at the dot inside the second
+    // type name. Mirrors the pattern used in Liquidity-Structure.pine where
+    // the script declares two `chart.point[]` arrays in one statement:
+    //   chart.point[] cpS_f = array.new<chart.point>(), chart.point[] cpB_f = array.new<chart.point>()
+    it('should parse two full chart.point[] declarations on one line (comma-separated)', () => {
+        const code = `
+//@version=6
+indicator("Test")
+chart.point[] cpS_f = array.new<chart.point>(), chart.point[] cpB_f = array.new<chart.point>()
+        `;
+
+        const result = pineToJS(code);
+        expect(result.success).toBe(true);
+        expect(result.code).toBeDefined();
+        expect(result.code).toContain('cpS_f');
+        expect(result.code).toContain('cpB_f');
+    });
+
+    // The shared-type form (one type, multiple names) must still work.
+    it('should still parse shared-type comma-decl: float a = 0.0, b = 1.0', () => {
+        const code = `
+//@version=5
+indicator("Test")
+float a = 0.0, b = 1.0
+        `;
+
+        const result = pineToJS(code);
+        expect(result.success).toBe(true);
+        expect(result.code).toBeDefined();
+        expect(result.code).toContain('a');
+        expect(result.code).toContain('b');
+    });
+
+    // The full-repeated-type form with a non-dotted type must also still work.
+    it('should parse full-repeated-type form: float a = 1.0, float b = 2.0', () => {
+        const code = `
+//@version=5
+indicator("Test")
+float a = 1.0, float b = 2.0
+        `;
+
+        const result = pineToJS(code);
+        expect(result.success).toBe(true);
+        expect(result.code).toBeDefined();
+        expect(result.code).toContain('a');
+        expect(result.code).toContain('b');
+    });
 });

--- a/tests/transpiler/parser-fixes.test.ts
+++ b/tests/transpiler/parser-fixes.test.ts
@@ -1704,3 +1704,58 @@ plot(val == "#00FF00" ? 1 : 0, "Check")
         expect(result.plots).toBeDefined();
     });
 });
+
+// ---------------------------------------------------------------------------
+// Param shadowing user-function name (regression: leg → leg_var bleed)
+// ---------------------------------------------------------------------------
+describe('Parser Fix: Param shadowing user-function name', () => {
+    it('does not rewrite param `leg` to `leg_var` when another function is named leg', () => {
+        // Pattern from Range-Average-Retest-Model: function `leg()` declares
+        // `var leg = 0` (renamed to `leg_var` to avoid colliding with the fn
+        // name). A separate function `startOfNewLeg(int leg)` has a parameter
+        // named `leg` — its body must reference `leg`, not `leg_var`.
+        const code = `
+//@version=5
+indicator("Param Shadow Test")
+leg() =>
+    var leg = 0
+    if close > open
+        leg := 1
+    leg
+
+startOfNewLeg(int leg) => ta.change(leg) != 0
+
+currentLeg = leg()
+plot(startOfNewLeg(currentLeg) ? 1 : 0)
+`;
+        const result = pineToJS(code);
+        expect(result.success).toBe(true);
+        const js = result.code as string;
+        // The local var inside leg() is renamed to avoid colliding with fn name
+        expect(js).toMatch(/function\s+leg\s*\(\s*\)\s*\{[\s\S]*var\s+leg_var\s*=\s*0/);
+        // BUT: the param `leg` in startOfNewLeg must not be rewritten to leg_var
+        expect(js).toMatch(/function\s+startOfNewLeg\s*\(\s*leg\s*\)\s*\{[\s\S]*ta\.change\(leg\)/);
+        expect(js).not.toMatch(/function\s+startOfNewLeg\s*\(\s*leg\s*\)\s*\{[\s\S]*ta\.change\(leg_var\)/);
+    });
+
+    it('runs at runtime without ReferenceError (leg_var is not defined)', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+        const code = `
+//@version=5
+indicator("Param Shadow Runtime")
+leg() =>
+    var leg = 0
+    if close > open
+        leg := 1
+    leg
+
+startOfNewLeg(int leg) => ta.change(leg) != 0
+
+currentLeg = leg()
+plot(startOfNewLeg(currentLeg) ? 1 : 0)
+`;
+        const r = await pineTS.run(code);
+        expect(r).toBeDefined();
+        expect(r.plots).toBeDefined();
+    });
+});

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1920,6 +1920,61 @@ plot(close)
     });
 });
 
+describe('Pine Script Transpilation - User function names colliding with JS reserved keywords', () => {
+    // Pine allows user-defined functions/methods named after JS reserved keywords
+    // (e.g. `method delete(...)`). The codegen must rename these consistently at
+    // both the declaration site (`function delete()` is invalid JS) and at any
+    // direct call site, while leaving method-style invocations (`obj.delete()`)
+    // alone since JS allows reserved words as property names.
+
+    it('renames user method named `delete` so generated JS parses', () => {
+        // Regression: previously emitted `function delete()` → "Unexpected keyword 'delete'"
+        const code = `
+//@version=6
+indicator("delete method", overlay=true)
+type Foo
+    int x
+method delete(Foo this) =>
+    this.x := 0
+
+f = Foo.new(1)
+f.delete()
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        // Declaration must be renamed
+        expect(jsCode).not.toMatch(/function\s+delete\s*\(/);
+        expect(jsCode).toMatch(/function\s+delete_\$\d+\s*\(/);
+        // Method-style call site (property access) is still valid JS — keep as-is
+        // (PineTS lowers `obj.delete()` to `obj?.delete?.()` via optional chaining)
+        expect(jsCode).toMatch(/\.delete[?]?\.?\(/);
+    });
+
+    it('renames direct call to a user function named after a JS reserved word', () => {
+        // When a user function name is renamed, direct CallExpression callees
+        // referencing it must be renamed too. (Method-style `obj.delete()` is
+        // a property access and stays as `obj.delete()`.)
+        const code = `
+//@version=6
+indicator("direct call to user delete()")
+delete(int x) =>
+    x + 1
+y = delete(5)
+plot(y)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // Declaration renamed
+        expect(jsCode).toMatch(/function\s+delete_\$\d+\s*\(/);
+        // Direct call site renamed too — same rename
+        expect(jsCode).toMatch(/delete_\$\d+\(/);
+        // Must NOT leave a bare `delete(` call (would fail JS parse if `delete` is the keyword)
+        expect(jsCode).not.toMatch(/[^_\w]delete\(\d/);
+    });
+});
+
 describe('Pine Script Transpilation - Real-World Example (MACD)', () => {
     it('should transpile complete MACD indicator', () => {
         const code = `

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1420,7 +1420,7 @@ plot(close)
 
             expect(jsCode).toBeDefined();
             // The variable 'plus' should be renamed to avoid collision with function 'plus'
-            expect(jsCode).toContain('for (const x1 of $.get(X1, 0).array)');
+            expect(jsCode).toContain('for (const x1 of $.iter($.get(X1, 0)))');
         });
     });
 });
@@ -1640,7 +1640,7 @@ plot(close)
 
         expect(jsCode).toBeDefined();
         // Should contain for-of loop with $.get() on the iterable
-        expect(jsCode).toContain('for (const x1 of $.get(X1, 0).array)');
+        expect(jsCode).toContain('for (const x1 of $.iter($.get(X1, 0)))');
         // Should NOT contain malformed loop syntax
         expect(jsCode).not.toMatch(/for \([^)]+= undefined[^)]*of/);
     });
@@ -1663,7 +1663,7 @@ plot(close)
         const jsCode = result.toString();
 
         // The iterable should use $.get(), but the loop variable should not be transformed
-        expect(jsCode).toContain('for (const item of $.get(arr, 0).array)');
+        expect(jsCode).toContain('for (const item of $.iter($.get(arr, 0)))');
         expect(jsCode).not.toContain('$$.const.fn1_item');
     });
 
@@ -1685,14 +1685,14 @@ plot(close)
 
         expect(jsCode).toBeDefined();
         // Should contain for-of loop with .entries()
-        expect(jsCode).toContain('for (const [idx, x1] of $.get(X1, 0).array.entries())');
+        expect(jsCode).toContain('for (const [idx, x1] of $.entries($.get(X1, 0)))');
     });
 
     it('should handle for-of destructuring over a member expression iterable', () => {
         // Regression: iterating with [index, value] destructuring over a UDT field
-        // (e.g. eachDay.prices) must wrap the iterable as <expr>.array.entries()
-        // — not just <expr> — otherwise destructuring a scalar yielded by
-        // PineArrayObject's [Symbol.iterator] throws "is not iterable".
+        // (e.g. eachDay.prices) must route through $.entries() so the runtime can
+        // resolve the underlying array — otherwise destructuring a scalar yielded
+        // by PineArrayObject's [Symbol.iterator] throws "is not iterable".
         const code = `
 //@version=6
 indicator("For-Of Member Destructuring")
@@ -1712,8 +1712,60 @@ plot(close)
         const jsCode = result.toString();
 
         expect(jsCode).toBeDefined();
-        // Inner loop: member expression iterable must be suffixed with .array.entries()
-        expect(jsCode).toContain('for (const [j, p] of b.prices.array.entries())');
+        expect(jsCode).toContain('for (const [j, p] of $.entries(b.prices))');
+        // Outer loop too — destructuring over a function param identifier
+        expect(jsCode).toContain('for (const [i, b] of $.entries(');
+    });
+
+    it('should wrap non-destructuring iteration over a member expression with $.iter', () => {
+        // Regression: built-ins like box.all return plain JS arrays (not PineArrayObject).
+        // Previously the codegen emitted `<expr>.array` unconditionally for member-expr
+        // iterables, which broke `for element in box.all` because plain arrays have no
+        // `.array` field. The $.iter helper handles both shapes uniformly.
+        const code = `
+//@version=6
+indicator("ForOf MemberExpr Plain JS Array")
+
+if true
+    for element in box.all
+        element.delete()
+    for ln in line.all
+        ln.delete()
+
+plot(close)
+        `;
+
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        expect(jsCode).toBeDefined();
+        expect(jsCode).toContain('for (const element of $.iter(box.all))');
+        expect(jsCode).toContain('for (const ln of $.iter(line.all))');
+        // Must NOT regress to the broken `.array` form
+        expect(jsCode).not.toContain('box.all.array');
+        expect(jsCode).not.toContain('line.all.array');
+    });
+
+    it('should handle for-of destructuring over a built-in plain JS array', () => {
+        // Symmetric to the non-destructuring case: `for [i, el] in box.all` must work
+        // even though box.all is a plain JS array (not a PineArrayObject).
+        const code = `
+//@version=6
+indicator("ForOf MemberExpr Destructuring Plain JS")
+
+if true
+    for [i, el] in box.all
+        x = i
+
+plot(close)
+        `;
+
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        expect(jsCode).toBeDefined();
+        expect(jsCode).toContain('for (const [i, el] of $.entries(box.all))');
+        expect(jsCode).not.toContain('box.all.array');
     });
 
     it('should handle for-of loops with nested operations', () => {
@@ -1735,7 +1787,7 @@ plot(close)
         const jsCode = result.toString();
 
         expect(jsCode).toBeDefined();
-        expect(jsCode).toContain('for (const val of $.get(values, 0).array)');
+        expect(jsCode).toContain('for (const val of $.iter($.get(values, 0)))');
         // The temp variable inside the loop should be transformed
         expect(jsCode).toMatch(/\$\$\.let\.fn\d+_temp/);
     });
@@ -1762,8 +1814,8 @@ plot(close)
         const result = transpile(code);
         const jsCode = result.toString();
 
-        expect(jsCode).toContain('for (const x of $.get(arr1, 0).array)');
-        expect(jsCode).toContain('for (const y of $.get(arr2, 0).array)');
+        expect(jsCode).toContain('for (const x of $.iter($.get(arr1, 0)))');
+        expect(jsCode).toContain('for (const y of $.iter($.get(arr2, 0)))');
     });
 
     it('should handle for-of with array operations', () => {
@@ -1786,7 +1838,7 @@ plot(result)
         const jsCode = result.toString();
 
         expect(jsCode).toBeDefined();
-        expect(jsCode).toContain('for (const element of $.get(arr, 0).array)');
+        expect(jsCode).toContain('for (const element of $.iter($.get(arr, 0)))');
     });
 });
 

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1688,6 +1688,34 @@ plot(close)
         expect(jsCode).toContain('for (const [idx, x1] of $.get(X1, 0).array.entries())');
     });
 
+    it('should handle for-of destructuring over a member expression iterable', () => {
+        // Regression: iterating with [index, value] destructuring over a UDT field
+        // (e.g. eachDay.prices) must wrap the iterable as <expr>.array.entries()
+        // — not just <expr> — otherwise destructuring a scalar yielded by
+        // PineArrayObject's [Symbol.iterator] throws "is not iterable".
+        const code = `
+//@version=6
+indicator("For-Of Member Destructuring")
+
+type bucket
+    array<float> prices = na
+
+process(buckets) =>
+    for [i, b] in buckets
+        for [j, p] in b.prices
+            x = p
+
+plot(close)
+        `;
+
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        expect(jsCode).toBeDefined();
+        // Inner loop: member expression iterable must be suffixed with .array.entries()
+        expect(jsCode).toContain('for (const [j, p] of b.prices.array.entries())');
+    });
+
     it('should handle for-of loops with nested operations', () => {
         const code = `
 //@version=6

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -2151,9 +2151,11 @@ plot(close)
         const result = transpile(code);
         const jsCode = result.toString();
         expect(jsCode).toBeDefined();
-        // Declaration must be renamed
+        // Declaration must be renamed — accepts both the JS-reserved-keyword
+        // rename suffix (`_$N`) and the method-disambiguation prefix (`$M_`).
+        // The bare `function delete(` form must NEVER appear (would break parse).
         expect(jsCode).not.toMatch(/function\s+delete\s*\(/);
-        expect(jsCode).toMatch(/function\s+delete_\$\d+\s*\(/);
+        expect(jsCode).toMatch(/function\s+\$M_delete_\$\d+\s*\(/);
         // Method-style call site (property access) is still valid JS — keep as-is
         // (PineTS lowers `obj.delete()` to `obj?.delete?.()` via optional chaining)
         expect(jsCode).toMatch(/\.delete[?]?\.?\(/);

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1920,6 +1920,82 @@ plot(close)
     });
 });
 
+describe('Pine Script Transpilation - Contextual keywords as UDT field names', () => {
+    // Pine v5/v6 treats `type`, `method`, `enum` as contextual keywords:
+    // they're reserved only when they introduce a declaration. Elsewhere they're
+    // valid identifiers — most notably as UDT field names like `int type = 0`.
+
+    it('parses `type` as a UDT field name', () => {
+        // Regression: "Expected IDENTIFIER but got KEYWORD at <line:col>"
+        const code = `
+//@version=6
+indicator("UDT field named type", overlay=true)
+type MS
+    int type = 0
+
+m = MS.new(5)
+plot(m.type)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        // The field should be present in the type definition / object initialization
+        expect(jsCode).toMatch(/type\s*[:=]/);
+    });
+
+    it('parses `method` as a UDT field name', () => {
+        const code = `
+//@version=6
+indicator("UDT field named method", overlay=true)
+type Action
+    string method = "click"
+
+a = Action.new("hover")
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        expect(jsCode).toMatch(/method\s*[:=]/);
+    });
+
+    it('parses `enum` as a UDT field name', () => {
+        const code = `
+//@version=6
+indicator("UDT field named enum", overlay=true)
+type Item
+    int enum = 1
+
+i = Item.new(2)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        expect(jsCode).toMatch(/enum\s*[:=]/);
+    });
+
+    it('still rejects `type` at the START of a top-level declaration line', () => {
+        // Sanity check: the contextual-keyword relaxation must NOT break the
+        // primary syntactic role of `type` as a UDT-introducer keyword.
+        const code = `
+//@version=6
+indicator("type still works as keyword")
+type Foo
+    int x = 1
+
+f = Foo.new(5)
+plot(f.x)
+        `;
+        // Should parse cleanly, with the `type` keyword properly consumed
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        // The Foo type should still produce a constructor / type wiring
+        expect(jsCode).toContain('Foo');
+    });
+});
+
 describe('Pine Script Transpilation - Comma-separated typed declarations', () => {
     // Pine v6 allows multiple typed variable declarations on a single line
     // sharing the leading type qualifier:

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1842,6 +1842,84 @@ plot(result)
     });
 });
 
+describe('Pine Script Transpilation - Type-as-function (typed-na pattern)', () => {
+    // Pine v6 lets you write `<TypeName>(value)` to wrap/cast a value as that type.
+    // The most common use is `box(na)`, `line(na)` etc. inside UDT initializers
+    // where a typed-na is needed. The transpiler must rewrite this to
+    // `<TypeName>.any(...)` — calling the namespace directly fails because the
+    // namespace object isn't callable. Each namespace's `any()` method delegates
+    // to `new()`.
+
+    it('rewrites box(na) → box.any(...) so the namespace call resolves at runtime', () => {
+        // Regression: `box(na)` previously emitted as a literal `box(...)` call,
+        // which threw "box is not a function" because BoxHelper isn't callable.
+        const code = `
+//@version=6
+indicator("box(na) typed-na", overlay=true)
+b = box(na)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        expect(jsCode).toContain('box.any(');
+        // Must NOT regress to the broken raw-call form (no "box(p" — but allow box.new(, box.any(, etc.)
+        expect(jsCode).not.toMatch(/[^.\w]box\(p\d+/);
+    });
+
+    it('rewrites line(na) → line.any(...) (already-working case kept stable)', () => {
+        const code = `
+//@version=6
+indicator("line(na) typed-na", overlay=true)
+l = line(na)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('line.any(');
+        expect(jsCode).not.toMatch(/[^.\w]line\(p\d+/);
+    });
+
+    it('rewrites linefill(na) → linefill.any(...)', () => {
+        const code = `
+//@version=6
+indicator("linefill(na) typed-na", overlay=true)
+lf = linefill(na)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('linefill.any(');
+        expect(jsCode).not.toMatch(/[^.\w]linefill\(p\d+/);
+    });
+
+    it('rewrites polyline(na) → polyline.any(...)', () => {
+        const code = `
+//@version=6
+indicator("polyline(na) typed-na", overlay=true)
+p = polyline(na)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('polyline.any(');
+        expect(jsCode).not.toMatch(/[^.\w]polyline\(p\d+/);
+    });
+
+    it('rewrites table(na) → table.any(...)', () => {
+        const code = `
+//@version=6
+indicator("table(na) typed-na", overlay=true)
+t = table(na)
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('table.any(');
+        expect(jsCode).not.toMatch(/[^.\w]table\(p\d+/);
+    });
+});
+
 describe('Pine Script Transpilation - Real-World Example (MACD)', () => {
     it('should transpile complete MACD indicator', () => {
         const code = `

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -2151,14 +2151,16 @@ plot(close)
         const result = transpile(code);
         const jsCode = result.toString();
         expect(jsCode).toBeDefined();
-        // Declaration must be renamed — accepts both the JS-reserved-keyword
-        // rename suffix (`_$N`) and the method-disambiguation prefix (`$M_`).
-        // The bare `function delete(` form must NEVER appear (would break parse).
+        // Declaration must NOT be the bare reserved word (would break JS parse).
         expect(jsCode).not.toMatch(/function\s+delete\s*\(/);
-        expect(jsCode).toMatch(/function\s+\$M_delete_\$\d+\s*\(/);
-        // Method-style call site (property access) is still valid JS — keep as-is
-        // (PineTS lowers `obj.delete()` to `obj?.delete?.()` via optional chaining)
-        expect(jsCode).toMatch(/\.delete[?]?\.?\(/);
+        // Method declarations get a `$M_` JS prefix that is collision-proof
+        // by construction — no `_$N` reserved-name suffix is needed (and adding
+        // one would break Pine-name lookup at the call site, since the AnalysisPass
+        // strips only `$M_` to recover the Pine name `delete`).
+        expect(jsCode).toMatch(/function\s+\$M_delete\s*\(/);
+        // The Pine call site `f.delete()` retargets to `$.call($M_delete, ...)`
+        // when the receiver is a known UDT instance.
+        expect(jsCode).toMatch(/\$\.call\s*\(\s*\$M_delete\b/);
     });
 
     it('renames direct call to a user function named after a JS reserved word', () => {

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1920,6 +1920,137 @@ plot(close)
     });
 });
 
+describe('Pine Script Transpilation - Comma-separated typed declarations', () => {
+    // Pine v6 allows multiple typed variable declarations on a single line
+    // sharing the leading type qualifier:
+    //   float a = 0.0, b = 1.0, c = 2.0
+    // Each segment after the first comma is `name = expr` with the captured
+    // type re-applied. The parser previously only handled this for var/varip
+    // chains (`var int x = 1, var int y = 2`).
+
+    it('parses comma-separated float declarations sharing the type', () => {
+        // Regression: previously failed with "Unexpected token COMMA ',' at <line:col>"
+        const code = `
+//@version=6
+indicator("multi-float decl")
+my_func() =>
+    float sumW = 0.0, sumWX = 0.0, sumWY = 0.0
+    sumW + sumWX + sumWY
+plot(my_func())
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toBeDefined();
+        // All three identifiers must end up as separate scoped bindings
+        expect(jsCode).toContain('fn1_sumW');
+        expect(jsCode).toContain('fn1_sumWX');
+        expect(jsCode).toContain('fn1_sumWY');
+        // None must end up swallowed as a sub-expression of the previous initializer
+        expect(jsCode).not.toMatch(/sumW\s*=\s*\([^)]*sumWX/);
+    });
+
+    it('parses comma-separated int declarations sharing the type', () => {
+        const code = `
+//@version=6
+indicator("multi-int decl")
+my_func() =>
+    int aa = 1, bb = 2, cc = 3
+    aa + bb + cc
+plot(my_func())
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('fn1_aa');
+        expect(jsCode).toContain('fn1_bb');
+        expect(jsCode).toContain('fn1_cc');
+    });
+
+    it('parses comma-separated bool declarations sharing the type', () => {
+        const code = `
+//@version=6
+indicator("multi-bool decl")
+my_func() =>
+    bool xx = true, yy = false
+    xx or yy
+plot(my_func() ? 1 : 0)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('fn1_xx');
+        expect(jsCode).toContain('fn1_yy');
+        // Both literal values must be present somewhere in the initializers
+        expect(jsCode).toContain('true');
+        expect(jsCode).toContain('false');
+    });
+
+    it('parses comma-separated string declarations sharing the type', () => {
+        const code = `
+//@version=6
+indicator("multi-string decl")
+my_func() =>
+    string ss = "hello", tt = "world"
+    ss + tt
+plot(close)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('fn1_ss');
+        expect(jsCode).toContain('fn1_tt');
+        expect(jsCode).toMatch(/['"]hello['"]/);
+        expect(jsCode).toMatch(/['"]world['"]/);
+    });
+
+    it('parses comma-separated qualified-type declarations (series float)', () => {
+        const code = `
+//@version=6
+indicator("multi series-float decl")
+series float ema1 = 0.0, ema2 = 0.0
+plot(ema1 + ema2)
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // Both bindings emitted at global scope (glb1_*)
+        expect(jsCode).toContain('glb1_ema1');
+        expect(jsCode).toContain('glb1_ema2');
+    });
+
+    it('parses comma-separated generic-type declarations (array<float>)', () => {
+        const code = `
+//@version=6
+indicator("multi generic-type decl")
+my_func() =>
+    array<float> pp = na, qq = na
+    array.size(pp) + array.size(qq)
+plot(my_func())
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        expect(jsCode).toContain('fn1_pp');
+        expect(jsCode).toContain('fn1_qq');
+    });
+
+    it('does not consume commas belonging to outer constructs', () => {
+        // Sanity check: a single typed decl followed by a function call
+        // (whose args are comma-separated) must not pull those args into the decl.
+        const code = `
+//@version=6
+indicator("guard")
+my_func() =>
+    float a = 1.0
+    math.max(a, 2.0, 3.0)
+plot(my_func())
+        `;
+        const result = transpile(code);
+        const jsCode = result.toString();
+        // math.max called normally
+        expect(jsCode).toMatch(/math\.max\(/);
+        // The constants `2` and `3` from math.max args must not have been
+        // mis-treated as additional declarators (which would emit fn1_2 etc.)
+        expect(jsCode).not.toMatch(/fn1_2\b/);
+        expect(jsCode).not.toMatch(/fn1_3\b/);
+    });
+});
+
 describe('Pine Script Transpilation - User function names colliding with JS reserved keywords', () => {
     // Pine allows user-defined functions/methods named after JS reserved keywords
     // (e.g. `method delete(...)`). The codegen must rename these consistently at


### PR DESCRIPTION
## [0.9.14] - 2026-05-05 - UDT & Transpiler Hardening, `request.security`, Streaming & Drawing `na`

### Added

- **`str.format_time(time, format, timezone)`**: Full string-based time formatting aligned with Pine Script (`Str.ts`, tests in `str.test.ts`).
- **`for...of` runtime helpers**: Codegen uses **`$.iter`** / **`$.entries`** instead of brittle one-off special cases.
- **UDT registry pre-pass**: **`preProcessUdtRegistry`** runs before analysis so **`ScopeManager`** is populated consistently (5 dedicated tests).

### Fixed

- **Live streaming with `eDate`**: **`runLive`** / live mode now works when an end date is provided; previously the combination was incorrectly rejected or behaved as non-live (**`PineTS.class.ts`**).
- **`for...in` over `MemberExpression` iterables**: Destructuring in **`for...in`** when the iterable is a member expression (e.g. chained property access) is transformed correctly (**`MainTransformer`**).
- **`request.security`**: Named arguments resolve through **`parseArgsForPineParams`** with **array/tuple-aware** `remaining_options`; secondary-context **bar alignment** improved; **`calc_bars_count`** threaded through the security pipeline.
- **Callable drawing/table namespaces**: **`box`**, **`linefill`**, **`polyline`**, **`table`** — fixes for correct call vs instance dispatch in transpiled code.
- **Reserved words in generated JS**: Transpiler avoids invalid identifiers when Pine names collide with JavaScript reserved words.
- **Comma-separated typed declarations**: Multiple declarations on one line with shared type; guard tightened so **`chart.point[] a = ..., chart.point[] b = ...`** (dotted / repeated types) is split handled as separate statements instead of mis-parsing (**`parseTypedVarDeclaration`**).
- **Contextual Pine Script keywords**: Parser treats keywords contextually so valid identifiers / constructs are not broken by overly greedy keyword rules.
- **UDT field subscripts in call arguments**: Per-bar lookback (`seriesVar.field[1]`) inside function-call arguments is transformed correctly.
- **UDT field-subscript & method transpiler**: Broader fixes for member access and methods on UDT instances.
- **UDT `.new()` mixed positional + named args**: When the last argument is a plain object whose keys match UDT field names, it is stripped and applied as named fields instead of shifting positional slots (**`Core.ts` UDT constructor**).
- **UFCS `obj.method()`**: Method names that are JS reserved words keep correct **`$M_`** naming without double **`_$N`** renames; **`Holder r = arr.get(0)`** with an explicit UDT type registers **`r`** for instance dispatch; **`.delete()`** on built-in drawing objects is not retargeted as a user method.
- **Typed `na` for drawings**: **`box(na)`**, **`line(na)`**, **`label(na)`**, **`polyline(na)`**, **`linefill(na)`**, **`table(na)`** behave as Pine **typed `na`** / casts, not as calls that build empty drawing instances.
- **UDT registration across function parameters**: Exiting a function that took a UDT parameter no longer clears outer-scope UDT-instance bindings — prior registrations are **snapshotted and restored** so patterns like **`var T x = T.new(...)`** plus **`foo(T x)`** still resolve **`x.foo()`** later.
- **Plots & deleted drawings**: Deleted drawing objects are **omitted** from generated plot payloads so consumers do not see stale handles.
- **Default colors**: Restored sensible default stroke/fill styling for **`box`** and **`polyline`** when colors are omitted.
- **Documentation**: Various doc updates (merged with this release train).