### PR TITLE
## [0.9.15] - 2026-05-08 - Titled Enums, Call-Path Isolation & `request.security_lower_tf` Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## [0.9.15] - 2026-05-08 - Titled Enums, Call-Path Isolation & `request.security_lower_tf` Optimizations
+
+### Added
+
+- **Titled enums**: Support for enum declarations with explicit titles aligned with Pine Script (**transpiler / runtime**).
+
+### Fixed
+
+- **`transformFunctionArgument` + array expressions**: **`ArrayExpression`** arguments now recurse into non-**`Identifier`** elements (**`CallExpression`**, **`BinaryExpression`**, etc.) so nested identifiers (e.g. **`maLenInput`** inside **`request.security_lower_tf(..., [volume, ta.sma(volume, maLenInput)])`**) get proper scope rewrites instead of leaking bare names and throwing **`ReferenceError`** at runtime.
+- **Transpiler “not defined” regressions**: Broader fixes for identifier / scope edge cases that surfaced as runtime **`ReferenceError`**s.
+- **Per-call-path state for user functions**: **`Context.peekId()`** maintains a **cumulative path stack** so **`var`** / **`let`** slots and **`ta.*`** accumulators do not leak across different call paths through a shared parametrized wrapper.
+- **`$.param(..., 'pN')` in nested calls**: Parameter slot ids inside function bodies are **path-prefixed with `$$.id`** so distinct call paths no longer share **`context.params[pN]`** (fixes wrong or missing internal lines in complex multi-path indicators).
+
+### Changed
+
+- **`request.security_lower_tf`**: Fetches a **bounded** number of lower-timeframe bars instead of over-fetching (**optimization**).
+- **Secondary contexts**: **Drawing** helpers are **skipped** when running **`request.security`** / LTF evaluation so work and payload generation stay on the chart context.
+- **`security_lower_tf` fast path**: When the expression only needs **market data** from the lower timeframe, execution takes a **lighter path** without full expression evaluation overhead.
+
+---
+
 ## [0.9.14] - 2026-05-05 - UDT & Transpiler Hardening, `request.security`, Streaming & Drawing `na`
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.14",
+    "version": "0.9.15",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -770,13 +770,27 @@ export class Context {
     //#region [Call Stack Management] ===========================
 
     private _callStack: string[] = [];
+    /**
+     * Cumulative call-path stack. Each entry is the full path from the root to
+     * the current call, formed by joining the syntactic call-site ids with '|'.
+     *
+     * Pine semantics is per-call-PATH (not per-syntactic-call-site): a function
+     * with internal `var` state, called via two distinct paths through a wrapper,
+     * must keep state independent per path. Keying lctx by the path (rather than
+     * the immediate site id) makes `$$.var.*` slots and `$$.id + '_taN'` ta
+     * callsite ids correctly path-scoped without any transpiler changes.
+     */
+    private _pathStack: string[] = [];
 
     /**
      * Pushes a call ID onto the stack
      * @param id - The call ID
      */
     public pushId(id: string) {
+        const parent = this._pathStack.length > 0 ? this._pathStack[this._pathStack.length - 1] : '';
+        const path = parent ? parent + '|' + id : id;
         this._callStack.push(id);
+        this._pathStack.push(path);
     }
 
     /**
@@ -784,13 +798,15 @@ export class Context {
      */
     public popId() {
         this._callStack.pop();
+        this._pathStack.pop();
     }
 
     /**
-     * Returns the current call ID from the top of the stack
+     * Returns the current call PATH (cumulative ids joined by '|') from the top
+     * of the stack. Used as the lctx key for the current function call.
      */
     public peekId() {
-        return this._callStack.length > 0 ? this._callStack[this._callStack.length - 1] : '';
+        return this._pathStack.length > 0 ? this._pathStack[this._pathStack.length - 1] : '';
     }
 
     /**

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -212,7 +212,18 @@ export class Context {
                 return _this.data.close.length - 1;
             },
             get last_bar_time() {
-                return _this.data.openTime.get(_this.data.openTime.length - 1);
+                // TV semantics: `last_bar_time` is the open time of the LAST
+                // bar of the chart's history — a CONSTANT across the whole
+                // script execution, even when iterating over historical bars.
+                // PineTS has the full preloaded series on `marketData`, so we
+                // read the absolute last bar's openTime there. Falling back
+                // to the progressively-fed `data.openTime` (current bar's
+                // time) is best-effort if marketData isn't available.
+                const md = _this.marketData;
+                if (Array.isArray(md) && md.length > 0) {
+                    return md[md.length - 1].openTime;
+                }
+                return _this.data.openTime.get(0);
             },
             get timenow() {
                 return new Date().getTime();

--- a/src/namespaces/Core.ts
+++ b/src/namespaces/Core.ts
@@ -506,7 +506,7 @@ export class Core {
             }
         }
 
-        const UDT = {
+        const UDT: any = {
             new: function (...args: any[]) {
                 // Map positional args to field names, applying defaults for missing args
                 const mappedArgs: Record<string, any> = {};
@@ -549,12 +549,22 @@ export class Core {
                     }
                     // else: field remains absent (na/undefined)
                 }
-                return new PineTypeObject(mappedArgs, this.context);
+                return new PineTypeObject(mappedArgs, this.context, UDT);
             },
 
             copy: function (object: PineTypeObject) {
-                return new PineTypeObject(object.__def__, this.context);
+                return new PineTypeObject(object.__def__, this.context, UDT);
             },
+
+            // Factory metadata exposed for the request.security_lower_tf
+            // pure-builtin fast path. `_fieldDefaults` holds the ORIGINAL
+            // default-initializer expressions (e.g. the `open` Series for
+            // `float o = open`) — Series identities preserved so the
+            // detector can compare against `context.data.<builtin>`.
+            // `_definitionKeys` is the field order matching positional
+            // construction.
+            _fieldDefaults: fieldDefaults,
+            _definitionKeys: definitionKeys,
         };
         return UDT;
     }

--- a/src/namespaces/Core.ts
+++ b/src/namespaces/Core.ts
@@ -4,6 +4,7 @@ import { Series } from '../Series';
 import { PineTypeObject } from './PineTypeObject';
 import { parseArgsForPineParams } from './utils';
 import type { IndicatorOptions, PlotCharOptions } from '../types/PineTypes';
+import { silentInSecondary } from './silentInSecondary';
 
 //prettier-ignore
 const TIMESTAMP_SIGNATURES = [
@@ -138,6 +139,7 @@ export class AlertHelper {
         return Series.from(source).get(0);
     }
 
+    @silentInSecondary
     any(message: any, freq?: any, opts?: any): void {
         const msg = Series.from(message).get(0);
         const f = freq ? Series.from(freq).get(0) : ALERT_FREQ.freq_once_per_bar;
@@ -260,6 +262,7 @@ export class Core {
     /** Per-callsite, per-bar dedup for alertcondition (prevents duplicate fires on live re-execution). */
     private _acFiredKeys: Set<string> = new Set();
 
+    @silentInSecondary
     alertcondition(condition: any, title?: any, message?: any) {
         const cond = Series.from(condition).get(0);
 

--- a/src/namespaces/PineTypeObject.ts
+++ b/src/namespaces/PineTypeObject.ts
@@ -3,14 +3,28 @@ export class PineTypeObject {
         return this._definition;
     }
 
-    constructor(private _definition: Record<string, string>, public context: any) {
+    /**
+     * Back-reference to the UDT factory that produced this instance.
+     * Used by `request.security_lower_tf`'s pure-builtin fast path to
+     * detect UDTs whose field defaults are all bare price builtins
+     * (e.g. `type candle { float o = open; float h = high; … }`) — when
+     * detected, the secondary's per-LTF-bar values can be synthesised
+     * directly from the candle stream without running any user script.
+     * Optional and nullable: instances created outside `Type().new` (or
+     * for legacy / direct constructions) leave this undefined and the
+     * fast path simply doesn't engage.
+     */
+    public _udt?: any;
+
+    constructor(private _definition: Record<string, string>, public context: any, _udt?: any) {
         for (let key in _definition) {
             this[key] = _definition[key];
         }
+        this._udt = _udt;
     }
 
     copy() {
-        return new PineTypeObject(this.__def__, this.context);
+        return new PineTypeObject(this.__def__, this.context, this._udt);
     }
 
     toString() {

--- a/src/namespaces/Plots.ts
+++ b/src/namespaces/Plots.ts
@@ -1,6 +1,7 @@
 import type { BackgroundColorOptions, BarColorOptions, FillOptions, PlotArrowOptions, PlotBarOptions, PlotCandleOptions, PlotOptions, PlotCharOptions, PlotShapeOptions, HlineOptions } from '../types/PineTypes';
 import { Series } from '../Series';
 import { parseArgsForPineParams, extractCallsiteId } from './utils';
+import { silentInSecondary } from './silentInSecondary';
 
 //prettier-ignore
 const PLOT_SIGNATURE = [
@@ -205,6 +206,7 @@ export class PlotHelper {
     }
 
     //in the current implementation, plot functions are only used to collect data for the plots array and map it to the market data
+    @silentInSecondary
     plotchar(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<PlotCharOptions>(args, PLOTCHAR_SIGNATURE, PLOTCHAR_ARGS_TYPES);
@@ -236,6 +238,7 @@ export class PlotHelper {
 
     //this will map to plot() - see README.md for more details
 
+    @silentInSecondary
     any(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<PlotOptions>(args, PLOT_SIGNATURE, PLOT_ARGS_TYPES);
@@ -275,6 +278,7 @@ export class PlotHelper {
         });
         return this.context.plots[plotKey];
     }
+    @silentInSecondary
     plotshape(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<PlotShapeOptions>(args, PLOT_SHAPE_SIGNATURE, PLOT_SHAPE_ARGS_TYPES);
@@ -313,6 +317,7 @@ export class PlotHelper {
         return this.context.plots[plotKey];
     }
 
+    @silentInSecondary
     plotarrow(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<PlotArrowOptions>(args, PLOT_ARROW_SIGNATURE, PLOT_ARROW_ARGS_TYPES);
@@ -346,6 +351,7 @@ export class PlotHelper {
         return this.context.plots[plotKey];
     }
 
+    @silentInSecondary
     plotbar(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<PlotBarOptions>(args, PLOTBAR_SIGNATURE, PLOTBAR_ARGS_TYPES);
@@ -368,6 +374,7 @@ export class PlotHelper {
         });
     }
 
+    @silentInSecondary
     plotcandle(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<PlotCandleOptions>(args, PLOTCANDLE_SIGNATURE, PLOTCANDLE_ARGS_TYPES);
@@ -391,6 +398,7 @@ export class PlotHelper {
         return this.context.plots[plotKey];
     }
 
+    @silentInSecondary
     bgcolor(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<BackgroundColorOptions>(args, BGCOLOR_SIGNATURE, BGCOLOR_ARGS_TYPES);
@@ -410,6 +418,7 @@ export class PlotHelper {
             options: { color: options.color },
         });
     }
+    @silentInSecondary
     barcolor(...args) {
         const callsiteId = extractCallsiteId(args);
         const _parsed = parseArgsForPineParams<BarColorOptions>(args, BGCOLOR_SIGNATURE, BGCOLOR_ARGS_TYPES);
@@ -449,6 +458,7 @@ export class HlineHelper {
     }
 
     //this will map to hline()
+    @silentInSecondary
     any(...args) {
         // Extract transpiler-injected callsite ID and forward to plot.any
         const callsiteId = extractCallsiteId(args);
@@ -467,6 +477,7 @@ export class FillHelper {
     param(source: any, index: number = 0, name?: string) {
         return Series.from(source).get(index);
     }
+    @silentInSecondary
     any(...args) {
         const callsiteId = extractCallsiteId(args);
 

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -5,6 +5,7 @@ import { parseArgsForPineParams } from '../utils';
 import { BoxObject } from './BoxObject';
 import { ChartPointObject } from '../chart/ChartPointObject';
 import { NAHelper } from '../Core';
+import { silentInSecondary } from '../silentInSecondary';
 
 //prettier-ignore
 const BOX_NEW_SIGNATURES = [
@@ -167,6 +168,7 @@ export class BoxHelper {
     }
 
     // box.new() — supports both chart.point and legacy signatures
+    @silentInSecondary
     new(...args: any[]): BoxObject {
         const parsed = parseArgsForPineParams<any>(args, BOX_NEW_SIGNATURES, BOX_NEW_ARGS_TYPES);
 
@@ -234,22 +236,27 @@ export class BoxHelper {
 
     // --- Coordinate setters ---
 
+    @silentInSecondary
     set_left(id: BoxObject, left: number): void {
         if (id && !id._deleted) id.left = this._resolve(left);
     }
 
+    @silentInSecondary
     set_right(id: BoxObject, right: number): void {
         if (id && !id._deleted) id.right = this._resolve(right);
     }
 
+    @silentInSecondary
     set_top(id: BoxObject, top: number): void {
         if (id && !id._deleted) id.top = this._resolve(top);
     }
 
+    @silentInSecondary
     set_bottom(id: BoxObject, bottom: number): void {
         if (id && !id._deleted) id.bottom = this._resolve(bottom);
     }
 
+    @silentInSecondary
     set_lefttop(id: BoxObject, left: number, top: number): void {
         if (id && !id._deleted) {
             id.left = this._resolve(left);
@@ -257,6 +264,7 @@ export class BoxHelper {
         }
     }
 
+    @silentInSecondary
     set_rightbottom(id: BoxObject, right: number, bottom: number): void {
         if (id && !id._deleted) {
             id.right = this._resolve(right);
@@ -264,6 +272,7 @@ export class BoxHelper {
         }
     }
 
+    @silentInSecondary
     set_top_left_point(id: BoxObject, point: ChartPointObject): void {
         if (id && !id._deleted && point) {
             const r = this._resolvePoint(point);
@@ -273,6 +282,7 @@ export class BoxHelper {
         }
     }
 
+    @silentInSecondary
     set_bottom_right_point(id: BoxObject, point: ChartPointObject): void {
         if (id && !id._deleted && point) {
             const r = this._resolvePoint(point);
@@ -282,6 +292,7 @@ export class BoxHelper {
         }
     }
 
+    @silentInSecondary
     set_xloc(id: BoxObject, left: number, right: number, xloc: string): void {
         if (id && !id._deleted) {
             id.left = this._resolve(left);
@@ -292,56 +303,69 @@ export class BoxHelper {
 
     // --- Style setters ---
 
+    @silentInSecondary
     set_bgcolor(id: BoxObject, color: string): void {
         if (id && !id._deleted) id.bgcolor = this._resolve(color);
     }
 
+    @silentInSecondary
     set_border_color(id: BoxObject, color: string): void {
         if (id && !id._deleted) id.border_color = this._resolve(color);
     }
 
+    @silentInSecondary
     set_border_width(id: BoxObject, width: number): void {
         if (id && !id._deleted) id.border_width = this._resolve(width) ?? 1;
     }
 
+    @silentInSecondary
     set_border_style(id: BoxObject, style: string): void {
         if (id && !id._deleted) id.border_style = this._resolve(style);
     }
 
+    @silentInSecondary
     set_extend(id: BoxObject, extend: string): void {
         if (id && !id._deleted) id.extend = this._resolve(extend);
     }
 
     // --- Text setters ---
 
+    @silentInSecondary
     set_text(id: BoxObject, text: string): void {
         if (id && !id._deleted) id.text = this._resolve(text) || '';
     }
 
+    @silentInSecondary
     set_text_color(id: BoxObject, color: string): void {
         if (id && !id._deleted) id.text_color = this._resolve(color);
     }
 
+    @silentInSecondary
     set_text_size(id: BoxObject, size: string): void {
         if (id && !id._deleted) id.text_size = this._resolve(size);
     }
 
+    @silentInSecondary
     set_text_halign(id: BoxObject, align: string): void {
         if (id && !id._deleted) id.text_halign = this._resolve(align);
     }
 
+    @silentInSecondary
     set_text_valign(id: BoxObject, align: string): void {
         if (id && !id._deleted) id.text_valign = this._resolve(align);
     }
 
+    @silentInSecondary
     set_text_wrap(id: BoxObject, wrap: string): void {
         if (id && !id._deleted) id.text_wrap = this._resolve(wrap);
     }
 
+    @silentInSecondary
     set_text_font_family(id: BoxObject, family: string): void {
         if (id && !id._deleted) id.text_font_family = this._resolve(family);
     }
 
+    @silentInSecondary
     set_text_formatting(id: BoxObject, formatting: string): void {
         if (id && !id._deleted) id.text_formatting = this._resolve(formatting);
     }
@@ -366,6 +390,7 @@ export class BoxHelper {
 
     // --- Management ---
 
+    @silentInSecondary
     copy(id: BoxObject): BoxObject | undefined {
         if (!id) return undefined;
         const b = id.copy();
@@ -377,6 +402,7 @@ export class BoxHelper {
         return b;
     }
 
+    @silentInSecondary
     delete(id: BoxObject): void {
         if (id) id._deleted = true;
     }

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -69,11 +69,17 @@ export class BoxHelper {
     }
 
     private _resolvePoint(point: ChartPointObject): { x: number; xloc: string } {
-        if (point.index !== undefined) {
-            return { x: point.index, xloc: 'bi' };
-        } else if (point.time !== undefined) {
-            return { x: point.time, xloc: 'bt' };
-        }
+        // Treat NaN as "not provided" so `chart.point.new(time, na, price)`
+        // (idiomatic in TV-published indicators — e.g. SMC's drawStructure)
+        // correctly resolves to a time-based point. Without the NaN check,
+        // `point.index !== undefined` is true for NaN and the helper
+        // returns x = NaN, leaving every line/box with x1=NaN/x2=NaN.
+        const hasIndex = point.index !== undefined &&
+            !(typeof point.index === 'number' && isNaN(point.index));
+        const hasTime = point.time !== undefined &&
+            !(typeof point.time === 'number' && isNaN(point.time));
+        if (hasIndex) return { x: point.index!, xloc: 'bi' };
+        if (hasTime) return { x: point.time!, xloc: 'bt' };
         return { x: 0, xloc: 'bi' };
     }
 

--- a/src/namespaces/label/LabelHelper.ts
+++ b/src/namespaces/label/LabelHelper.ts
@@ -5,6 +5,7 @@ import { parseArgsForPineParams } from '../utils';
 import { LabelObject } from './LabelObject';
 import { ChartPointObject } from '../chart/ChartPointObject';
 import { NAHelper } from '../Core';
+import { silentInSecondary } from '../silentInSecondary';
 
 //prettier-ignore
 const LABEL_NEW_SIGNATURES = [
@@ -151,6 +152,7 @@ export class LabelHelper {
     // Supports two signatures:
     //   label.new(x, y, text, xloc, yloc, color, style, textcolor, size, textalign, tooltip, text_font_family, force_overlay)
     //   label.new(point, text, xloc, yloc, color, style, textcolor, size, textalign, tooltip, text_font_family, force_overlay)
+    @silentInSecondary
     new(...args: any[]): LabelObject {
         const parsed = parseArgsForPineParams<any>(args, LABEL_NEW_SIGNATURES, LABEL_NEW_ARGS_TYPES);
 
@@ -209,14 +211,17 @@ export class LabelHelper {
 
     // --- Setter methods ---
 
+    @silentInSecondary
     set_x(id: LabelObject, x: number): void {
         if (id && !id._deleted) id.x = x;
     }
 
+    @silentInSecondary
     set_y(id: LabelObject, y: number): void {
         if (id && !id._deleted) id.y = y;
     }
 
+    @silentInSecondary
     set_xy(id: LabelObject, x: number, y: number): void {
         if (id && !id._deleted) {
             id.x = x;
@@ -224,42 +229,52 @@ export class LabelHelper {
         }
     }
 
+    @silentInSecondary
     set_text(id: LabelObject, text: string): void {
         if (id && !id._deleted) id.text = text;
     }
 
+    @silentInSecondary
     set_color(id: LabelObject, color: string): void {
         if (id && !id._deleted) id.color = color;
     }
 
+    @silentInSecondary
     set_textcolor(id: LabelObject, textcolor: string): void {
         if (id && !id._deleted) id.textcolor = textcolor;
     }
 
+    @silentInSecondary
     set_size(id: LabelObject, size: string): void {
         if (id && !id._deleted) id.size = size;
     }
 
+    @silentInSecondary
     set_style(id: LabelObject, style: string): void {
         if (id && !id._deleted) id.style = style;
     }
 
+    @silentInSecondary
     set_textalign(id: LabelObject, textalign: string): void {
         if (id && !id._deleted) id.textalign = textalign;
     }
 
+    @silentInSecondary
     set_tooltip(id: LabelObject, tooltip: string): void {
         if (id && !id._deleted) id.tooltip = tooltip;
     }
 
+    @silentInSecondary
     set_xloc(id: LabelObject, xloc: string): void {
         if (id && !id._deleted) id.xloc = xloc;
     }
 
+    @silentInSecondary
     set_yloc(id: LabelObject, yloc: string): void {
         if (id && !id._deleted) id.yloc = yloc;
     }
 
+    @silentInSecondary
     set_point(id: LabelObject, point: ChartPointObject): void {
         if (id && !id._deleted && point) {
             // Treat NaN as "not provided" so `chart.point.new(time, na, price)`
@@ -299,6 +314,7 @@ export class LabelHelper {
 
     // --- Management methods ---
 
+    @silentInSecondary
     copy(id: LabelObject): LabelObject | undefined {
         if (!id) return undefined;
         const lbl = id.copy();
@@ -310,6 +326,7 @@ export class LabelHelper {
         return lbl;
     }
 
+    @silentInSecondary
     delete(id: LabelObject): void {
         if (id) id._deleted = true;
     }

--- a/src/namespaces/label/LabelHelper.ts
+++ b/src/namespaces/label/LabelHelper.ts
@@ -160,11 +160,16 @@ export class LabelHelper {
 
         if (parsed.point instanceof ChartPointObject) {
             const pt = parsed.point as ChartPointObject;
-            if (pt.index !== undefined) {
-                x = pt.index;
+            // Treat NaN as "not provided" — see set_point() comment for context.
+            const hasIndex = pt.index !== undefined &&
+                !(typeof pt.index === 'number' && isNaN(pt.index));
+            const hasTime = pt.time !== undefined &&
+                !(typeof pt.time === 'number' && isNaN(pt.time));
+            if (hasIndex) {
+                x = pt.index!;
                 xloc = xloc || 'bi';
-            } else if (pt.time !== undefined) {
-                x = pt.time;
+            } else if (hasTime) {
+                x = pt.time!;
                 xloc = xloc || 'bt';
             } else {
                 x = 0;
@@ -257,11 +262,21 @@ export class LabelHelper {
 
     set_point(id: LabelObject, point: ChartPointObject): void {
         if (id && !id._deleted && point) {
-            if (point.index !== undefined) {
-                id.x = point.index;
+            // Treat NaN as "not provided" so `chart.point.new(time, na, price)`
+            // and `chart.point.new(na, bar_index, price)` (idiomatic in TV-
+            // published indicators, e.g. SMC's drawHighLowSwings) correctly
+            // resolve to whichever coord is actually set. Without the NaN
+            // check, `point.index !== undefined` is true for NaN and the
+            // label silently lands at x=NaN, hiding it from the chart.
+            const hasIndex = point.index !== undefined &&
+                !(typeof point.index === 'number' && isNaN(point.index));
+            const hasTime = point.time !== undefined &&
+                !(typeof point.time === 'number' && isNaN(point.time));
+            if (hasIndex) {
+                id.x = point.index!;
                 id.xloc = 'bi';
-            } else if (point.time !== undefined) {
-                id.x = point.time;
+            } else if (hasTime) {
+                id.x = point.time!;
                 id.xloc = 'bt';
             }
             id.y = point.price;

--- a/src/namespaces/line/LineHelper.ts
+++ b/src/namespaces/line/LineHelper.ts
@@ -5,6 +5,7 @@ import { parseArgsForPineParams } from '../utils';
 import { LineObject } from './LineObject';
 import { ChartPointObject } from '../chart/ChartPointObject';
 import { NAHelper } from '../Core';
+import { silentInSecondary } from '../silentInSecondary';
 
 //prettier-ignore
 const LINE_NEW_SIGNATURES = [
@@ -150,6 +151,7 @@ export class LineHelper {
     // Supports two signatures:
     //   line.new(x1, y1, x2, y2, xloc, extend, color, style, width, force_overlay)
     //   line.new(first_point, second_point, xloc, extend, color, style, width, force_overlay)
+    @silentInSecondary
     new(...args: any[]): LineObject {
         const parsed = parseArgsForPineParams<any>(args, LINE_NEW_SIGNATURES, LINE_NEW_ARGS_TYPES);
 
@@ -209,22 +211,27 @@ export class LineHelper {
 
     // --- Setter methods ---
 
+    @silentInSecondary
     set_x1(id: LineObject, x: number): void {
         if (id && !id._deleted) id.x1 = this._resolve(x);
     }
 
+    @silentInSecondary
     set_y1(id: LineObject, y: number): void {
         if (id && !id._deleted) id.y1 = this._resolve(y);
     }
 
+    @silentInSecondary
     set_x2(id: LineObject, x: number): void {
         if (id && !id._deleted) id.x2 = this._resolve(x);
     }
 
+    @silentInSecondary
     set_y2(id: LineObject, y: number): void {
         if (id && !id._deleted) id.y2 = this._resolve(y);
     }
 
+    @silentInSecondary
     set_xy1(id: LineObject, x: number, y: number): void {
         if (id && !id._deleted) {
             id.x1 = this._resolve(x);
@@ -232,6 +239,7 @@ export class LineHelper {
         }
     }
 
+    @silentInSecondary
     set_xy2(id: LineObject, x: number, y: number): void {
         if (id && !id._deleted) {
             id.x2 = this._resolve(x);
@@ -239,22 +247,27 @@ export class LineHelper {
         }
     }
 
+    @silentInSecondary
     set_color(id: LineObject, color: string): void {
         if (id && !id._deleted) id.color = this._resolve(color);
     }
 
+    @silentInSecondary
     set_width(id: LineObject, width: number): void {
         if (id && !id._deleted) id.width = this._resolve(width) || 1;
     }
 
+    @silentInSecondary
     set_style(id: LineObject, style: string): void {
         if (id && !id._deleted) id.style = this._resolve(style);
     }
 
+    @silentInSecondary
     set_extend(id: LineObject, extend: string): void {
         if (id && !id._deleted) id.extend = this._resolve(extend);
     }
 
+    @silentInSecondary
     set_xloc(id: LineObject, x1: number, x2: number, xloc: string): void {
         if (id && !id._deleted) {
             id.x1 = x1;
@@ -263,6 +276,7 @@ export class LineHelper {
         }
     }
 
+    @silentInSecondary
     set_first_point(id: LineObject, point: ChartPointObject): void {
         if (id && !id._deleted && point) {
             const r = this._resolvePoint(point);
@@ -272,6 +286,7 @@ export class LineHelper {
         }
     }
 
+    @silentInSecondary
     set_second_point(id: LineObject, point: ChartPointObject): void {
         if (id && !id._deleted && point) {
             const r = this._resolvePoint(point);
@@ -311,6 +326,7 @@ export class LineHelper {
 
     // --- Management methods ---
 
+    @silentInSecondary
     copy(id: LineObject): LineObject | undefined {
         if (!id) return undefined;
         const ln = id.copy();
@@ -322,6 +338,7 @@ export class LineHelper {
         return ln;
     }
 
+    @silentInSecondary
     delete(id: LineObject): void {
         if (id) id._deleted = true;
     }

--- a/src/namespaces/line/LineHelper.ts
+++ b/src/namespaces/line/LineHelper.ts
@@ -66,11 +66,17 @@ export class LineHelper {
     }
 
     private _resolvePoint(point: ChartPointObject): { x: number; xloc: string } {
-        if (point.index !== undefined) {
-            return { x: point.index, xloc: 'bi' };
-        } else if (point.time !== undefined) {
-            return { x: point.time, xloc: 'bt' };
-        }
+        // Treat NaN as "not provided" so `chart.point.new(time, na, price)`
+        // (idiomatic in TV-published indicators — e.g. SMC's drawStructure)
+        // correctly resolves to a time-based point. Without the NaN check,
+        // `point.index !== undefined` is true for NaN and the helper
+        // returns x = NaN, leaving every line/box with x1=NaN/x2=NaN.
+        const hasIndex = point.index !== undefined &&
+            !(typeof point.index === 'number' && isNaN(point.index));
+        const hasTime = point.time !== undefined &&
+            !(typeof point.time === 'number' && isNaN(point.time));
+        if (hasIndex) return { x: point.index!, xloc: 'bi' };
+        if (hasTime) return { x: point.time!, xloc: 'bt' };
         return { x: 0, xloc: 'bi' };
     }
 

--- a/src/namespaces/linefill/LinefillHelper.ts
+++ b/src/namespaces/linefill/LinefillHelper.ts
@@ -4,6 +4,7 @@ import { Series } from '../../Series';
 import { LineObject } from '../line/LineObject';
 import { LinefillObject } from './LinefillObject';
 import { NAHelper } from '../Core';
+import { silentInSecondary } from '../silentInSecondary';
 
 export class LinefillHelper {
     private _linefills: LinefillObject[] = [];
@@ -74,6 +75,7 @@ export class LinefillHelper {
     // lines (in either order), the existing one is replaced rather than creating
     // a duplicate. This prevents accumulation when linefill.new() is called
     // every bar without explicitly deleting the old fill.
+    @silentInSecondary
     new(line1: LineObject, line2: LineObject, color: any): LinefillObject {
         // Resolve thunks: in `var` UDT declarations, line.new() calls are hoisted
         // as thunks (functions). Resolve them here so LinefillObject stores actual
@@ -125,6 +127,7 @@ export class LinefillHelper {
     }
 
     // linefill.set_color(id, color) → void
+    @silentInSecondary
     set_color(id: LinefillObject, color: any): void {
         if (id && !id._deleted) {
             id.color = this._resolve(color) || '';
@@ -142,6 +145,7 @@ export class LinefillHelper {
     }
 
     // linefill.delete(id) → void
+    @silentInSecondary
     delete(id: LinefillObject): void {
         if (id) id._deleted = true;
     }

--- a/src/namespaces/polyline/PolylineHelper.ts
+++ b/src/namespaces/polyline/PolylineHelper.ts
@@ -4,6 +4,7 @@ import { Series } from '../../Series';
 import { PolylineObject } from './PolylineObject';
 import { ChartPointObject } from '../chart/ChartPointObject';
 import { NAHelper } from '../Core';
+import { silentInSecondary } from '../silentInSecondary';
 
 export class PolylineHelper {
     private _polylines: PolylineObject[] = [];
@@ -82,6 +83,7 @@ export class PolylineHelper {
     //   1. A single options object: polyline.new({points: pts, curved: true, ...})
     //   2. Points + options object: polyline.new(pts, {curved: true, ...})
     //   3. Positional arguments: polyline.new(pts, true, false, ...)
+    @silentInSecondary
     new(...args: any[]): PolylineObject {
         let points: any;
         let curved: any = false;
@@ -195,6 +197,7 @@ export class PolylineHelper {
     }
 
     // polyline.delete(id) → void
+    @silentInSecondary
     delete(id: PolylineObject): void {
         if (id) id._deleted = true;
     }

--- a/src/namespaces/request/methods/param.ts
+++ b/src/namespaces/request/methods/param.ts
@@ -41,6 +41,16 @@ export function param(context: any) {
             context.params[name][context.params[name].length - 1] = val;
         }
 
+        // Preserve the ORIGINAL source (with Series identity intact, before
+        // value extraction) so request.security_lower_tf can detect pure-
+        // builtin expressions (`close`, `[open, high, low, close, volume]`,
+        // …) and bypass running the user script in the secondary context.
+        // Stored by param-name on a side channel — the existing 2-tuple
+        // [val, name] return shape is preserved, so no other consumers of
+        // request.param care.
+        if (!context._requestParamSources) context._requestParamSources = {};
+        context._requestParamSources[name] = source;
+
         return [val, name];
     };
 }

--- a/src/namespaces/request/methods/security.ts
+++ b/src/namespaces/request/methods/security.ts
@@ -168,10 +168,20 @@ export function security(context: any) {
             throw new Error('Invalid timeframe');
         }
 
-        if (ctxTimeframeIdx === reqTimeframeIdx) {
-            // Same-timeframe shortcut: resolve any helper objects (TimeComponentHelper,
-            // NAHelper, Series, etc.) in the expression that haven't been extracted
-            // to their primitive values yet.
+        // Same-timeframe shortcut is only valid when the requested symbol is the
+        // chart's symbol — at that point the secondary would just re-evaluate the
+        // same data. If the symbol differs, the shortcut would return the chart's
+        // expression verbatim (e.g. BTC close) for a request meant to fetch a
+        // different ticker (e.g. ETH close). Fall through to the secondary-context
+        // path (line ~280+) which builds a fresh PineTS instance for `_symbol`.
+        const ctxRawSymbol = typeof context.tickerId === 'string' && context.tickerId.includes(':')
+            ? context.tickerId.split(':')[1]
+            : context.tickerId;
+        const isSameSymbol = !_symbol || _symbol === '' || _symbol === ctxRawSymbol;
+
+        if (ctxTimeframeIdx === reqTimeframeIdx && isSameSymbol) {
+            // Resolve any helper objects (TimeComponentHelper, NAHelper, Series, etc.)
+            // in the expression that haven't been extracted to their primitive values yet.
             const resolved = resolveExprValue(_expression);
             return Array.isArray(resolved) ? [resolved] : resolved;
         }

--- a/src/namespaces/request/methods/security_lower_tf.ts
+++ b/src/namespaces/request/methods/security_lower_tf.ts
@@ -4,6 +4,7 @@ import { PineTS } from '../../../PineTS.class';
 import { Series } from '../../../Series';
 import { TIMEFRAMES, normalizeTimeframe } from '../utils/TIMEFRAMES';
 import { PineArrayObject, PineArrayType } from '../../array/PineArrayObject';
+import { PineTypeObject } from '../../PineTypeObject';
 import { parseArgsForPineParams } from '../../utils';
 
 // Pine signature (v5/v6):
@@ -68,6 +69,201 @@ function detectArrayType(value: any): PineArrayType {
     if (typeof value === 'boolean') return PineArrayType.bool;
     if (typeof value === 'string') return PineArrayType.string;
     return PineArrayType.any;
+}
+
+/**
+ * Names of price/time builtins on `context.data` that the LTF fast path
+ * can resolve directly from the secondary's market-data candles, without
+ * having to run a single line of the user script in the secondary
+ * context. Maps the Pine builtin name to the candle field it reads.
+ */
+const BUILTIN_TO_CANDLE_FIELD: Record<string, (c: any) => any> = {
+    open:    (c) => c.open,
+    high:    (c) => c.high,
+    low:     (c) => c.low,
+    close:   (c) => c.close,
+    volume:  (c) => c.volume,
+    hl2:     (c) => (c.high + c.low) / 2,
+    hlc3:    (c) => (c.high + c.low + c.close) / 3,
+    ohlc4:   (c) => (c.high + c.low + c.open + c.close) / 4,
+    hlcc4:   (c) => (c.high + c.low + c.close + c.close) / 4,
+    time:    (c) => c.openTime,
+    openTime:  (c) => c.openTime,
+    closeTime: (c) => c.closeTime,
+};
+
+/**
+ * If `series` is one of `context.data.<builtin>` (by reference identity),
+ * return the builtin name. Otherwise null. Reference equality is the
+ * right test because every Pine Script's `close`/`high`/etc. resolves
+ * to the same Series instance held on `context.data` for the lifetime
+ * of the script (see PineTS.class.ts `_initializeContext`).
+ */
+function builtinNameOf(series: any, context: any): string | null {
+    if (!(series instanceof Series)) return null;
+    const data = context?.data;
+    if (!data) return null;
+    for (const name of Object.keys(BUILTIN_TO_CANDLE_FIELD)) {
+        if (series === data[name]) return name;
+    }
+    return null;
+}
+
+/**
+ * Descriptor returned by the pure-builtin detector. Drives the shape of
+ * the values written into the synthesised secondary context's
+ * `params[expression_name]`.
+ *   - `kind: 'series'` — single bare builtin (e.g. `close`); each LTF
+ *     bar produces one scalar.
+ *   - `kind: 'tuple'`  — array of bare builtins (e.g. `[open, …, volume]`);
+ *     each LTF bar produces a 5-tuple of scalars.
+ *   - `kind: 'udt'`    — UDT instance whose ALL field defaults are bare
+ *     builtins (e.g. `type candle { float o = open; float h = high; …}`);
+ *     each LTF bar produces a fresh PineTypeObject of that type, fields
+ *     populated from the candle.
+ */
+type BuiltinExpr =
+    | { kind: 'series'; builtinNames: [string] }
+    | { kind: 'tuple'; builtinNames: string[] }
+    | { kind: 'udt'; builtinNames: string[]; fieldNames: string[]; udt: any };
+
+/**
+ * UDT detector — succeeds when ALL of the type's fields have bare-
+ * builtin defaults (Series identity preserved on the factory's
+ * `_fieldDefaults` map by Core.ts `Type()`). A field with no default
+ * or a non-builtin default disqualifies the whole UDT.
+ */
+function detectPureBuiltinUdt(source: any, context: any): BuiltinExpr | null {
+    // `let mycandle = candle.new()` stores the UDT instance inside a
+    // Series slot (`$.let.glb1_mycandle`); when passed as the third
+    // argument to `request.security_lower_tf`, request.param sees the
+    // Series itself, not the inner PineTypeObject. Unwrap to peek at
+    // the current bar's instance.
+    if (source instanceof Series) {
+        source = source.get(0);
+    }
+    if (!(source instanceof PineTypeObject)) return null;
+    const udt = source._udt;
+    if (!udt || !udt._fieldDefaults || !Array.isArray(udt._definitionKeys)) return null;
+    const fieldNames: string[] = udt._definitionKeys;
+    if (fieldNames.length === 0) return null;
+    const builtinNames: string[] = [];
+    for (const f of fieldNames) {
+        if (!(f in udt._fieldDefaults)) return null;
+        const def = udt._fieldDefaults[f];
+        const name = builtinNameOf(def, context);
+        if (name === null) return null;
+        builtinNames.push(name);
+    }
+    return { kind: 'udt', builtinNames, fieldNames, udt };
+}
+
+/**
+ * Inspect the original (pre-extraction) `expression` source recorded by
+ * `request.param` and return a descriptor of its fast-path shape, or
+ * null if the expression isn't a pure-builtin form. Three cases handled:
+ *   - bare Series (e.g. `close`) → kind 'series'
+ *   - tuple of bare Series (e.g. `[open, …]`) → kind 'tuple'
+ *   - UDT whose every field default is a bare Series → kind 'udt'
+ */
+function detectPureBuiltinExpression(originalSource: any, context: any): BuiltinExpr | null {
+    if (originalSource === undefined) return null;
+    if (Array.isArray(originalSource)) {
+        const names: string[] = [];
+        for (const elem of originalSource) {
+            const n = builtinNameOf(elem, context);
+            if (n === null) return null;
+            names.push(n);
+        }
+        return names.length > 0 ? { kind: 'tuple', builtinNames: names } : null;
+    }
+    const single = builtinNameOf(originalSource, context);
+    if (single !== null) return { kind: 'series', builtinNames: [single] };
+    return detectPureBuiltinUdt(originalSource, context);
+}
+
+/**
+ * Fast path: build a minimal "secondary context" object whose shape
+ * matches the subset of fields the downstream LTF aggregation reads —
+ * `data.openTime.data`, `data.closeTime.data`, and
+ * `params[expression_name]`. No PineTS instance is created and no user
+ * script ever runs in the secondary; we just open the LTF candle stream
+ * and shred each candle into its requested builtin field(s).
+ *
+ * The shape of `values[i]` (each LTF bar's contribution to the
+ * captured expression) follows the descriptor:
+ *   - 'series' → scalar
+ *   - 'tuple'  → array of scalars
+ *   - 'udt'    → fresh `PineTypeObject` whose fields are populated from
+ *                that LTF candle (matching what the slow path would
+ *                have produced when running `MyType.new()` per LTF bar
+ *                with builtin defaults resolved against the secondary's
+ *                `context.data`).
+ */
+async function buildFastBuiltinSecContext(
+    context: any,
+    _symbol: string,
+    _timeframe: string,
+    _calc_bars_count: number | undefined,
+    expr: BuiltinExpr,
+    expressionName: string,
+) {
+    const effectiveSDate = context.sDate
+        || (context.marketData?.length > 0 ? context.marketData[0].openTime : undefined);
+    const lastBarCloseTime = context.marketData?.length > 0
+        ? context.marketData[context.marketData.length - 1].closeTime
+        : 0;
+    const secEDate = lastBarCloseTime || context.eDate || Date.now();
+
+    // Reuse PineTS's data-loading path so we get exactly the same
+    // candle stream a slow-path secondary would have used (provider,
+    // pagination semantics, syminfo). Wait for `ready()` and read the
+    // populated arrays — never call `run()`, so no transpile, no
+    // iteration, no shifts, no helpers.
+    const pineTS = new PineTS(context.source, _symbol, _timeframe, _calc_bars_count, effectiveSDate, secEDate);
+    pineTS.markAsSecondary();
+    await pineTS.ready();
+
+    // Use the openTime/closeTime arrays already prepared by the
+    // PineTS instance — these have the closeTime fallback (openTime +
+    // timeframe duration) applied for providers that omit closeTime.
+    // Reading raw `marketData[i].closeTime` would diverge from the
+    // slow-path secondary, breaking the bar-grouping check downstream.
+    const openTimes = (pineTS as any).openTime as number[];
+    const closeTimes = (pineTS as any).closeTime as number[];
+    const candles = (pineTS as any).data as any[];
+
+    const fieldGetters = expr.builtinNames.map((n) => BUILTIN_TO_CANDLE_FIELD[n]);
+
+    let values: any[];
+    if (expr.kind === 'series') {
+        values = candles.map((c) => fieldGetters[0](c));
+    } else if (expr.kind === 'tuple') {
+        values = candles.map((c) => fieldGetters.map((g) => g(c)));
+    } else {
+        // UDT: synthesise a PineTypeObject per LTF bar. We bypass
+        // `udt.new(...)` and construct directly so the fields are
+        // populated from the LTF candle (not from the primary
+        // context's `context.data.<builtin>`, which is what the
+        // factory's defaults would resolve to).
+        const fieldNames = (expr as any).fieldNames as string[];
+        const udt = (expr as any).udt;
+        values = candles.map((c) => {
+            const fields: Record<string, any> = {};
+            for (let i = 0; i < fieldNames.length; i++) {
+                fields[fieldNames[i]] = fieldGetters[i](c);
+            }
+            return new PineTypeObject(fields, context, udt);
+        });
+    }
+
+    return {
+        data: {
+            openTime: { data: openTimes },
+            closeTime: { data: closeTimes },
+        },
+        params: { [expressionName]: values },
+    };
 }
 
 /**
@@ -146,42 +342,79 @@ export function security_lower_tf(context: any) {
 
         const cacheKey = `${_symbol}_${_timeframe}_${_expression_name}_lower`;
 
+        // Fast path: when the captured expression is a bare price/time
+        // builtin Series (or a tuple of them — e.g. `[open, high, low,
+        // close, volume]`), the secondary doesn't need to run a single
+        // line of the user script. Every LTF bar's value of `close` IS
+        // the LTF candle's `close`. We fetch the candles once and build
+        // the secondary context's `params[expression_name]` directly.
+        // This is what dominates request.security_lower_tf perf for the
+        // ~90% of indicators that pull raw OHLCV at 1m (footprint,
+        // volume profile, structural-leg-profiler, …).
+        const originalSource = context._requestParamSources?.[_expression_name];
+        const builtinExpr = detectPureBuiltinExpression(originalSource, context);
+
         if (!context.cache[cacheKey]) {
-            // For request.security_lower_tf the secondary's data window is
-            // bounded by the chart's own window — every LTF bar that
-            // contributes to a chart bar falls inside that chart bar's
-            // [openTime, closeTime]. Adding a fixed historical buffer (the
-            // way security.ts does for higher-timeframe warmup) blows up
-            // bar counts dramatically: a 30-day buffer at 1-minute LTF
-            // forces the secondary to iterate ~43,200 extra bars before
-            // the main loop can advance past bar 0, which manifests as a
-            // multi-minute hang on small charts (e.g. 50 bars on 5m). Use
-            // the chart's earliest openTime directly.
-            const effectiveSDate = context.sDate
-                || (context.marketData?.length > 0 ? context.marketData[0].openTime : undefined);
-            const adjustedSDate = effectiveSDate;
+            if (builtinExpr !== null) {
+                // ── Fast path ────────────────────────────────────────
+                const fastSecContext = await buildFastBuiltinSecContext(
+                    context, _symbol, _timeframe, _calc_bars_count,
+                    builtinExpr, _expression_name,
+                );
+                context.cache[cacheKey] = {
+                    pineTS: null,
+                    context: fastSecContext,
+                    dataVersion: context.dataVersion,
+                    _fastPath: true,
+                    _fastPathArgs: { builtinExpr },
+                };
+            } else {
+                // ── Slow path: run the full user script in a secondary ──
+                // For request.security_lower_tf the secondary's data window
+                // is bounded by the chart's own window — every LTF bar that
+                // contributes to a chart bar falls inside that chart bar's
+                // [openTime, closeTime]. Adding a fixed historical buffer
+                // (the way security.ts does for higher-timeframe warmup)
+                // blows up bar counts dramatically: a 30-day buffer at 1-
+                // minute LTF forces the secondary to iterate ~43,200 extra
+                // bars before the main loop can advance past bar 0, which
+                // manifests as a multi-minute hang on small charts (e.g.
+                // 50 bars on 5m). Use the chart's earliest openTime.
+                const effectiveSDate = context.sDate
+                    || (context.marketData?.length > 0 ? context.marketData[0].openTime : undefined);
+                const adjustedSDate = effectiveSDate;
 
-            // Align secondary's end date with the chart's actual data so that
-            // `barstate.islast` in the secondary fires at the same temporal point as
-            // the chart's `barstate.islast`. See security.ts for full rationale.
-            const lastBarCloseTime = context.marketData?.length > 0
-                ? context.marketData[context.marketData.length - 1].closeTime
-                : 0;
-            const secEDate = lastBarCloseTime || context.eDate || Date.now();
+                const lastBarCloseTime = context.marketData?.length > 0
+                    ? context.marketData[context.marketData.length - 1].closeTime
+                    : 0;
+                const secEDate = lastBarCloseTime || context.eDate || Date.now();
 
-            const pineTS = new PineTS(context.source, _symbol, _timeframe, _calc_bars_count, adjustedSDate, secEDate);
-            pineTS.markAsSecondary();
+                const pineTS = new PineTS(context.source, _symbol, _timeframe, _calc_bars_count, adjustedSDate, secEDate);
+                pineTS.markAsSecondary();
 
-            const secContext = await pineTS.run(context.pineTSCode);
-            context.cache[cacheKey] = { pineTS, context: secContext, dataVersion: context.dataVersion };
+                const secContext = await pineTS.run(context.pineTSCode);
+                context.cache[cacheKey] = { pineTS, context: secContext, dataVersion: context.dataVersion };
+            }
         }
 
         const cached = context.cache[cacheKey];
 
         // Refresh secondary context when main context's data has changed (streaming mode)
         if (context.dataVersion > cached.dataVersion) {
-            await cached.pineTS.updateTail(cached.context);
-            cached.dataVersion = context.dataVersion;
+            if (cached._fastPath) {
+                // Re-fetch and rebuild the fast-path cache entry — there
+                // is no `updateTail` for fast-path entries because no
+                // PineTS instance was constructed.
+                const refreshed = await buildFastBuiltinSecContext(
+                    context, _symbol, _timeframe, _calc_bars_count,
+                    cached._fastPathArgs.builtinExpr, _expression_name,
+                );
+                cached.context = refreshed;
+                cached.dataVersion = context.dataVersion;
+            } else {
+                await cached.pineTS.updateTail(cached.context);
+                cached.dataVersion = context.dataVersion;
+            }
         }
 
         const secContext = cached.context;

--- a/src/namespaces/request/methods/security_lower_tf.ts
+++ b/src/namespaces/request/methods/security_lower_tf.ts
@@ -147,13 +147,19 @@ export function security_lower_tf(context: any) {
         const cacheKey = `${_symbol}_${_timeframe}_${_expression_name}_lower`;
 
         if (!context.cache[cacheKey]) {
-            const buffer = 1000 * 60 * 60 * 24 * 30; // 30 days buffer
-
-            // Determine start date: use context.sDate if available, otherwise
-            // derive from the earliest bar's openTime (same logic as security.ts)
+            // For request.security_lower_tf the secondary's data window is
+            // bounded by the chart's own window — every LTF bar that
+            // contributes to a chart bar falls inside that chart bar's
+            // [openTime, closeTime]. Adding a fixed historical buffer (the
+            // way security.ts does for higher-timeframe warmup) blows up
+            // bar counts dramatically: a 30-day buffer at 1-minute LTF
+            // forces the secondary to iterate ~43,200 extra bars before
+            // the main loop can advance past bar 0, which manifests as a
+            // multi-minute hang on small charts (e.g. 50 bars on 5m). Use
+            // the chart's earliest openTime directly.
             const effectiveSDate = context.sDate
                 || (context.marketData?.length > 0 ? context.marketData[0].openTime : undefined);
-            const adjustedSDate = effectiveSDate ? effectiveSDate - buffer : undefined;
+            const adjustedSDate = effectiveSDate;
 
             // Align secondary's end date with the chart's actual data so that
             // `barstate.islast` in the secondary fires at the same temporal point as

--- a/src/namespaces/silentInSecondary.ts
+++ b/src/namespaces/silentInSecondary.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * `@silentInSecondary` — method decorator.
+ *
+ * Marks a helper method as a no-op when invoked on a secondary context
+ * (i.e. the auxiliary PineTS instance that `request.security` /
+ * `request.security_lower_tf` spawns to compute the captured expression
+ * at another symbol/timeframe).
+ *
+ * Drawings, plots, alerts and similar side-effect-only operations are
+ * never observable from a secondary context — its sole job is to populate
+ * `secContext.params[expression_name]` with the value of the captured
+ * expression bar-by-bar. Silencing those operations on secondaries cuts
+ * the per-bar work substantially without changing the captured value
+ * (the only output that callers ever read).
+ *
+ * Constructor-style methods (e.g. `label.new`, `line.new`, `box.new`)
+ * return `null`; setters / mutators / deletes return `undefined`. The
+ * existing helper code is null-safe end-to-end:
+ *   - `get_*` methods already return `NaN`/`""` when the receiver is null.
+ *   - The transpiler emits method calls on UDT-typed receivers as
+ *     `obj?.method?.(...)`, so `null?.set_x1?.(...)` short-circuits.
+ *   - Built-in setters like `LineHelper.set_x1(id, x)` already guard
+ *     `if (id && !id._deleted) ...` and no-op on null.
+ *
+ * Pre-condition: target classes use the conventional
+ *   `constructor(private context: any) {}`
+ * shape, so `this.context.isSecondaryContext` is uniformly accessible.
+ * (`Core.ts` `AlertHelper`, `Plots.ts` `PlotHelper`/`HlineHelper`/
+ * `FillHelper`, and the drawing helpers all conform.)
+ */
+export function silentInSecondary(
+    _target: any,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor,
+): PropertyDescriptor {
+    const original = descriptor.value;
+    if (typeof original !== 'function') return descriptor;
+
+    descriptor.value = function (...args: any[]) {
+        if (this && this.context && this.context.isSecondaryContext) {
+            return null;
+        }
+        return original.apply(this, args);
+    };
+
+    return descriptor;
+}

--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -2,6 +2,7 @@
 
 import { Series } from '../../Series';
 import { TableObject } from './TableObject';
+import { silentInSecondary } from '../silentInSecondary';
 
 export class TableHelper {
     private _tables: TableObject[] = [];
@@ -48,6 +49,7 @@ export class TableHelper {
 
     // ── table.new ──────────────────────────────────────────────
 
+    @silentInSecondary
     new(...args: any[]): TableObject {
         let position: any = 'top_right';
         let columns: any = 1;
@@ -125,6 +127,7 @@ export class TableHelper {
 
     // ── table.cell ─────────────────────────────────────────────
 
+    @silentInSecondary
     cell(...args: any[]): void {
         let table_id: any;
         let column: any;
@@ -207,12 +210,14 @@ export class TableHelper {
 
     // ── table.delete ───────────────────────────────────────────
 
+    @silentInSecondary
     delete(id: TableObject): void {
         if (id) id._deleted = true;
     }
 
     // ── table.clear ────────────────────────────────────────────
 
+    @silentInSecondary
     clear(...args: any[]): void {
         let table_id: any;
         let start_column: any;
@@ -257,6 +262,7 @@ export class TableHelper {
 
     // ── table.merge_cells ──────────────────────────────────────
 
+    @silentInSecondary
     merge_cells(...args: any[]): void {
         let table_id: any;
         let start_column: any;
@@ -308,48 +314,59 @@ export class TableHelper {
 
     // ── Cell setter methods ────────────────────────────────────
 
+    @silentInSecondary
     cell_set_text(table_id: any, column: any, row: any, text: any): void {
         this._setCellProp(table_id, column, row, 'text', text, true);
     }
 
+    @silentInSecondary
     cell_set_bgcolor(table_id: any, column: any, row: any, bgcolor: any): void {
         this._setCellProp(table_id, column, row, 'bgcolor', bgcolor);
     }
 
+    @silentInSecondary
     cell_set_text_color(table_id: any, column: any, row: any, text_color: any): void {
         this._setCellProp(table_id, column, row, 'text_color', text_color);
     }
 
+    @silentInSecondary
     cell_set_text_size(table_id: any, column: any, row: any, text_size: any): void {
         this._setCellProp(table_id, column, row, 'text_size', text_size);
     }
 
+    @silentInSecondary
     cell_set_height(table_id: any, column: any, row: any, height: any): void {
         this._setCellProp(table_id, column, row, 'height', height);
     }
 
+    @silentInSecondary
     cell_set_width(table_id: any, column: any, row: any, width: any): void {
         this._setCellProp(table_id, column, row, 'width', width);
     }
 
+    @silentInSecondary
     cell_set_tooltip(table_id: any, column: any, row: any, tooltip: any): void {
         this._setCellProp(table_id, column, row, 'tooltip', tooltip, true);
     }
 
+    @silentInSecondary
     cell_set_text_halign(table_id: any, column: any, row: any, text_halign: any): void {
         this._setCellProp(table_id, column, row, 'text_halign', text_halign);
     }
 
+    @silentInSecondary
     cell_set_text_valign(table_id: any, column: any, row: any, text_valign: any): void {
         this._setCellProp(table_id, column, row, 'text_valign', text_valign);
     }
 
+    @silentInSecondary
     cell_set_text_font_family(table_id: any, column: any, row: any, text_font_family: any): void {
         this._setCellProp(table_id, column, row, 'text_font_family', text_font_family);
     }
 
     // ── Table setter methods ───────────────────────────────────
 
+    @silentInSecondary
     set_position(table_id: any, position: any): void {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
@@ -357,6 +374,7 @@ export class TableHelper {
         this.syncToPlot();
     }
 
+    @silentInSecondary
     set_bgcolor(table_id: any, bgcolor: any): void {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
@@ -364,6 +382,7 @@ export class TableHelper {
         this.syncToPlot();
     }
 
+    @silentInSecondary
     set_border_color(table_id: any, border_color: any): void {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
@@ -371,6 +390,7 @@ export class TableHelper {
         this.syncToPlot();
     }
 
+    @silentInSecondary
     set_border_width(table_id: any, border_width: any): void {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
@@ -378,6 +398,7 @@ export class TableHelper {
         this.syncToPlot();
     }
 
+    @silentInSecondary
     set_frame_color(table_id: any, frame_color: any): void {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
@@ -385,6 +406,7 @@ export class TableHelper {
         this.syncToPlot();
     }
 
+    @silentInSecondary
     set_frame_width(table_id: any, frame_width: any): void {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -202,6 +202,20 @@ export class ScopeManager {
         return this.scopeTypes[this.scopeTypes.length - 1];
     }
 
+    /**
+     * True when any active scope on the stack is a function scope.
+     * Different from `getCurrentScopeType() === 'fn'`, which only matches
+     * the immediate scope — code inside a nested `if`/`for`/`while` inside
+     * a function body still needs the function-scope context (e.g. for
+     * call-path-keyed param/ta-callsite ids).
+     */
+    isInsideFunctionScope(): boolean {
+        for (let i = this.scopeTypes.length - 1; i >= 0; i--) {
+            if (this.scopeTypes[i] === 'fn') return true;
+        }
+        return false;
+    }
+
     getCurrentScopeCount(): number {
         return this.scopeCounts.get(this.getCurrentScopeType()) || 1;
     }

--- a/src/transpiler/pineToJS/lexer.ts
+++ b/src/transpiler/pineToJS/lexer.ts
@@ -161,6 +161,20 @@ export class Lexer {
         // Convert spaces to indent levels (4 spaces = 1 level)
         indent += Math.floor(spaceCount / 4);
 
+        // Pine allows binary-operator (and comma / ternary `:` / logical
+        // and|or) line continuation. The continuation line is typically
+        // visually aligned past the operand of the previous line, which
+        // looks like a deeper indent — but it must NOT push a new block
+        // onto the indent stack. Without this guard, the lexer emits an
+        // INDENT for the continuation line and a matching DEDENT when
+        // the next real statement returns to the original block indent;
+        // the block parser sees that DEDENT and prematurely closes the
+        // surrounding function/if/for body, dropping subsequent
+        // statements (which then reference now-out-of-scope parameters).
+        if (this.isContinuationFromPrevToken()) {
+            return;
+        }
+
         const currentIndent = this.indentStack[this.indentStack.length - 1];
 
         // Increased indentation - emit INDENT
@@ -181,6 +195,31 @@ export class Lexer {
             }
         }
         // Same indentation - no INDENT/DEDENT
+    }
+
+    /**
+     * True when the most recently emitted token (skipping NEWLINE / COMMENT
+     * — those are layout, not content) is a token that requires a right-
+     * hand-side and therefore implies the next non-blank line is a
+     * continuation, not a new block. Mirrors the set the parser's
+     * `peekOperatorEx` already crosses NEWLINE for.
+     */
+    private isContinuationFromPrevToken(): boolean {
+        for (let i = this.tokens.length - 1; i >= 0; i--) {
+            const t = this.tokens[i];
+            if (t.type === TokenType.NEWLINE || t.type === TokenType.COMMENT) continue;
+            if (t.type === TokenType.OPERATOR) {
+                // `=>` introduces a new block (arrow function / method body),
+                // not a continuation — the next indent IS a real INDENT.
+                if (t.value === '=>') return false;
+                return true;
+            }
+            if (t.type === TokenType.COMMA) return true;
+            if (t.type === TokenType.COLON) return true;
+            if (t.type === TokenType.KEYWORD && (t.value === 'and' || t.value === 'or')) return true;
+            return false;
+        }
+        return false;
     }
 
     // Read comment

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -434,8 +434,17 @@ export class Parser {
         return baseType; // Simple type: "float", "int", etc.
     }
 
-    // Parse enum definition: enum Name \n member1 \n member2 \n ...
-    // Generates: const Name = { member1: 'Name.member1', member2: 'Name.member2', ... }
+    // Parse enum definition. Supports both Pine v6 forms:
+    //   enum X            (untitled — bare member names)
+    //       a
+    //       b
+    //   enum Y            (titled — `member = "title"`)
+    //       a = "Alpha"
+    //       b = "Beta"
+    //
+    // Runtime value matches TradingView's str.tostring(EnumName.member):
+    //   - titled: the title string verbatim (incl. empty `""`)
+    //   - untitled: just the member name (e.g. "a", NOT "X.a")
     parseEnumDefinition() {
         this.expect(TokenType.KEYWORD, 'enum');
         const name = this.expect(TokenType.IDENTIFIER).value;
@@ -443,7 +452,7 @@ export class Parser {
         this.skipNewlines();
         this.expect(TokenType.INDENT);
 
-        const members: string[] = [];
+        const members: { name: string; title: string | null }[] = [];
         while (!this.match(TokenType.DEDENT) && !this.match(TokenType.EOF)) {
             this.skipNewlines();
             if (this.match(TokenType.DEDENT)) break;
@@ -453,7 +462,12 @@ export class Parser {
             }
 
             const memberName = this.expect(TokenType.IDENTIFIER).value;
-            members.push(memberName);
+            let memberTitle: string | null = null;
+            if (this.match(TokenType.OPERATOR, '=')) {
+                this.advance(); // consume '='
+                memberTitle = this.expect(TokenType.STRING).value;
+            }
+            members.push({ name: memberName, title: memberTitle });
             this.skipNewlines();
         }
 
@@ -461,8 +475,10 @@ export class Parser {
             this.advance();
         }
 
-        // Generate: const Name = { member1: 'Name.member1', ... }
-        const props = members.map((m) => new Property(new Identifier(m), new Literal(`${name}.${m}`)));
+        // Generate: const Name = { member: title-or-name, ... }
+        const props = members.map((m) =>
+            new Property(new Identifier(m.name), new Literal(m.title !== null ? m.title : m.name)),
+        );
         const objExpr = new ObjectExpression(props);
         return new VariableDeclaration(
             [new VariableDeclarator(new Identifier(name), objExpr)],

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -67,11 +67,26 @@ export function transformArrayIndex(node: any, scopeManager: ScopeManager): void
 
         // Only transform if it's not a context-bound variable
         if (!scopeManager.isContextBound(node.property.name)) {
-            // Transform property to $.kind.scopedName
-            node.property = createScopedVariableReference(node.property.name, scopeManager);
+            // Local series var (e.g. function parameter) used as an index:
+            // keep as a bare identifier wrapped with $.get(param, 0). Mirrors
+            // the same handling at the loop-variable case above and the
+            // object-position case below. Without this branch, a function
+            // param used as a history-lookback index (e.g. `high[size]` where
+            // `size` is a fn param) is mis-scoped to `$.let.size_$0`, which
+            // is undefined → resolves to 0 → `high[size]` returns the current
+            // bar instead of the bar `size` ago, breaking pivot-detection
+            // idioms like `high[size] > ta.highest(size)`.
+            if (scopeManager.isLocalSeriesVar(node.property.name)) {
+                const plainIdentifier = ASTFactory.createIdentifier(node.property.name);
+                plainIdentifier._skipTransformation = true;
+                node.property = ASTFactory.createGetCall(plainIdentifier, 0);
+            } else {
+                // Transform property to $.kind.scopedName
+                node.property = createScopedVariableReference(node.property.name, scopeManager);
 
-            // Add [0] to the index: $.get($.kind.scopedName, 0)
-            node.property = ASTFactory.createGetCall(node.property, 0);
+                // Add [0] to the index: $.get($.kind.scopedName, 0)
+                node.property = ASTFactory.createGetCall(node.property, 0);
+            }
         }
     }
 

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -11,6 +11,38 @@ const UNDEFINED_ARG = {
     name: 'undefined',
 };
 
+/**
+ * Build the third argument to a `*.param(value, idx, name)` call. The
+ * statically-allocated `pN` string is unique across the script, but
+ * `Context.param` stores the resulting series in `context.params[name]` —
+ * a globally-keyed map — so two distinct call paths through the same
+ * function body would clobber each other (the function body bakes in
+ * the same `pN`, but each call writes a different value). Mirroring the
+ * existing ta-callsite-id convention (`$$.id + '_taN'`), we prefix the
+ * static `pN` with the current call-path id when inside a fn scope so
+ * each path writes to its own `params[path|pN]` slot. At top level
+ * `$$` doesn't exist, so we fall back to the literal `pN`.
+ */
+function makeParamNameArg(scopeManager: ScopeManager, paramId: string): any {
+    const literal = { type: 'Identifier', name: `'${paramId}'` };
+    // Use any-fn-scope-on-stack rather than `getCurrentScopeType() === 'fn'`
+    // — params can be emitted from inside if/for/while/switch nested inside
+    // a function body, where the immediate scope is e.g. 'if' but `$$` is
+    // still the function's local context.
+    if (!scopeManager.isInsideFunctionScope()) return literal;
+    const [localCtxName] = scopeManager.getVariable('$$');
+    if (!localCtxName) return literal;
+    return {
+        type: 'BinaryExpression',
+        operator: '+',
+        left: ASTFactory.createMemberExpression(
+            ASTFactory.createLocalContextIdentifier(),
+            ASTFactory.createIdentifier('id'),
+        ),
+        right: literal,
+    };
+}
+
 export function createScopedVariableReference(name: string, scopeManager: ScopeManager): any {
     const [scopedName, kind] = scopeManager.getVariable(name);
 
@@ -869,7 +901,7 @@ function getParamFromConditionalExpression(node: any, scopeManager: ScopeManager
     const paramCall = {
         type: 'CallExpression',
         callee: memberExpr,
-        arguments: [node, UNDEFINED_ARG, { type: 'Identifier', name: `'${nextParamId}'` }],
+        arguments: [node, UNDEFINED_ARG, makeParamNameArg(scopeManager, nextParamId)],
         _transformed: true,
         _isParamCall: true,
     };
@@ -1097,7 +1129,7 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
         const paramCall = {
             type: 'CallExpression',
             callee: memberExpr,
-            arguments: [transformedObject, transformedProperty, { type: 'Identifier', name: `'${nextParamId}'` }],
+            arguments: [transformedObject, transformedProperty, makeParamNameArg(scopeManager, nextParamId)],
             _transformed: true,
             _isParamCall: true,
         };
@@ -1253,7 +1285,7 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
             const paramCall = {
                 type: 'CallExpression',
                 callee: memberExpr,
-                arguments: [arg, UNDEFINED_ARG, { type: 'Identifier', name: `'${nextParamId}'` }],
+                arguments: [arg, UNDEFINED_ARG, makeParamNameArg(scopeManager, nextParamId)],
                 _transformed: true,
                 _isParamCall: true,
             };
@@ -1284,7 +1316,7 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
     const paramCall = {
         type: 'CallExpression',
         callee: memberExpr,
-        arguments: [transformedArg, UNDEFINED_ARG, { type: 'Identifier', name: `'${nextParamId}'` }],
+        arguments: [transformedArg, UNDEFINED_ARG, makeParamNameArg(scopeManager, nextParamId)],
         _transformed: true,
         _isParamCall: true,
     };

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -915,7 +915,12 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
             arg = getParamFromUnaryExpression(arg, scopeManager, namespace);
             break;
         case 'ArrayExpression':
-            // Transform each element in the array
+            // Transform each element in the array. Non-Identifier elements
+            // (e.g. nested calls like `ta.sma(volume, maLenInput)` inside a
+            // `request.security_lower_tf(..., [open, close, ta.sma(...)])`
+            // tuple) must also be transformed so their nested identifiers
+            // get scoped — otherwise `maLenInput` leaks bare and throws
+            // "ReferenceError: maLenInput is not defined" at runtime.
             arg.elements = arg.elements.map((element: any) => {
                 if (element.type === 'Identifier') {
                     // Transform identifiers to use $.get(variable, 0)
@@ -931,6 +936,28 @@ export function transformFunctionArgument(arg: any, namespace: string, scopeMana
                     }
                     // It's a user variable - transform to context reference
                     return createScopedVariableAccess(element.name, scopeManager);
+                }
+                // Recurse into non-Identifier elements using the same helpers
+                // the outer switch uses when these shapes appear at top level.
+                if (element.type === 'CallExpression') {
+                    transformCallExpression(element, scopeManager);
+                    return element;
+                }
+                if (element.type === 'BinaryExpression') {
+                    return getParamFromBinaryExpression(element, scopeManager, namespace);
+                }
+                if (element.type === 'LogicalExpression') {
+                    return getParamFromLogicalExpression(element, scopeManager, namespace);
+                }
+                if (element.type === 'ConditionalExpression') {
+                    return getParamFromConditionalExpression(element, scopeManager, namespace);
+                }
+                if (element.type === 'UnaryExpression') {
+                    return getParamFromUnaryExpression(element, scopeManager, namespace);
+                }
+                if (element.type === 'MemberExpression') {
+                    transformMemberExpression(element, namespace, scopeManager);
+                    return element;
                 }
                 return element;
             });

--- a/src/transpiler/transformers/InjectionTransformer.ts
+++ b/src/transpiler/transformers/InjectionTransformer.ts
@@ -79,6 +79,17 @@ export function injectImplicitImports(ast: any): void {
                 // Nested declarations shadow global ones, so that's fine.
                 // If we inject `const open = ...` at top level, it might conflict if `open` is already declared at top level.
                 // So we scan top level statements for declarations.
+                //
+                // Walk default-value expressions in params so identifiers that
+                // appear ONLY in defaults (e.g. `myFn(color bg = na) =>`) still
+                // register as used. Otherwise the implicit destructure misses
+                // them and JS throws "ReferenceError: na is not defined" when
+                // the default fires at a call site that omitted the arg.
+                for (const p of node.params) {
+                    if (p && p.type === 'AssignmentPattern' && p.right) {
+                        c(p.right, state);
+                    }
+                }
                 c(node.body, state);
             },
             Identifier(node: any, state: any, c: any) {

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -412,6 +412,25 @@ export function transformVariableDeclaration(varNode: any, scopeManager: ScopeMa
                             c(node.left, { parent: node });
                             c(node.right, { parent: node });
                         },
+                        // LogicalExpression (`and`/`or`) and UnaryExpression
+                        // (`not`/unary `-`) need explicit visitors here so the
+                        // parent reference threaded into their children is the
+                        // expression itself — not the surrounding decl.init.
+                        // Without this, an Identifier inside `not a and not b`
+                        // sees state.parent === LogicalExpression instead of
+                        // UnaryExpression, the "unwrap as series-operand" path
+                        // never fires, and the JS emits `!a && !b` (always
+                        // false because `a`/`b` are Series objects).
+                        LogicalExpression(node: any, state: any, c: any) {
+                            if (node.left.type === 'Identifier') node.left.parent = node;
+                            if (node.right.type === 'Identifier') node.right.parent = node;
+                            c(node.left, { parent: node });
+                            c(node.right, { parent: node });
+                        },
+                        UnaryExpression(node: any, state: any, c: any) {
+                            if (node.argument.type === 'Identifier') node.argument.parent = node;
+                            c(node.argument, { parent: node });
+                        },
                         MemberExpression(node: any, state: any, c: any) {
                             // Set parent reference
                             if (node.object && node.object.type === 'Identifier') {
@@ -656,6 +675,15 @@ export function transformVariableDeclaration(varNode: any, scopeManager: ScopeMa
             walk.recursive(decl.init.body, scopeManager, {
                 IfStatement(node: any, state: ScopeManager, c: any) {
                     state.pushScope('if');
+                    // Transform the test condition. Without this, an if-test
+                    // inside an arrow-function body never gets walked — the
+                    // function-arg-unwrap path is skipped, and patterns like
+                    // `if not a and not b` (very common in Pine) emit JS
+                    // `if (!a && !b)` where `a`/`b` are Series objects (always
+                    // truthy → `!Series === false` → branch never taken).
+                    if (node.test) {
+                        transformExpression(node.test, state);
+                    }
                     c(node.consequent, state);
                     if (node.alternate) {
                         state.pushScope('els');
@@ -994,8 +1022,58 @@ export function transformExpression(node: any, scopeManager: ScopeManager): void
         CallExpression(node: any, state: ScopeManager) {
             transformCallExpression(node, state);
         },
+        // BinaryExpression / LogicalExpression / UnaryExpression need explicit
+        // visitors here so parent references are threaded into the operand
+        // identifiers. Without this, an Identifier inside `not a and not b`
+        // (a common Pine pattern in if-conditions) ends up with `node.parent`
+        // pointing at the outer LogicalExpression — or at nothing at all —
+        // and `transformIdentifier` skips its localSeriesVar unwrap because
+        // the `is(NamespaceMember|ParamCall|SeriesFunctionArg|...)` guards
+        // misclassify the node. The result is JS like `!a && !b`, which
+        // always evaluates to `false` because `a`/`b` are Series objects.
+        BinaryExpression(node: any, state: ScopeManager, c: any) {
+            if (node.left.type === 'Identifier') node.left.parent = node;
+            if (node.right.type === 'Identifier') node.right.parent = node;
+            c(node.left, state);
+            c(node.right, state);
+        },
+        LogicalExpression(node: any, state: ScopeManager, c: any) {
+            if (node.left.type === 'Identifier') node.left.parent = node;
+            if (node.right.type === 'Identifier') node.right.parent = node;
+            c(node.left, state);
+            c(node.right, state);
+        },
+        UnaryExpression(node: any, state: ScopeManager, c: any) {
+            if (node.argument.type === 'Identifier') node.argument.parent = node;
+            c(node.argument, state);
+        },
         Identifier(node: any, state: ScopeManager) {
+            // Capture parent BEFORE transformIdentifier mutates `node` in
+            // place (Object.assign overwrites node.parent on rewrites such as
+            // wrap-in-$.get).
+            const parent = node.parent;
+            const isUnary = parent && parent.type === 'UnaryExpression';
+            const isBinary = parent && parent.type === 'BinaryExpression';
+            const isLogical = parent && parent.type === 'LogicalExpression';
+            const isConditional = parent && parent.type === 'ConditionalExpression';
+
             transformIdentifier(node, state);
+
+            // After identifier rewrite, if the node still looks like a bare
+            // Identifier sitting under a `not`/`and`/`or`/binary/conditional
+            // expression, force-wrap it with `$.get(..., 0)` so function-
+            // parameter Series get unwrapped to scalars before the operator
+            // applies. Without this, `if not a and not b` (with `a`/`b` as
+            // bool fn params) emits `!a && !b` — Series objects are truthy,
+            // so `!Series === false` and the branch is never taken.
+            if (node.type === 'Identifier' && (isUnary || isBinary || isLogical || isConditional)) {
+                const isGetCall = parent && parent.type === 'CallExpression' && parent.callee &&
+                    parent.callee.object && parent.callee.object.name === CONTEXT_NAME &&
+                    parent.callee.property?.name === 'get';
+                if (!isGetCall) {
+                    addArrayAccess(node, state);
+                }
+            }
 
             //context bound variable was not transformed, but we still need to ensure array annotation
             const isIfStatement = scopeManager.getCurrentScopeType() === 'if';

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -128,8 +128,20 @@ export function transformAssignmentExpression(node: any, scopeManager: ScopeMana
         { parent: node.right, inNamespaceCall: false },
         {
             Identifier(node: any, state: any, c: any) {
+                // Don't unwrap when the identifier is a namespace base in a
+                // constant access like `label.style_label_down`. NAMESPACES_LIKE
+                // mixes Series-wrapper names (time, na, dayofweek, …) with
+                // drawing namespaces (label, line, box, …); only the former
+                // have a .__value Series. For a member access where this
+                // identifier is the object, treat it as a plain namespace base.
+                const isNamespaceBase =
+                    state.parent &&
+                    state.parent.type === 'MemberExpression' &&
+                    !state.parent.computed &&
+                    state.parent.object === node;
+
                 // Rewrite NAMESPACES_LIKE entries (na, time, etc.) to $.get(__value, 0)
-                if (NAMESPACES_LIKE.includes(node.name) && scopeManager.isContextBound(node.name)) {
+                if (NAMESPACES_LIKE.includes(node.name) && scopeManager.isContextBound(node.name) && !isNamespaceBase) {
                     const originalName = node.name;
                     const valueExpr = {
                         type: 'MemberExpression',
@@ -1219,6 +1231,16 @@ export function transformReturnStatement(node: any, scopeManager: ScopeManager):
                     },
                     MemberExpression(node: any) {
                         transformMemberExpression(node, '', scopeManager);
+                    },
+                    // When an arrow function's last statement is an assignment
+                    // (e.g. `tracker.field := …`), the parser folds it into the
+                    // implicit return as an AssignmentExpression. Without this
+                    // visitor, the default acorn-walk fall-through visits the
+                    // LHS as a MemberExpression — which doesn't rewrite the
+                    // root identifier of an assignment LHS — and `tracker`
+                    // leaks bare → "ReferenceError: tracker is not defined".
+                    AssignmentExpression(node: any, state: ScopeManager) {
+                        transformAssignmentExpression(node, state);
                     },
                     // c is the callback function for recursion (acorn-walk)
                     CallExpression(node: any, state: ScopeManager, c: any) {

--- a/tests/core/last-bar-time.test.ts
+++ b/tests/core/last-bar-time.test.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: `last_bar_time` was implemented as
+ * `data.openTime.get(data.openTime.length - 1)`. Since `Series.get` is
+ * reverse-indexed (idx 0 = latest bar), `get(length - 1)` returned the
+ * OLDEST bar's open time — the opposite of what the symbol means.
+ *
+ * Symptom in Smart-Money-Concepts (LuxAlgo)'s drawHighLowSwings:
+ * `rightTimeBar = last_bar_time + 20 * (time - time[1])` extrapolated
+ * 20 bars past the FIRST bar of the dataset instead of the last, so the
+ * trailing Strong Low / Weak High lines were drawn from the historical
+ * pivot back into the start of the dataset, not forward into the
+ * future past the last bar.
+ *
+ * TV semantics: `last_bar_time` is the open time of the LAST bar of the
+ * chart's history — a CONSTANT across the entire script execution, even
+ * when iterating over historical bars. PineTS has the full preloaded
+ * candle array on `context.marketData`, so it reads the absolute last
+ * bar's openTime there.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// BTCUSDC weekly 2019-01-01 → 2019-02-01: 4 bars.
+// Last bar openTime = 1548633600000 (2019-01-27 UTC).
+const FIRST_BAR_TIME = 1546819200000;
+const LAST_BAR_TIME = 1548633600000;
+
+describe('last_bar_time (constant across the run)', () => {
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', 'W', null,
+            new Date('2019-01-01').getTime(),
+            new Date('2019-02-01').getTime());
+
+    it('returns the absolute last bar`s openTime, not the first', async () => {
+        const { plots } = await makePineTS().run(`
+//@version=5
+indicator("lbt")
+plot(last_bar_time, "lbt")
+`);
+        const data = plots['lbt'].data;
+        expect(data.length).toBeGreaterThan(0);
+        // Constant across every bar — including the first.
+        for (const entry of data) {
+            expect(entry.value).toBe(LAST_BAR_TIME);
+        }
+        // Defensive: must NOT be returning the first bar's time.
+        expect(data[0].value).not.toBe(FIRST_BAR_TIME);
+    });
+
+    it('on the last bar, last_bar_time === time', async () => {
+        const { plots } = await makePineTS().run(`
+//@version=5
+indicator("eq")
+match = last_bar_time == time ? 1 : 0
+plot(match, "match")
+plot(time,  "t")
+plot(last_bar_time, "lbt")
+`);
+        const matchData = plots['match'].data;
+        const tData = plots['t'].data;
+        const lbtData = plots['lbt'].data;
+
+        // On the last bar (last entry), they should be equal.
+        const last = matchData.length - 1;
+        expect(matchData[last].value).toBe(1);
+        expect(tData[last].value).toBe(LAST_BAR_TIME);
+        expect(lbtData[last].value).toBe(LAST_BAR_TIME);
+
+        // On earlier bars, time advances but last_bar_time is constant —
+        // so they must NOT be equal.
+        if (matchData.length > 1) {
+            expect(matchData[0].value).toBe(0);
+        }
+    });
+
+    it('rightTimeBar pattern (SMC-style projected future) lands past last_bar_time', async () => {
+        const { plots } = await makePineTS().run(`
+//@version=5
+indicator("rtb")
+rightTimeBar = last_bar_time + 20 * (time - time[1])
+plot(rightTimeBar, "rtb")
+`);
+        const data = plots['rtb'].data;
+        const lastEntry = data[data.length - 1];
+        // 20 weekly bars past last_bar_time = 20 * 7 * 86400 * 1000 ms = 12_096_000_000.
+        const expected = LAST_BAR_TIME + 20 * 7 * 86_400 * 1000;
+        expect(lastEntry.value).toBe(expected);
+        // Must be strictly in the future past the last bar.
+        expect(lastEntry.value).toBeGreaterThan(LAST_BAR_TIME);
+    });
+});

--- a/tests/namespaces/box/box.test.ts
+++ b/tests/namespaces/box/box.test.ts
@@ -443,4 +443,28 @@ if barstate.isfirst
         expect(bx.bgcolor).not.toBe('#2962ff');
         expect(bx.border_color).not.toBe('#2962ff');
     });
+
+    // Regression: `box.new(chart.point.new(time, na, price), …)` used to
+    // resolve to `left = NaN`/`right = NaN` because `_resolvePoint` returned
+    // x = NaN when the index slot was NaN (NaN !== undefined). Boxes
+    // existed but couldn't render at any specific bar.
+    it('box.new(chart.point.new(time, na, price), …) resolves to time-based left/right', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 30, new Date('2025-01-01').getTime(), new Date('2025-02-01').getTime());
+
+        const { plots } = await pineTS.run(`//@version=5
+indicator("probe", overlay = true)
+if barstate.isfirst
+    chart.point cp1 = chart.point.new(time, na, low)
+    chart.point cp2 = chart.point.new(time + 5*24*60*60*1000, na, low * 1.1)
+    box.new(cp1, cp2, xloc = xloc.bar_time, bgcolor = color.new(color.green, 80))
+`);
+        const bx = plots['__boxes__']?.data?.[0]?.value?.[0];
+        expect(bx).toBeDefined();
+        expect(bx.xloc).toBe('bt');
+        expect(typeof bx.left).toBe('number');
+        expect(typeof bx.right).toBe('number');
+        expect(Number.isNaN(bx.left)).toBe(false);
+        expect(Number.isNaN(bx.right)).toBe(false);
+        expect(bx.right).toBeGreaterThan(bx.left);
+    });
 });

--- a/tests/namespaces/line/line.test.ts
+++ b/tests/namespaces/line/line.test.ts
@@ -459,4 +459,49 @@ if barstate.isfirst
         expect(isNa(ln.color)).toBe(true);
         expect(ln.color).not.toBe('#2962ff');
     });
+
+    // Regression: `chart.point.new(time, na, price)` (idiomatic in TV-published
+    // indicators — e.g. SMC's drawStructure) used to resolve to `x = NaN`
+    // because `_resolvePoint` checked `point.index !== undefined` first
+    // (`NaN !== undefined` is true) and never fell through to the time path.
+    // Result: every line built from such chart points had x1=NaN/x2=NaN and
+    // didn't render in QFChart.
+    it('line.new(chart.point.new(time, na, price), …) resolves to time-based x1/x2', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 30, new Date('2025-01-01').getTime(), new Date('2025-02-01').getTime());
+        const { plots } = await pineTS.run(`//@version=5
+indicator("probe", overlay = true)
+if barstate.isfirst
+    chart.point cp1 = chart.point.new(time, na, low)
+    chart.point cp2 = chart.point.new(time + 5*24*60*60*1000, na, low)
+    line.new(cp1, cp2, xloc.bar_time, color = color.green)
+`);
+        const ln = plots['__lines__']?.data?.[0]?.value?.[0];
+        expect(ln).toBeDefined();
+        expect(ln.xloc).toBe('bt');
+        // x1/x2 must be real timestamps, not NaN.
+        expect(typeof ln.x1).toBe('number');
+        expect(typeof ln.x2).toBe('number');
+        expect(Number.isNaN(ln.x1)).toBe(false);
+        expect(Number.isNaN(ln.x2)).toBe(false);
+        expect(ln.x2).toBeGreaterThan(ln.x1);
+    });
+
+    // Symmetric: `chart.point.new(na, bar_index, price)` must resolve via
+    // the index path even when `time` slot is NaN.
+    it('line.new(chart.point.new(na, bar_index, price), …) resolves to index-based x1/x2', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', 30, new Date('2025-01-01').getTime(), new Date('2025-02-01').getTime());
+        const { plots } = await pineTS.run(`//@version=5
+indicator("probe", overlay = true)
+if barstate.isfirst
+    chart.point cp1 = chart.point.new(na, bar_index, low)
+    chart.point cp2 = chart.point.new(na, bar_index + 5, low)
+    line.new(cp1, cp2, xloc.bar_index, color = color.red)
+`);
+        const ln = plots['__lines__']?.data?.[0]?.value?.[0];
+        expect(ln).toBeDefined();
+        expect(ln.xloc).toBe('bi');
+        expect(Number.isNaN(ln.x1)).toBe(false);
+        expect(Number.isNaN(ln.x2)).toBe(false);
+        expect(ln.x2).toBe(ln.x1 + 5);
+    });
 });

--- a/tests/namespaces/request-lower-tf-fast-path.test.ts
+++ b/tests/namespaces/request-lower-tf-fast-path.test.ts
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: `request.security_lower_tf` used to spawn a full secondary
+ * PineTS instance and run the entire user script in it for every LTF
+ * bar in the chart's window — even when the captured expression was a
+ * trivially-pure price tuple like `[open, high, low, close, volume]`,
+ * the most common LTF pattern (~90% of footprint / volume-profile /
+ * structural-leg-profiler indicators).
+ *
+ * The fast path detects bare-builtin expressions at the runtime entry
+ * (via the original Series identity recorded by `request.param`) and
+ * synthesises the secondary's `params[expression_name]` directly from
+ * the LTF candle stream — no transpile, no script execution, no
+ * per-LTF-bar shifting / drawing-helper allocation in the secondary.
+ *
+ * Captured-expression values must match what the slow path would have
+ * produced (when the slow path also produces consistent values), so
+ * this test verifies a non-trivial subset of the fast-path output
+ * against the LTF candles read directly from the same provider.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+describe('request.security_lower_tf fast path for pure-builtin expressions', () => {
+    const chartStart = new Date('2018-12-10').getTime();
+    const chartEnd = new Date('2019-01-21').getTime();
+
+    it('takes the fast path for `close` and produces correct values', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, plotchar } = context.pine;
+            const res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            // Sum across the LTF slice for each chart bar — deterministic
+            // and lets us assert against the underlying daily candles.
+            let sum = 0.0;
+            const sz = res?.size?.() ?? 0;
+            for (let i = 0; i < sz; i++) sum += res.get(i);
+            plotchar(sum, 'sum');
+            plotchar(sz, 'sz');
+        });
+
+        // Cache shape: fast-path entries set `_fastPath: true` and
+        // `pineTS: null`. This is the contract the fast-path streaming
+        // refresh code depends on.
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        expect(ltfKey).toBeDefined();
+        const cached = (context as any).cache[ltfKey!];
+        expect(cached._fastPath).toBe(true);
+        expect(cached.pineTS).toBeNull();
+        expect(cached._fastPathArgs).toBeDefined();
+        expect(cached._fastPathArgs.builtinExpr).toBeDefined();
+        expect(cached._fastPathArgs.builtinExpr.kind).toBe('series');
+        expect(cached._fastPathArgs.builtinExpr.builtinNames).toEqual(['close']);
+
+        // The fast-path stub holds openTime/closeTime arrays + the
+        // params slot. No `pine`, no `plots` (those are for full Contexts).
+        const sec = cached.context;
+        expect(sec.data.openTime.data.length).toBeGreaterThan(0);
+        expect(sec.data.closeTime.data.length).toBe(sec.data.openTime.data.length);
+        expect(sec.params).toBeDefined();
+        const expressionParam = Object.keys(sec.params)[0];
+        expect(sec.params[expressionParam].length).toBe(sec.data.openTime.data.length);
+
+        // Captured sums on the chart bars must be > 0 (sanity that the
+        // values flowed through to the user-visible scalar).
+        const sumData = (context as any).plots['sum']?.data ?? [];
+        expect(sumData.length).toBeGreaterThan(0);
+        const sumNonZero = sumData.filter((d: any) => typeof d.value === 'number' && d.value > 0);
+        expect(sumNonZero.length).toBeGreaterThan(0);
+    });
+
+    it('takes the fast path for `[open, high, low, close, volume]` tuple', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const context = await pineTS.run(async (context) => {
+            const { open, high, low, close, volume } = context.data;
+            const { request, plotchar } = context.pine;
+            const r = await request.security_lower_tf('BTCUSDC', 'D', [open, high, low, close, volume]);
+            // r is a 5-element array of PineArrayObjects per chart bar.
+            plotchar(r?.[0]?.size?.() ?? 0, 'sz');
+        });
+
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const cached = (context as any).cache[ltfKey!];
+        expect(cached._fastPath).toBe(true);
+        expect(cached._fastPathArgs.builtinExpr.kind).toBe('tuple');
+        expect(cached._fastPathArgs.builtinExpr.builtinNames).toEqual(['open', 'high', 'low', 'close', 'volume']);
+
+        // params slot holds an array of 5-tuples (one per LTF bar).
+        const sec = cached.context;
+        const expressionParam = Object.keys(sec.params)[0];
+        const values = sec.params[expressionParam];
+        expect(values.length).toBeGreaterThan(0);
+        expect(Array.isArray(values[0])).toBe(true);
+        expect(values[0].length).toBe(5); // O, H, L, C, V
+        // Sanity: H >= L on a real candle.
+        expect(values[0][1]).toBeGreaterThanOrEqual(values[0][2]);
+    });
+
+    it('falls back to the slow path when the expression is NOT a pure builtin', async () => {
+        // ta.sma is stateful — the secondary needs to actually run the
+        // user script to compute it bar-by-bar. The fast path must NOT
+        // claim this case (silently producing wrong values).
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, ta, plotchar } = context.pine;
+            const res = await request.security_lower_tf('BTCUSDC', 'D', ta.sma(close, 3));
+            plotchar(res?.size?.() ?? 0, 'sz');
+        });
+
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const cached = (context as any).cache[ltfKey!];
+        // Slow path: no fast-path markers.
+        expect(cached._fastPath).toBeUndefined();
+        // A real PineTS instance was constructed for the slow secondary.
+        expect(cached.pineTS).not.toBeNull();
+    });
+
+    it('falls back to the slow path when expression is a tuple containing a non-builtin', async () => {
+        // [close, ta.sma(close, 3)] mixes a builtin with a derived
+        // series — the fast path must reject the whole tuple.
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, ta, plotchar } = context.pine;
+            const r = await request.security_lower_tf('BTCUSDC', 'D', [close, ta.sma(close, 3)]);
+            plotchar(r?.[0]?.size?.() ?? 0, 'sz');
+        });
+
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const cached = (context as any).cache[ltfKey!];
+        expect(cached._fastPath).toBeUndefined();
+    });
+
+    it('fast path and slow path produce identical values for the same `close` expression', async () => {
+        // Run the same probe twice — once with `close` (fast path) and
+        // once with `ta.sma(close, 1)` (slow path; SMA-1 IS just close,
+        // so values must agree). Compare per-chart-bar sums.
+        const makePineTS = () => new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+
+        const fast = await makePineTS().run(async (context) => {
+            const { close } = context.data;
+            const { request, plotchar } = context.pine;
+            const res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            let s = 0.0;
+            const sz = res?.size?.() ?? 0;
+            for (let i = 0; i < sz; i++) s += res.get(i);
+            plotchar(s, 'sum');
+        });
+
+        const slow = await makePineTS().run(async (context) => {
+            const { close } = context.data;
+            const { request, ta, plotchar } = context.pine;
+            const res = await request.security_lower_tf('BTCUSDC', 'D', ta.sma(close, 1));
+            let s = 0.0;
+            const sz = res?.size?.() ?? 0;
+            for (let i = 0; i < sz; i++) s += res.get(i);
+            plotchar(s, 'sum');
+        });
+
+        const fastData = (fast as any).plots['sum'].data;
+        const slowData = (slow as any).plots['sum'].data;
+        expect(fastData.length).toEqual(slowData.length);
+        for (let i = 0; i < fastData.length; i++) {
+            const f = fastData[i].value;
+            const s = slowData[i].value;
+            // Allow tiny floating-point tolerance for the cumulative sum.
+            expect(Math.abs(f - s) < 0.001 || (Number.isNaN(f) && Number.isNaN(s)),
+                `fast vs slow mismatch at bar ${i}: fast=${f} slow=${s}`).toBe(true);
+        }
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // UDT-of-builtins fast path
+    // ─────────────────────────────────────────────────────────────────────
+    it('takes the UDT fast path when every field default is a bare builtin', async () => {
+        // type candle { float o = open; float h = high; float l = low;
+        //               float c = close; float v = volume; }
+        // c = candle.new() — every field defaults to a price builtin.
+        // Passing `c` to security_lower_tf should hit the UDT fast path.
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const code = `
+//@version=5
+indicator("udt-fast")
+type candle
+    float o = open
+    float h = high
+    float l = low
+    float c = close
+    float v = volume
+mycandle = candle.new()
+ltf = request.security_lower_tf(syminfo.tickerid, "D", mycandle)
+plot(ltf.size(), "sz")
+`;
+        const context: any = await pineTS.run(code);
+        const cacheKeys = Object.keys(context.cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        expect(ltfKey, 'cache entry expected').toBeDefined();
+        const cached = context.cache[ltfKey!];
+        expect(cached._fastPath).toBe(true);
+        expect(cached._fastPathArgs.builtinExpr.kind).toBe('udt');
+        expect(cached._fastPathArgs.builtinExpr.fieldNames).toEqual(['o', 'h', 'l', 'c', 'v']);
+        expect(cached._fastPathArgs.builtinExpr.builtinNames).toEqual(['open', 'high', 'low', 'close', 'volume']);
+
+        // Each captured per-LTF-bar value must be a PineTypeObject of
+        // the same UDT shape, with fields populated from the candle.
+        const expressionParam = Object.keys(cached.context.params)[0];
+        const values = cached.context.params[expressionParam];
+        expect(values.length).toBeGreaterThan(0);
+        const first = values[0];
+        expect(first).toBeDefined();
+        // Field names match the type definition.
+        expect(first.o).toBeDefined();
+        expect(first.h).toBeDefined();
+        expect(first.l).toBeDefined();
+        expect(first.c).toBeDefined();
+        expect(first.v).toBeDefined();
+        // Sanity: high >= low on a real candle.
+        expect(first.h).toBeGreaterThanOrEqual(first.l);
+    });
+
+    it('falls back to the slow path when a UDT has any non-builtin default', async () => {
+        // The type has 5 builtin defaults + 1 user-derived default
+        // (`extra = ta.sma(close, 3)`). The detector must reject the
+        // whole UDT and use the slow path.
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const code = `
+//@version=5
+indicator("udt-mixed")
+type candle
+    float o = open
+    float extra = ta.sma(close, 3)
+mycandle = candle.new()
+ltf = request.security_lower_tf(syminfo.tickerid, "D", mycandle)
+plot(ltf.size(), "sz")
+`;
+        const context: any = await pineTS.run(code);
+        const cacheKeys = Object.keys(context.cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const cached = context.cache[ltfKey!];
+        // Slow path: no fast-path markers.
+        expect(cached._fastPath).toBeUndefined();
+        expect(cached.pineTS).not.toBeNull();
+    });
+
+    it('falls back to the slow path when a UDT has any field without a default', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+        const code = `
+//@version=5
+indicator("udt-no-default")
+type candle
+    float o = open
+    float h
+mycandle = candle.new()
+ltf = request.security_lower_tf(syminfo.tickerid, "D", mycandle)
+plot(ltf.size(), "sz")
+`;
+        const context: any = await pineTS.run(code);
+        const cacheKeys = Object.keys(context.cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const cached = context.cache[ltfKey!];
+        // Slow path: the field `h` has no default → can't fast-path.
+        expect(cached._fastPath).toBeUndefined();
+    });
+});

--- a/tests/namespaces/request-lower-tf-window.test.ts
+++ b/tests/namespaces/request-lower-tf-window.test.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: request.security_lower_tf used to subtract a flat 30-day
+ * buffer from the secondary context's start date. The buffer was lifted
+ * from the higher-timeframe `security` path (where it's needed for
+ * indicator warmup), but for LOWER-timeframe security the secondary's
+ * window is bounded by the chart's own window — every LTF bar that
+ * contributes to a chart bar lies inside that chart bar's
+ * [openTime, closeTime]. The 30-day buffer caused the secondary to
+ * load and iterate ~43,000 extra 1-minute bars before the main loop
+ * could advance past bar 0, manifesting as a multi-minute hang on
+ * small charts (e.g. 50 bars on 5m running Structural-Leg-Profiler).
+ *
+ * Fix: drop the buffer, use the chart's earliest openTime directly.
+ *
+ * This test verifies the bounded data window without going to the
+ * network — it uses Mock weekly data with a daily LTF request, then
+ * inspects the cached secondary context.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+describe('request.security_lower_tf window bounding', () => {
+    it('secondary context is bounded by the chart window — no historical buffer', async () => {
+        // Chart: BTCUSDC weekly, ~6 bars (Dec 10 → Jan 21 ≈ 42 days).
+        const chartStart = new Date('2018-12-10').getTime();
+        const chartEnd = new Date('2019-01-21').getTime();
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null, chartStart, chartEnd);
+
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { plotchar, request } = context.pine;
+            const res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            plotchar(res, '_p');
+        });
+
+        // The secondary context is cached on the main context. Find it.
+        const cacheKeys = Object.keys((context as any).cache || {});
+        expect(cacheKeys.length).toBeGreaterThan(0);
+        const ltfCacheKey = cacheKeys.find((k) => k.includes('_lower'));
+        expect(ltfCacheKey, 'expected a _lower cache entry, got: ' + cacheKeys.join(',')).toBeDefined();
+        const sec = (context as any).cache[ltfCacheKey!].context;
+
+        // Chart window is ~42 days. With the bug (30-day buffer), the
+        // secondary would load roughly 42 + 30 = ~72 daily bars. After
+        // the fix it should be bounded by the chart's window, i.e. <= ~42.
+        const secLen = sec.data.close.data.length;
+        expect(secLen, `secondary daily-bar count should be bounded by chart window`).toBeLessThanOrEqual(45);
+        // Sanity floor — must have actually loaded the LTF data we need.
+        expect(secLen).toBeGreaterThanOrEqual(28);
+
+        // Also: the earliest secondary bar must NOT be earlier than the
+        // chart's earliest bar (ie. no buffer applied).
+        const secFirstOpen = sec.data.openTime.data[0];
+        expect(secFirstOpen, 'secondary should not start before the chart').toBeGreaterThanOrEqual(chartStart);
+    });
+});

--- a/tests/namespaces/request-lower-tf-window.test.ts
+++ b/tests/namespaces/request-lower-tf-window.test.ts
@@ -47,7 +47,10 @@ describe('request.security_lower_tf window bounding', () => {
         // Chart window is ~42 days. With the bug (30-day buffer), the
         // secondary would load roughly 42 + 30 = ~72 daily bars. After
         // the fix it should be bounded by the chart's window, i.e. <= ~42.
-        const secLen = sec.data.close.data.length;
+        // We read openTime/closeTime — those are populated by both the
+        // slow path (full pineTS.run) and the fast path (pure-builtin
+        // shortcut), so this assertion is path-agnostic.
+        const secLen = sec.data.openTime.data.length;
         expect(secLen, `secondary daily-bar count should be bounded by chart window`).toBeLessThanOrEqual(45);
         // Sanity floor — must have actually loaded the LTF data we need.
         expect(secLen).toBeGreaterThanOrEqual(28);

--- a/tests/namespaces/request.test.ts
+++ b/tests/namespaces/request.test.ts
@@ -828,6 +828,87 @@ plot(volume, "_v")
         expect(secHigh[0].value).toBeCloseTo(8752.45, 1);
         expect(secLow[0].value).toBeCloseTo(7441.21, 1);
     }, 30000);
+
+    // Regression: array-literal arguments to request.security_lower_tf used
+    // to only rewrite bare-Identifier elements. Nested CallExpressions like
+    // `ta.sma(volume, maLenInput)` passed through untouched, so the global
+    // `let maLenInput` reference inside leaked bare and threw
+    // "ReferenceError: maLenInput is not defined" at runtime.
+    it('request.security_lower_tf accepts a tuple with nested ta.sma(volume, globalLet)', async () => {
+        const sDate = new Date('2024-06-01').getTime();
+        const eDate = new Date('2024-06-15').getTime();
+        const warmup = 365 * 24 * 60 * 60 * 1000;
+
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', 'D', null, sDate - warmup);
+
+        // Must NOT throw "maLenInput is not defined" during the run.
+        const { plots } = await pineTS.run(
+`//@version=6
+indicator("LTF nested call")
+int maLenInput = input.int(20, "MA Length", minval = 5)
+[ltfV, ltfVma] = request.security_lower_tf(syminfo.tickerid, "60", [volume, ta.sma(volume, maLenInput)])
+plot(not na(ltfV) ? ltfV.size() : 0,   "_n")
+plot(not na(ltfVma) ? ltfVma.size() : 0, "_m")
+`);
+
+        const sizes = plots['_n']?.data || [];
+        const matchedSizes = plots['_m']?.data || [];
+        // Both arrays must populate (the LTF "60" inside a "D" chart yields
+        // multiple LTF bars per chart bar — non-zero on most days).
+        const inWindow = sizes.filter((e: any) => e.time >= sDate && e.time <= eDate);
+        expect(inWindow.length).toBeGreaterThan(0);
+        // At least one bar in the window must report a non-empty LTF tuple
+        // for both raw and ta.sma(...) channels.
+        expect(inWindow.some((e: any) => e.value > 0)).toBe(true);
+        const matchedInWindow = matchedSizes.filter((e: any) => e.time >= sDate && e.time <= eDate);
+        expect(matchedInWindow.some((e: any) => e.value > 0)).toBe(true);
+    }, 60000);
+
+    // Regression: cross-symbol request at the chart's timeframe must fetch
+    // the requested symbol's data, not return the chart symbol's expression
+    // verbatim. The same-TF shortcut used to fire on timeframe match alone
+    // and skip building the secondary context for the requested ticker —
+    // returning BTC's close for an `request.security("ETHUSDC", ...)` call.
+    it('request.security("ETHUSDC", chart_tf, close) returns ETH close, not chart symbol close', async () => {
+        const sDate = new Date('2024-06-01').getTime();
+        const eDate = new Date('2024-08-15').getTime();
+        const warmup = 365 * 24 * 60 * 60 * 1000;
+
+        const pineTS = new PineTS(Provider.Binance, 'BTCUSDC', 'W', null, sDate - warmup);
+
+        const { plots } = await pineTS.run(
+`//@version=6
+indicator("Cross-symbol same-TF")
+float eth_close_chartTF = request.security("ETHUSDC", timeframe.period, close)
+float chart_close_self  = request.security(syminfo.tickerid, timeframe.period, close)
+plot(close,            "_btc")
+plot(eth_close_chartTF, "_eth")
+plot(chart_close_self,  "_self")
+`);
+
+        const btc  = extractPlot(plots, '_btc',  sDate, eDate);
+        const eth  = extractPlot(plots, '_eth',  sDate, eDate);
+        const self_ = extractPlot(plots, '_self', sDate, eDate);
+
+        expect(btc.length).toBeGreaterThan(0);
+        expect(eth.length).toBe(btc.length);
+        expect(self_.length).toBe(btc.length);
+
+        // Spot check: 2024-06 BTC weekly is ~$60-70k, ETH weekly is ~$3-4k.
+        // The requested ETH value must NOT equal BTC's close on any bar
+        // (which is what the bug produced).
+        for (let i = 0; i < btc.length; i++) {
+            // ETH weekly close in this window is < $5k; BTC weekly close > $50k.
+            // So an order-of-magnitude separation makes the assertion robust to
+            // small price drift.
+            expect(eth[i].value).toBeLessThan(10000);
+            expect(btc[i].value).toBeGreaterThan(50000);
+            expect(eth[i].value).not.toBeCloseTo(btc[i].value, -2);
+
+            // Same-symbol same-TF shortcut still valid: must equal chart's close.
+            expect(self_[i].value).toBeCloseTo(btc[i].value, 2);
+        }
+    }, 60000);
 });
 
 /**

--- a/tests/namespaces/silent-in-secondary.test.ts
+++ b/tests/namespaces/silent-in-secondary.test.ts
@@ -43,10 +43,12 @@ describe('silentInSecondary — side-effect helpers no-op in secondary contexts'
 
         const context = await pineTS.run(async (context) => {
             const { close } = context.data;
-            const { request, line, label, box, polyline } = context.pine;
-            // Pull a daily series via security_lower_tf; the user script
-            // (this one) re-runs as the secondary's body.
-            const _res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            const { request, line, label, box, polyline, ta } = context.pine;
+            // Pull a daily series via security_lower_tf; we wrap close in
+            // ta.sma so the captured expression is NOT a pure builtin —
+            // that forces the slow-path secondary (full user-script
+            // execution), which is what the silencing decorator targets.
+            const _res = await request.security_lower_tf('BTCUSDC', 'D', ta.sma(close, 3));
             // These are drawing side effects — when this body runs in the
             // secondary they should all be silenced.
             line.new(0, 0, 1, 1);
@@ -83,8 +85,9 @@ describe('silentInSecondary — side-effect helpers no-op in secondary contexts'
 
         const context = await pineTS.run(async (context) => {
             const { close } = context.data;
-            const { request, plot, plotchar } = context.pine;
-            const _res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            const { request, plot, plotchar, ta } = context.pine;
+            // Force slow-path secondary by wrapping close in ta.sma.
+            const _res = await request.security_lower_tf('BTCUSDC', 'D', ta.sma(close, 3));
             plot(close, 'main_plot');
             plotchar(close, 'main_plotchar');
         });
@@ -116,8 +119,9 @@ describe('silentInSecondary — side-effect helpers no-op in secondary contexts'
 
         const context = await pineTS.run(async (context) => {
             const { close } = context.data;
-            const { request, alert } = context.pine;
-            const _res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            const { request, alert, ta } = context.pine;
+            // Force slow-path secondary by wrapping close in ta.sma.
+            const _res = await request.security_lower_tf('BTCUSDC', 'D', ta.sma(close, 3));
             alert.any('fire');
         });
 

--- a/tests/namespaces/silent-in-secondary.test.ts
+++ b/tests/namespaces/silent-in-secondary.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: side-effect-only operations executed inside a secondary
+ * context (the auxiliary PineTS instance that `request.security` /
+ * `request.security_lower_tf` spawns) used to do their full work — push
+ * to plot streams, allocate drawing objects, fire alerts, etc. — even
+ * though the secondary's only observable output is the single captured
+ * expression read via `secContext.params[...]`. On large LTF/HTF gaps
+ * the redundant work dominated runtime: a 50-bar daily chart running
+ * Structural-Leg-Profiler at 1m secondary resolution would build /
+ * mutate ~72k drawing objects per chart bar before the main loop could
+ * advance.
+ *
+ * Fix: the @silentInSecondary method decorator makes drawing
+ * constructors / setters / deletes, plot-family functions, and alert
+ * helpers no-op when invoked on a secondary context. The captured
+ * value is unchanged (the secondary still runs the rest of the user
+ * script and its `params[...]` capture happens on the same call site
+ * with the same value).
+ *
+ * `log.*` is intentionally NOT silenced — log.info()/warning()/error()
+ * are diagnostic and should remain visible from secondaries.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+describe('silentInSecondary — side-effect helpers no-op in secondary contexts', () => {
+    // We exercise the secondary-vs-primary divergence by running the same
+    // script first in the main context and then asking
+    // `request.security_lower_tf` to evaluate an expression in a secondary
+    // (same-symbol, same-timeframe, daily). The secondary IS spawned and
+    // the user script DOES run end-to-end inside it — but every drawing /
+    // plot / alert call inside should be silenced, leaving the
+    // captured-expression value unchanged.
+
+    it('drawing helpers no-op when context.isSecondaryContext is true', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null,
+            new Date('2018-12-10').getTime(),
+            new Date('2019-01-21').getTime());
+
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, line, label, box, polyline } = context.pine;
+            // Pull a daily series via security_lower_tf; the user script
+            // (this one) re-runs as the secondary's body.
+            const _res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            // These are drawing side effects — when this body runs in the
+            // secondary they should all be silenced.
+            line.new(0, 0, 1, 1);
+            label.new(0, 0, 'x');
+            box.new(0, 0, 1, 1);
+            polyline.new([]);
+        });
+
+        // Sanity: the main context DID accumulate drawings (these calls
+        // ran in the primary, where the decorator does nothing).
+        const mainLines = (context as any).pine.line.all;
+        const mainLabels = (context as any).pine.label.all;
+        const mainBoxes = (context as any).pine.box.all;
+        expect(mainLines.length).toBeGreaterThan(0);
+        expect(mainLabels.length).toBeGreaterThan(0);
+        expect(mainBoxes.length).toBeGreaterThan(0);
+
+        // The secondary context cached on the main: its drawing arrays
+        // must be empty because every `*.new()` in there short-circuited.
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        expect(ltfKey).toBeDefined();
+        const sec = (context as any).cache[ltfKey!].context;
+        expect(sec.pine.line.all.length).toBe(0);
+        expect(sec.pine.label.all.length).toBe(0);
+        expect(sec.pine.box.all.length).toBe(0);
+        expect(sec.pine.polyline.all.length).toBe(0);
+    });
+
+    it('plot helpers no-op when context.isSecondaryContext is true', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null,
+            new Date('2018-12-10').getTime(),
+            new Date('2019-01-21').getTime());
+
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, plot, plotchar } = context.pine;
+            const _res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            plot(close, 'main_plot');
+            plotchar(close, 'main_plotchar');
+        });
+
+        // Main context: plots were registered.
+        const mainKeys = Object.keys((context as any).plots);
+        expect(mainKeys.includes('main_plot')).toBe(true);
+        expect(mainKeys.includes('main_plotchar')).toBe(true);
+
+        // Secondary context: those same titles must NOT appear because
+        // plot/plotchar were silenced. (The framework's internal
+        // __labels__/__lines__/etc. plot keys are pre-allocated and may
+        // exist; we check user-named entries specifically.)
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const sec = (context as any).cache[ltfKey!].context;
+        const secKeys = Object.keys(sec.plots);
+        expect(secKeys.includes('main_plot')).toBe(false);
+        expect(secKeys.includes('main_plotchar')).toBe(false);
+    });
+
+    it('alert helpers no-op when context.isSecondaryContext is true', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null,
+            new Date('2018-12-10').getTime(),
+            new Date('2019-01-21').getTime());
+
+        // Force every-bar alert mode so the alert call always tries to fire.
+        pineTS.setAlertMode('all');
+
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, alert } = context.pine;
+            const _res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            alert.any('fire');
+        });
+
+        // Main: alerts accumulated.
+        expect((context as any).alerts.length).toBeGreaterThan(0);
+        // Secondary: silenced.
+        const cacheKeys = Object.keys((context as any).cache || {});
+        const ltfKey = cacheKeys.find((k) => k.includes('_lower'));
+        const sec = (context as any).cache[ltfKey!].context;
+        expect(sec.alerts.length).toBe(0);
+    });
+
+    it('captured expression value is unchanged by silencing', async () => {
+        // The whole point: silencing the side effects must not change
+        // what `request.security_lower_tf` returns.
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'W', null,
+            new Date('2018-12-10').getTime(),
+            new Date('2019-02-04').getTime());
+
+        const context = await pineTS.run(async (context) => {
+            const { close } = context.data;
+            const { request, line, label, plotchar } = context.pine;
+            const res = await request.security_lower_tf('BTCUSDC', 'D', close);
+            // Capture the LTF array's size as a scalar plotchar — easier
+            // to assert than the array itself.
+            const sz = res && res.size ? res.size() : 0;
+            plotchar(sz, 'sz');
+            // Side effects: silenced in the secondary, kept in the main.
+            line.new(0, 0, 1, 1);
+            label.new(0, 0, 'x');
+        });
+
+        // The captured `res` should still have valid data — Layer 1 +
+        // decorator combined shouldn't alter the value, only suppress
+        // side effects.
+        const szData = (context as any).plots['sz']?.data ?? [];
+        expect(szData.length).toBeGreaterThan(0);
+        // At least one chart bar must have a non-zero LTF size (the
+        // request returned data).
+        const hasNonZero = szData.some((d: any) => typeof d.value === 'number' && d.value > 0);
+        expect(hasNonZero).toBe(true);
+    });
+});

--- a/tests/transpiler/multiline-continuation.test.ts
+++ b/tests/transpiler/multiline-continuation.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: multi-line binary-operator continuation inside a function
+ * or method body used to truncate the body. The lexer emitted an INDENT
+ * for the (visually deeper) continuation line because it tracks indent
+ * via raw column counts. When the next real statement returned to the
+ * function's body indent, the matching DEDENT was interpreted by the
+ * block parser as "the function body just ended" — every subsequent
+ * statement escaped to the top scope and referenced now-undefined
+ * function parameters.
+ *
+ * Discovered while investigating Structural-Leg-Profiler-LuxAlgo, whose
+ * `method draw(int startBar, int endBar, ...)` builds a multi-line
+ * `summaryText` via `+` continuation, then immediately uses `startBar`
+ * / `endBar` to compute `midBar` and place a label. Pre-fix, those last
+ * three lines escaped the method body and crashed at runtime with
+ * "startBar is not defined".
+ *
+ * Fix: the lexer suppresses INDENT/DEDENT emission on lines whose most
+ * recently emitted non-NEWLINE/non-COMMENT token is a continuation
+ * token — any binary/assignment/ternary OPERATOR (except `=>`, which
+ * opens a new block), COMMA, COLON, or the `and` / `or` keyword.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { transpile } from '../../src/transpiler/index';
+import { pineToJS } from '../../src/transpiler/pineToJS/pineToJS.index';
+import { PineTS, Provider } from 'index';
+
+const makePineTS = () =>
+    new PineTS(Provider.Mock, 'BTCUSDC', 'D', null,
+        new Date('2019-01-01').getTime(),
+        new Date('2019-01-15').getTime());
+
+describe('Multi-line operator continuation inside function bodies', () => {
+    // ─────────────────────────────────────────────────────────────────────
+    // Codegen — the function body must contain ALL of its statements.
+    // ─────────────────────────────────────────────────────────────────────
+    it('keeps statements after a multi-line `+` continuation inside the function body', () => {
+        const code = `
+//@version=5
+indicator("x")
+f(int x) =>
+    int a = x + 1
+    string s = "p1: " + str.tostring(x) +
+               "p2: " + str.tostring(a)
+    int b = a + 1
+    b
+plot(f(5))
+`;
+        // Phase-1 view is the cleanest place to assert structural shape.
+        const r = pineToJS(code);
+        expect(r.success).toBe(true);
+        const js = r.code as string;
+        // The `b` assignment + return must remain inside `function f(...)`.
+        // A simple structural check: between `function f(x) {` and the
+        // matching `}` we must see the continuation-following lines.
+        const fnStart = js.indexOf('function f(x) {');
+        expect(fnStart).toBeGreaterThanOrEqual(0);
+        const fnEnd = js.indexOf('}', fnStart);
+        expect(fnEnd).toBeGreaterThan(fnStart);
+        const body = js.slice(fnStart, fnEnd);
+        expect(body).toContain('let b = a + 1');
+        expect(body).toMatch(/return\s+b|^\s*b\s*;?\s*$/m);
+    });
+
+    it('keeps statements after a multi-line continuation inside a `method` body', () => {
+        // Direct shape from Structural-Leg-Profiler.
+        const code = `
+//@version=6
+indicator("x")
+type T
+    float v
+method draw(T this, int startBar, int endBar) =>
+    string summary = "L: " + str.tostring(startBar) + " " +
+                     "R: " + str.tostring(endBar)
+    int midBar = int(math.round((startBar + endBar) / 2))
+    midBar
+T.new(0).draw(10, 30)
+`;
+        const js = transpile(code).toString();
+        // The `midBar` computation references the method parameters; if
+        // it had escaped to top-level, the transpiler would emit it
+        // outside the function and the bare identifiers would be
+        // undefined at runtime.
+        const fnStart = js.indexOf('function $M_draw(self, startBar, endBar)');
+        expect(fnStart).toBeGreaterThanOrEqual(0);
+        const fnEnd = js.indexOf('  $M_draw.__pineMethod__', fnStart);
+        expect(fnEnd).toBeGreaterThan(fnStart);
+        const body = js.slice(fnStart, fnEnd);
+        expect(body).toMatch(/midBar/);
+        expect(body).toMatch(/math\.round/);
+    });
+
+    it('does NOT swallow indent for `=>` (still opens a new block)', () => {
+        // `=>` ends with an OPERATOR token but is the function-body opener,
+        // not a continuation — so the next line must still emit INDENT.
+        // Without this exclusion the body is mis-parsed as if it were on
+        // the header line and the parser breaks immediately.
+        const code = `
+//@version=5
+indicator("x")
+f(int x) =>
+    int a = x + 1
+    a
+plot(f(5))
+`;
+        const r = pineToJS(code);
+        expect(r.success).toBe(true);
+        expect(r.code).toContain('function f(x) {');
+        expect(r.code).toMatch(/let a = x \+ 1/);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Runtime — the bug surfaced as `ReferenceError: <param> is not defined`
+    // when the escaped statements ran at top level.
+    // ─────────────────────────────────────────────────────────────────────
+    it('runtime: function returns the right value after a multi-line continuation', async () => {
+        const code = `
+//@version=5
+indicator("x")
+
+probe(int startBar, int endBar) =>
+    string summary = "L: " + str.tostring(startBar) + " " +
+                     "R: " + str.tostring(endBar)   + " " +
+                     "M: " + str.tostring((startBar + endBar) / 2)
+    int mid = int(math.round((startBar + endBar) / 2))
+    int sum = startBar + endBar
+    [str.length(summary), mid, sum]
+
+[lenV, midV, sumV] = probe(10, 30)
+
+plot(lenV, "lenV")
+plot(midV, "midV")
+plot(sumV, "sumV")
+`;
+        const { plots } = await makePineTS().run(code);
+        const last = (k: string) => {
+            const d = plots[k]?.data;
+            return d?.[d.length - 1].value;
+        };
+        expect(last('lenV')).toBeGreaterThan(0);
+        expect(last('midV')).toEqual(20);
+        expect(last('sumV')).toEqual(40);
+    });
+
+    it('runtime: comma-continuation in a function-arg list also stays inside the body', async () => {
+        // Same mechanism, different trigger: a function call argument
+        // list spanning multiple lines via comma. Comma is also a
+        // continuation token in the lexer fix.
+        const code = `
+//@version=5
+indicator("x")
+
+probe(int a, int b, int c) =>
+    int s = math.max(a,
+                     b,
+                     c)
+    int t = a + b + c
+    [s, t]
+
+[mx, sm] = probe(1, 5, 3)
+
+plot(mx, "mx")
+plot(sm, "sm")
+`;
+        const { plots } = await makePineTS().run(code);
+        const last = (k: string) => {
+            const d = plots[k]?.data;
+            return d?.[d.length - 1].value;
+        };
+        expect(last('mx')).toEqual(5);
+        expect(last('sm')).toEqual(9);
+    });
+});

--- a/tests/transpiler/not-and-fn-param.test.ts
+++ b/tests/transpiler/not-and-fn-param.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: `not paramA and not paramB` (and the equivalent `or`-form,
+ * any nesting under a logical/binary/conditional/unary expression) used
+ * to skip the function-parameter Series-unwrap inside arrow-function
+ * bodies. The transpiler emitted `!a && !b` where `a` / `b` are bool
+ * function parameters — i.e. `Series` objects at runtime. Since `Series`
+ * is truthy in JS, `!Series === false`, so the entire expression
+ * collapsed to `false` and any branch gated on it was unreachable.
+ *
+ * This bit Smart-Money-Concepts (LuxAlgo) hard: the swing-pivot branch
+ * `if not equalHighLow and not internal` never executed, leaving every
+ * `trailing.*` field na/undefined. Downstream `chart.point.new(rightTimeBar,
+ * na, trailing.top)` produced NaN coords, so the Strong Low / Weak High
+ * labels and lines never rendered.
+ *
+ * Three call sites had the same gap:
+ *   1. `transformVariableDeclaration` walker — for `direct = not a and not b`
+ *   2. `transformExpression`            walker — for `if not a and not b`
+ *   3. The arrow-function-body walker had no IfStatement.test traversal at
+ *      all, so step 2's walker was never invoked for if-tests inside fn bodies.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { transpile } from '../../src/transpiler/index';
+import { PineTS, Provider } from 'index';
+
+const makePineTS = () =>
+    new PineTS(
+        Provider.Mock,
+        'BTCUSDC',
+        'D',
+        null,
+        new Date('2019-01-01').getTime(),
+        new Date('2019-01-15').getTime(),
+    );
+
+describe('`not param` inside logical expressions in fn bodies', () => {
+    // ─────────────────────────────────────────────────────────────────────
+    // Codegen shape
+    // ─────────────────────────────────────────────────────────────────────
+    it('unwraps both operands of `not a and not b` in a variable-declaration RHS', () => {
+        const code = `
+//@version=5
+indicator("x")
+f(bool a = false, bool b = false) =>
+    direct = not a and not b
+    direct
+f(false, false)
+`;
+        const js = transpile(code).toString();
+        expect(js).toContain('!$.get(a, 0) && !$.get(b, 0)');
+        // Defensive: must NOT emit the bare-identifier form.
+        expect(js).not.toMatch(/\$\.init\([^,]+,\s*!a\s*&&\s*!b\)/);
+    });
+
+    it('unwraps both operands of `not a and not b` inside an if-test in a fn body', () => {
+        const code = `
+//@version=5
+indicator("x")
+f(bool a = false, bool b = false) =>
+    int v = 0
+    if not a and not b
+        v := 1
+    v
+f(false, false)
+`;
+        const js = transpile(code).toString();
+        expect(js).toContain('if (!$.get(a, 0) && !$.get(b, 0))');
+        expect(js).not.toMatch(/if\s*\(\s*!a\s*&&\s*!b\s*\)/);
+    });
+
+    it('unwraps both operands of `not a or not b` (or-form)', () => {
+        const code = `
+//@version=5
+indicator("x")
+f(bool a = false, bool b = false) =>
+    or_form = not a or not b
+    or_form
+f(false, true)
+`;
+        const js = transpile(code).toString();
+        expect(js).toContain('!$.get(a, 0) || !$.get(b, 0)');
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Runtime behaviour — the actual bite
+    // ─────────────────────────────────────────────────────────────────────
+    it('runtime: `not a and not b` evaluates correctly across all four bool combinations', async () => {
+        const code = `
+//@version=5
+indicator("not-and runtime", overlay=false)
+
+probe(bool a, bool b) =>
+    direct = not a and not b
+    if_taken = 0
+    if not a and not b
+        if_taken := 1
+    [direct ? 1 : 0, if_taken]
+
+[d_ff, b_ff] = probe(false, false)
+[d_tf, b_tf] = probe(true,  false)
+[d_ft, b_ft] = probe(false, true)
+[d_tt, b_tt] = probe(true,  true)
+
+plot(d_ff, "d_ff")
+plot(b_ff, "b_ff")
+plot(d_tf, "d_tf")
+plot(d_ft, "d_ft")
+plot(d_tt, "d_tt")
+`;
+        const { plots } = await makePineTS().run(code);
+        const last = (k: string) => {
+            const d = plots[k]?.data;
+            return d?.[d.length - 1].value;
+        };
+        // Truth table for `not a and not b`: only true when a=false,b=false.
+        expect(last('d_ff')).toEqual(1);
+        expect(last('b_ff')).toEqual(1);   // if-branch taken
+        expect(last('d_tf')).toEqual(0);
+        expect(last('d_ft')).toEqual(0);
+        expect(last('d_tt')).toEqual(0);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Higher-arity / nested chains — make sure the parent-threading
+    // recursion works to arbitrary depth, not just one level of `not`.
+    // ─────────────────────────────────────────────────────────────────────
+    it('runtime: chained `not a and not b and not c`', async () => {
+        const code = `
+//@version=5
+indicator("triple not")
+
+probe3(bool a, bool b, bool c) =>
+    cond = not a and not b and not c
+    cond ? 1 : 0
+
+v_fff = probe3(false, false, false)
+v_tff = probe3(true,  false, false)
+v_ftt = probe3(false, true,  true)
+
+plot(v_fff, "v_fff")
+plot(v_tff, "v_tff")
+plot(v_ftt, "v_ftt")
+`;
+        const { plots } = await makePineTS().run(code);
+        const last = (k: string) => {
+            const d = plots[k]?.data;
+            return d?.[d.length - 1].value;
+        };
+        expect(last('v_fff')).toEqual(1);
+        expect(last('v_tff')).toEqual(0);
+        expect(last('v_ftt')).toEqual(0);
+    });
+});

--- a/tests/transpiler/param-history-callsite.test.ts
+++ b/tests/transpiler/param-history-callsite.test.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Regression: function-level `*.param(value, idx, 'pN')` calls used to
+ * pass a STATIC `'pN'` string baked into the function body, and the
+ * runtime stored the resulting series in `context.params[name]` — a
+ * globally-keyed map. When the same function body was reached via two
+ * distinct call paths in the same bar (one wrapper invoked twice with
+ * different args), each path wrote a different value to the SAME
+ * `params['pN']` slot — clobbering the other path's history.
+ *
+ * Concretely it broke `ta.crossover` / `ta.crossunder` inside a
+ * function: those are stateless, but they read `s2.get(1)` from the
+ * param series. With a clobbered `params['pN']`, the previous-bar
+ * threshold reflected the OTHER call path's value — flipping the
+ * crossover/crossunder result on the next bar.
+ *
+ * Symptom in Smart-Money-Concepts (LuxAlgo): `displayStructure(true)`
+ * (internal) and `displayStructure()` (swing) are both called every
+ * bar. Both write the same `params['p3']` for the bullish-branch
+ * threshold. The second call clobbered the first, so the next bar's
+ * `ta.crossover(close, p_ivot.currentLevel)` saw the wrong prev
+ * threshold and either fired spuriously or missed real crossovers,
+ * producing spurious / missing internal BOS lines.
+ *
+ * Fix: emit `$$.id + 'pN'` as the third arg when inside a function
+ * scope, so the runtime keys params on the call-path id. Mirrors the
+ * existing `$$.id + '_taN'` convention used for ta callsite ids.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { transpile } from '../../src/transpiler/index';
+import { PineTS, Provider } from 'index';
+
+const makePineTS = () =>
+    new PineTS(Provider.Mock, 'BTCUSDC', 'D', null,
+        new Date('2019-01-01').getTime(),
+        new Date('2019-01-15').getTime());
+
+describe('Param-history callsite isolation', () => {
+    // ─────────────────────────────────────────────────────────────────────
+    // Codegen shape
+    // ─────────────────────────────────────────────────────────────────────
+    it('inside a function body, *.param(value, idx, name) uses `$$.id + \'pN\'`', () => {
+        const code = `
+//@version=5
+indicator("x")
+f(float t) =>
+    ta.crossover(close, t)
+f(50.0)
+`;
+        const js = transpile(code).toString();
+        // The threshold-tracking ta.param call lives inside f(), where $$
+        // is the local context. The third arg should be the path-prefixed
+        // form, not a bare literal.
+        expect(js).toMatch(/ta\.param\([^)]*,\s*\$\$\.id\s*\+\s*'p\d+'\s*\)/);
+    });
+
+    it('at top level, *.param(value, idx, name) keeps a literal `\'pN\'`', () => {
+        const code = `
+//@version=5
+indicator("x")
+plot(close[1])
+`;
+        const js = transpile(code).toString();
+        // Top-level `close[1]` becomes `plot.param(close, 1, 'pN')` —
+        // must be the literal form (no `$$` at module scope).
+        expect(js).toMatch(/plot\.param\(close,\s*1,\s*'p\d+'\)/);
+        // The path-prefixed form should NOT appear at top level.
+        expect(js).not.toMatch(/\.param\([^)]*,\s*\$\$\.id\s*\+/);
+    });
+
+    it('inside a function body, params nested inside if/for still get path-prefixed', () => {
+        // The fix relies on `isInsideFunctionScope()` (any 'fn' on the
+        // scope stack), not just the immediate scope type — params often
+        // get emitted from within a nested if/for/while inside a fn body.
+        const code = `
+//@version=5
+indicator("x")
+f(float t) =>
+    if close > t
+        plot(close[1])
+    t
+f(50.0)
+`;
+        const js = transpile(code).toString();
+        // close[1] inside the if inside f() must still be path-prefixed.
+        expect(js).toMatch(/\.param\(close,\s*1,\s*\$\$\.id\s*\+\s*'p\d+'\)/);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Runtime — the actual bite
+    // ─────────────────────────────────────────────────────────────────────
+    it('runtime: ta.crossunder via wrapper called from two paths does not leak history', async () => {
+        // Direct repro of the SMC shape: a probe function uses
+        // ta.crossunder with a passed-in threshold. Two call paths feed
+        // the same body different thresholds. Source is a literal 50,
+        // never moves — so neither crossunder should ever fire.
+        // Pre-fix, the high-threshold path's prev-threshold is clobbered
+        // every bar by the low-threshold call → false positive on bar 2+.
+        const code = `
+//@version=5
+indicator("path-leak runtime")
+
+probe(float threshold) =>
+    ta.crossunder(50.0, threshold) ? 1 : 0
+
+xa = probe(100.0)   // pre-fix: 1 from bar 2 onwards. post-fix: 0 always.
+xb = probe(10.0)    // 0 always (own threshold, no clobber)
+
+plot(xa, "xa")
+plot(xb, "xb")
+`;
+        const { plots } = await makePineTS().run(code);
+        const xa = plots['xa'].data;
+        const xb = plots['xb'].data;
+        expect(xa.length).toBeGreaterThan(5);
+        // Neither should ever fire.
+        for (let i = 0; i < xa.length; i++) {
+            expect(xa[i].value, `xa@bar${i}`).toEqual(0);
+            expect(xb[i].value, `xb@bar${i}`).toEqual(0);
+        }
+    });
+
+    it('runtime: ta.crossover via wrapper called from two paths does not leak history', async () => {
+        // Mirror test for the bullish branch. With sources kept BELOW
+        // every threshold, no crossover should ever fire.
+        const code = `
+//@version=5
+indicator("path-leak crossover")
+
+probe(float threshold) =>
+    ta.crossover(50.0, threshold) ? 1 : 0
+
+xa = probe(10.0)    // pre-fix: 1 from bar 2 onwards. post-fix: 0 always.
+xb = probe(100.0)   // 0 always
+
+plot(xa, "xa")
+plot(xb, "xb")
+`;
+        const { plots } = await makePineTS().run(code);
+        const xa = plots['xa'].data;
+        const xb = plots['xb'].data;
+        for (let i = 0; i < xa.length; i++) {
+            expect(xa[i].value, `xa@bar${i}`).toEqual(0);
+            expect(xb[i].value, `xb@bar${i}`).toEqual(0);
+        }
+    });
+
+    it('runtime: ta.barssince via wrapper called from two paths gets independent state', async () => {
+        // ta.barssince keeps state via taState (not via params), but its
+        // condition argument is wrapped with ta.param. With shared
+        // params, the LAST condition written by either path overwrites
+        // the other's previous-bar value — so subsequent reads see the
+        // wrong history. Two different conditions through the same
+        // wrapper exercise this clearly.
+        const code = `
+//@version=5
+indicator("ta-via-wrapper-paths")
+
+probe(bool cond) =>
+    int n = ta.barssince(cond)
+    n
+
+// On bar k, x5 should be (k % 5) and x3 should be (k % 3) — they are
+// independent counters. Pre-fix, the shared params slot for the
+// condition argument made each path see whichever cond was written
+// LAST in the previous bar, scrambling both counts.
+x5 = probe(bar_index % 5 == 0)
+x3 = probe(bar_index % 3 == 0)
+
+plot(x5, "x5")
+plot(x3, "x3")
+plot(bar_index, "bidx")
+`;
+        const { plots } = await makePineTS().run(code);
+        const x5 = plots['x5'].data;
+        const x3 = plots['x3'].data;
+        const bidx = plots['bidx'].data;
+        expect(x5.length).toBeGreaterThan(8);
+        let differing = 0;
+        for (let i = 0; i < x5.length; i++) {
+            const k = bidx[i].value;
+            expect(x5[i].value, `x5@bar${i}`).toEqual(k % 5);
+            expect(x3[i].value, `x3@bar${i}`).toEqual(k % 3);
+            if (x5[i].value !== x3[i].value) differing++;
+        }
+        // Sanity: the two series MUST actually differ on multiple bars,
+        // otherwise the test is vacuously satisfied.
+        expect(differing).toBeGreaterThan(3);
+    });
+});

--- a/tests/transpiler/parser-fixes.test.ts
+++ b/tests/transpiler/parser-fixes.test.ts
@@ -1830,4 +1830,194 @@ plot(startOfNewLeg(currentLeg) ? 1 : 0)
         expect(r).toBeDefined();
         expect(r.plots).toBeDefined();
     });
+
+    // Regression: an identifier that appears ONLY in a function-parameter
+    // default position (e.g. `myFn(color bg = na)`) used to be missed by
+    // the implicit-import injector because its walker descended into the
+    // function body but never the params. Result: `na` was absent from
+    // the top-level `const { … } = $.pine` destructure and JS threw
+    // "ReferenceError: na is not defined" when the default fired.
+    it('includes `na` in implicit destructure when used only in a default param', async () => {
+        const code = `
+//@version=6
+indicator("Test")
+checkBg(color bg = na) =>
+    na(bg) ? 1 : 0
+plot(checkBg() == 1 ? 1 : 0)
+`;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // Top-level destructure must include `na`.
+        const destructureMatch = jsCode.match(/const\s*\{([^}]*)\}\s*=\s*\$\.pine/);
+        expect(destructureMatch).not.toBeNull();
+        expect(destructureMatch![1]).toContain('na');
+    });
+
+    it('runs at runtime without ReferenceError when fn has `na`-default param', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2024-06-01').getTime(), new Date('2024-06-15').getTime());
+        const code = `
+//@version=6
+indicator("na default")
+checkBg(color bg = na) =>
+    na(bg) ? 1 : 0
+plot(checkBg())
+`;
+        const r = await pineTS.run(code);
+        expect(r).toBeDefined();
+        expect(r.plots).toBeDefined();
+    });
+
+    // Regression: when an arrow function's last statement is an assignment to
+    // a UDT field on a global var, the Pine parser folds it into the implicit
+    // return as an AssignmentExpression. The return-walker had no
+    // AssignmentExpression visitor — the default acorn-walk fall-through
+    // visited the LHS as a MemberExpression, which doesn't rewrite the root
+    // identifier of an assignment LHS. Result: `tracker` leaked bare in
+    // `return $.precision(tracker.bottom = …)` → "ReferenceError: tracker is
+    // not defined" at runtime. Mirrors `updateTrailingExtremes()` in the
+    // LuxAlgo Smart Money Concepts indicator.
+    it('rewrites root identifier in implicit-return AssignmentExpression on UDT field', () => {
+        const code = `
+//@version=6
+indicator("Test")
+type Tracker
+    float top
+    float bottom
+var Tracker tracker = Tracker.new(0.0, 0.0)
+update() =>
+    tracker.top    := math.max(high, tracker.top)
+    tracker.bottom := math.min(low,  tracker.bottom)
+update()
+plot(tracker.top)
+`;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // The implicit return must reference the scoped form of `tracker`.
+        // Bare `tracker.bottom` on the LHS of the return's assignment was the bug.
+        expect(jsCode).toMatch(/return\s+\$\.precision\(\s*\$\.get\(\s*\$\.var\.glb1_tracker\s*,\s*0\s*\)\.bottom\s*=/);
+        // The implicit return should NOT contain a bare `tracker.bottom = ` LHS
+        // (i.e. without a `$.get(...)` wrapper before it).
+        expect(jsCode).not.toMatch(/return\s+\$\.precision\(\s*tracker\.bottom\s*=/);
+    });
+
+    it('runs at runtime without ReferenceError when fn ends with UDT-field assignment', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2024-06-01').getTime(), new Date('2024-06-15').getTime());
+        const code = `
+//@version=6
+indicator("UDT implicit-return")
+type T
+    float top
+    float bottom
+var T t = T.new(0.0, 0.0)
+update() =>
+    t.top    := math.max(high, t.top)
+    t.bottom := math.min(low,  t.bottom)
+update()
+plot(t.top)
+`;
+        const r = await pineTS.run(code);
+        expect(r).toBeDefined();
+        expect(r.plots).toBeDefined();
+    });
+
+    // Regression: a function parameter used directly as a history-lookback
+    // index (e.g. `high[size]` where `size` is a fn param) used to be
+    // mis-scoped to `$.let.size_$0` (a global let lookup). That returned
+    // undefined → resolved to 0 → `high[size]` silently returned the
+    // CURRENT bar instead of the bar `size` ago. Pivot-detection idioms like
+    //   `high[size] > ta.highest(size)`
+    // were therefore never strictly true — breaking SMC's `leg()` and any
+    // other indicator that uses the same pattern.
+    it('emits bare param identifier (not $.let.<name>) when used as a history-lookback index', () => {
+        const code = `
+//@version=5
+indicator("Param as history index")
+probe(int size) =>
+    int k = size + 0
+    h_via_param = high[size]
+    h_via_param == high[k] ? 1 : 0
+plot(probe(5))
+`;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // Inside the function body, the index must reference the bare param
+        // identifier `size_$0`, NOT a `$.let.size_$0` global lookup.
+        // The exact wrapping (`high[$.get(size_$0,0)]` vs
+        // `$.get(high, $.get(size_$0, 0))`) depends on the call-context, so
+        // the assertion only constrains: NO `$.let.size_$0` reference for
+        // the param's bare name.
+        expect(jsCode).not.toMatch(/\$\.let\.size_\$0/);
+        // And the bare `size_$0` must appear as an index source at least once.
+        expect(jsCode).toMatch(/\bsize_\$0\b/);
+    });
+
+    it('runs at runtime: param-direct subscript yields a defined value', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2024-06-01').getTime(), new Date('2024-06-15').getTime());
+        const code = `
+//@version=5
+indicator("param-as-history-index runtime")
+probe(int size) =>
+    h = high[size]
+    not na(h) ? 1 : 0
+plot(probe(2), "defined")
+`;
+        const r = await pineTS.run(code);
+        expect(r).toBeDefined();
+        const data = r.plots['defined']?.data || [];
+        // Before the fix, param-direct subscript resolved to undefined →
+        // `not na(h)` was always 0 after warmup. After the fix it returns
+        // the actual lookback value → 1 on bars with sufficient history.
+        const definedEntries = data.filter((e: any) => e.value === 1);
+        expect(definedEntries.length).toBeGreaterThan(0);
+    });
+
+    // Regression: `<drawing-namespace>.<const>` on the RHS of an assignment
+    // (e.g. `s := label.style_label_down`) used to throw "Cannot read
+    // properties of undefined (reading 'style_label_down')". The
+    // assignment-RHS Identifier visitor unwrapped `label` via the
+    // `__value` Series rewrite (which is correct for `time`/`na`/etc.) —
+    // but drawing namespaces have no `__value`, so the dereference failed.
+    it('does not unwrap drawing-namespace base in assignment-RHS member access', () => {
+        const code = `
+//@version=5
+indicator("namespace const RHS")
+flip(bool b) =>
+    string s = label.style_label_up
+    if b
+        s := label.style_label_down
+    s
+plot(flip(false) == label.style_label_up ? 1 : 0)
+`;
+        const result = transpile(code);
+        const jsCode = result.toString();
+
+        // The assignment RHS must reference `label.style_label_down`
+        // directly, not via the buggy `label.__value` indirection.
+        expect(jsCode).toMatch(/\$\.set\([^,]+,\s*label\.style_label_down\)/);
+        expect(jsCode).not.toMatch(/label\.__value/);
+    });
+
+    it('runs at runtime: drawing-namespace const RHS in assignment fires without error', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2024-06-01').getTime(), new Date('2024-06-15').getTime());
+        const code = `
+//@version=5
+indicator("ns const RHS runtime")
+flip(bool b) =>
+    string s = label.style_label_up
+    if b
+        s := label.style_label_down
+    s
+plot(flip(true) == label.style_label_down ? 1 : 0, "ok")
+`;
+        const r = await pineTS.run(code);
+        expect(r).toBeDefined();
+        const data = r.plots['ok']?.data || [];
+        // Before the fix this threw at runtime. After, every bar emits 1
+        // (the assigned RHS equals `label.style_label_down`).
+        const okEntries = data.filter((e: any) => e.value === 1);
+        expect(okEntries.length).toBeGreaterThan(0);
+    });
 });

--- a/tests/transpiler/parser-fixes.test.ts
+++ b/tests/transpiler/parser-fixes.test.ts
@@ -519,6 +519,78 @@ plot(s == State.Active ? 1 : 0)
         expect(pine2js.code).toContain('return State.Active');
         expect(pine2js.code).toContain('return State.Idle');
     });
+
+    // Pine v6 titled-enum syntax: each member can have an explicit string title
+    // (`member = "Title"`) used by str.tostring() and the input.enum dropdown.
+    // The parser used to expect a bare IDENTIFIER per line and failed at the `=`
+    // with "Expected IDENTIFIER but got OPERATOR".
+    it('should parse titled enum: member = "title"', () => {
+        const code = `
+//@version=6
+indicator("Titled Enum")
+
+enum tz
+    utc  = "UTC"
+    exch = ""
+    ny   = "America/New_York"
+
+t = tz.utc
+plot(close)
+`;
+        const pine2js = pineToJS(code);
+        expect(pine2js.success).toBe(true);
+        expect(pine2js.code).toBeDefined();
+        // Each titled member must use its title as the runtime value, not the
+        // dotted "EnumName.member" string PineTS used to emit.
+        expect(pine2js.code).toMatch(/utc:\s*['"]UTC['"]/);
+        expect(pine2js.code).toMatch(/exch:\s*['"]['"]/);
+        expect(pine2js.code).toMatch(/ny:\s*['"]America\/New_York['"]/);
+    });
+
+    // Untitled members must serialise to the bare member name to match TV's
+    // str.tostring(EnumName.member) output. PineTS used to emit "EnumName.member"
+    // which diverged from TradingView.
+    it('untitled enum members serialise to the bare member name (TV parity)', () => {
+        const code = `
+//@version=6
+indicator("Untitled Enum TV Parity")
+
+enum Dir
+    up
+    dn
+
+d = Dir.up
+plot(close)
+`;
+        const pine2js = pineToJS(code);
+        expect(pine2js.success).toBe(true);
+        // Member runtime values must be just the member name, not "Dir.up".
+        expect(pine2js.code).toMatch(/up:\s*['"]up['"]/);
+        expect(pine2js.code).toMatch(/dn:\s*['"]dn['"]/);
+        expect(pine2js.code).not.toMatch(/up:\s*['"]Dir\.up['"]/);
+    });
+
+    // Mixed titled + untitled members in the same enum body.
+    it('should parse mixed titled and untitled members in one enum', () => {
+        const code = `
+//@version=6
+indicator("Mixed Enum")
+
+enum Mix
+    plain
+    withTitle = "With Title"
+    other     = "Other"
+
+x = Mix.plain
+y = Mix.withTitle
+plot(close)
+`;
+        const pine2js = pineToJS(code);
+        expect(pine2js.success).toBe(true);
+        expect(pine2js.code).toMatch(/plain:\s*['"]plain['"]/);
+        expect(pine2js.code).toMatch(/withTitle:\s*['"]With Title['"]/);
+        expect(pine2js.code).toMatch(/other:\s*['"]Other['"]/);
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/transpiler/pinets-source-to-js.test.ts
+++ b/tests/transpiler/pinets-source-to-js.test.ts
@@ -1026,9 +1026,9 @@ let src_open = input.any({ title: 'Open Source', defval: open });
   function angle(src) {
     const $$ = $.peekCtx();
     $$.const.fn1_rad2degree = $.init($$.const.fn1_rad2degree, 180 / Math.PI);
-    const p0 = ta.param(14, undefined, 'p0');
+    const p0 = ta.param(14, undefined, $$.id + 'p0');
     const temp_1 = ta.atr(p0, $$.id + "_ta0");
-    const p1 = math.param(($.get(src, 0) - $.get(src, 1)) / temp_1, undefined, 'p1');
+    const p1 = math.param(($.get(src, 0) - $.get(src, 1)) / temp_1, undefined, $$.id + 'p1');
     const temp_2 = math.atan(p1);
     $$.const.fn1_ang = $.init($$.const.fn1_ang, $.get($$.const.fn1_rad2degree, 0) * temp_2);
     return $.precision($.get($$.const.fn1_ang, 0));

--- a/tests/transpiler/wrapper-callsite-state.test.ts
+++ b/tests/transpiler/wrapper-callsite-state.test.ts
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * Wrapper-callsite-state regression tests
+ *
+ * Pine semantics is per-call-PATH. PineTS used to key user-function `var`/`let`
+ * slots and `ta.*` accumulator state by the immediate (top-of-stack) callsite
+ * id only. When a stateful function was reached via two different paths
+ * through a common parametrised wrapper, both invocations resolved to the
+ * SAME runtime slot and clobbered each other every bar.
+ *
+ * The fix replaces `peekId()` with the cumulative path of the call stack
+ * (joined ids), so each unique call path gets its own lctx entry. The
+ * transpiler is unchanged — both `$$.var.*` slots and `$$.id + '_taN'`
+ * ta callsite ids inherit the new key shape automatically.
+ *
+ * Discovered while reproducing Smart-Money-Concepts-LuxAlgo's mismatched
+ * internal-OB count (4 vs 5 on BTCUSDC weekly).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+const makePineTS = () =>
+    new PineTS(
+        Provider.Mock,
+        'BTCUSDC',
+        'D',
+        null,
+        new Date('2019-01-01').getTime(),
+        new Date('2019-02-15').getTime(),
+    );
+
+/**
+ * Read the value of plot `title` on the last produced bar.
+ * Using `plot(value, "title")` in the script and reading from
+ * `plots[title].data[lastIndex].value` is the simplest way to expose
+ * bar-level scalar values to the JS test harness.
+ */
+function lastPlotValue(plots: any, title: string): number {
+    const data = plots?.[title]?.data;
+    expect(data, `plot ${title} should exist`).toBeDefined();
+    expect(data.length, `plot ${title} should have at least 1 bar`).toBeGreaterThan(0);
+    return data[data.length - 1].value;
+}
+
+describe('Wrapper-callsite var/let/ta state isolation', () => {
+    // ─────────────────────────────────────────────────────────────────────
+    // 1. Bug repro — a stateful inner fn called from one syntactic site
+    //    inside a wrapper, the wrapper itself called from two distinct
+    //    global call sites. State must NOT bleed between call paths.
+    // ─────────────────────────────────────────────────────────────────────
+    it('isolates `var` state when a stateful inner fn is reached via two paths through one wrapper', async () => {
+        const code = `
+//@version=5
+indicator("wrapper var-state isolation")
+
+counter() =>
+    var int n = 0
+    n += 1
+    n
+
+w() => counter()
+
+a = w()
+b = w()
+
+plot(a, "a")
+plot(b, "b")
+`;
+        const { plots } = await makePineTS().run(code);
+        const a = lastPlotValue(plots, 'a');
+        const b = lastPlotValue(plots, 'b');
+
+        // Pine semantics: each call path has its own counter — both paths
+        // see the SAME final count (one increment per bar in their own slot).
+        // Pre-fix, the shared counter is incremented twice per bar so
+        // `a` is one less than `b` on every bar (a = 2k+1, b = 2k+2).
+        expect(a).toEqual(b);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 2. Single-path wrapper preservation: state must persist across bars
+    //    when the wrapper has only one global call path.
+    // ─────────────────────────────────────────────────────────────────────
+    it('preserves cross-bar state for a wrapper called from one global site', async () => {
+        const code = `
+//@version=5
+indicator("single-path wrapper state")
+
+counter() =>
+    var int n = 0
+    n += 1
+    n
+
+w() => counter()
+
+x = w()
+
+plot(x, "x")
+`;
+        const { plots } = await makePineTS().run(code);
+        const data = plots['x']?.data ?? [];
+        // Counter should equal bar number (1-indexed) on every bar.
+        expect(data.length).toBeGreaterThan(5);
+        for (let i = 0; i < data.length; i++) {
+            expect(data[i].value).toEqual(i + 1);
+        }
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 3. Two distinct global call sites, no wrapper. The fix must not
+    //    regress the case that already worked — each syntactic site keeps
+    //    its own state.
+    // ─────────────────────────────────────────────────────────────────────
+    it('keeps state independent for two distinct global call sites of the same fn', async () => {
+        const code = `
+//@version=5
+indicator("two global call sites")
+
+counter() =>
+    var int n = 0
+    n += 1
+    n
+
+a = counter()
+b = counter()
+
+plot(a, "a")
+plot(b, "b")
+`;
+        const { plots } = await makePineTS().run(code);
+        const a = lastPlotValue(plots, 'a');
+        const b = lastPlotValue(plots, 'b');
+
+        // Distinct syntactic sites → distinct state → both equal final bar.
+        expect(a).toEqual(b);
+        // And each must equal the total bar count (one increment per bar
+        // per site), not 2× the bar count (which would indicate they
+        // share state and increment twice per bar).
+        const dataLen = plots['a'].data.length;
+        expect(a).toEqual(dataLen);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 4. Wrapper called inside a `for` loop with the same arg —
+    //    iterations of the same syntactic call share state (correct Pine
+    //    semantics: the path doesn't depend on argument values, only on
+    //    syntactic ids).
+    // ─────────────────────────────────────────────────────────────────────
+    it('shares state across loop iterations of the same syntactic wrapper call', async () => {
+        const code = `
+//@version=5
+indicator("loop-iteration shared state")
+
+counter() =>
+    var int n = 0
+    n += 1
+    n
+
+w() => counter()
+
+var int last = 0
+for i = 0 to 4
+    last := w()
+
+plot(last, "last")
+`;
+        const { plots } = await makePineTS().run(code);
+        const data = plots['last']?.data ?? [];
+        expect(data.length).toBeGreaterThan(5);
+        // 5 increments per bar via one syntactic call site → same path on
+        // each iteration → final count = 5 × bar-number.
+        for (let i = 0; i < data.length; i++) {
+            expect(data[i].value).toEqual(5 * (i + 1));
+        }
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 5. Three-deep nesting — outer → mid → inner where outer is called
+    //    from two distinct global call sites. The deepest stateful
+    //    function must split state along both paths.
+    // ─────────────────────────────────────────────────────────────────────
+    it('splits state at depth 3 when the outermost wrapper has two distinct call sites', async () => {
+        const code = `
+//@version=5
+indicator("depth-3 path split")
+
+counter() =>
+    var int n = 0
+    n += 1
+    n
+
+inner() => counter()
+mid()   => inner()
+outer() => mid()
+
+a = outer()
+b = outer()
+
+plot(a, "a")
+plot(b, "b")
+`;
+        const { plots } = await makePineTS().run(code);
+        const a = lastPlotValue(plots, 'a');
+        const b = lastPlotValue(plots, 'b');
+        expect(a).toEqual(b);
+        // Each path increments its own counter once per bar → equals the
+        // bar count, not 2× the bar count (which would indicate path
+        // collapse below depth 1).
+        const barCount = plots['a'].data.length;
+        expect(a).toEqual(barCount);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 6. Multiple sibling stateful call sites inside one wrapper, with the
+    //    wrapper itself reached via two distinct paths. Both inner sites
+    //    must independently split state across paths — i.e. the path key
+    //    composes uniformly across every nested syntactic site, not just
+    //    the first one.
+    //
+    // (UDT method dispatch through a wrapper parameter is an intentional
+    // gap left for now: `obj.method()` where `obj` is a function param
+    // currently transpiles to `$.get(obj, 0)?.method?.()` and bypasses
+    // `$.call(...)` entirely. That short-circuit is a separate pre-existing
+    // limitation; for path-keyed state we exercise the equivalent shape
+    // via plain-function nesting.)
+    // ─────────────────────────────────────────────────────────────────────
+    it('splits state at every sibling callsite inside a wrapper across two paths', async () => {
+        const code = `
+//@version=5
+indicator("sibling callsites path split")
+
+counter() =>
+    var int n = 0
+    n += 1
+    n
+
+w() =>
+    p = counter()
+    q = counter()
+    p + q
+
+a = w()
+b = w()
+
+plot(a, "a")
+plot(b, "b")
+`;
+        const { plots } = await makePineTS().run(code);
+        const a = lastPlotValue(plots, 'a');
+        const b = lastPlotValue(plots, 'b');
+
+        // Post-fix, each path has its own pair of counters (one per
+        // syntactic call site), each incremented exactly once per bar →
+        // a == b == 2 × barCount.
+        // Pre-fix, the two paths share BOTH inner slots, so each counter
+        // increments twice per bar; a = 4k+2 and b = 4k+4 diverge.
+        const barCount = plots['a'].data.length;
+        expect(a).toEqual(b);
+        expect(a).toEqual(2 * barCount);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────
+    // 7. `ta.*` accumulator state — the secondary leak: ta callsite ids
+    //    are emitted as `$$.id + '_taN'`. Once `$$.id` is path-keyed, the
+    //    ta state key automatically follows. Verify with `ta.barssince`,
+    //    which is unambiguously path-dependent: pre-fix, two paths feeding
+    //    different conditions into one syntactic ta.barssince() call
+    //    share `state.prevLastTrueIndex` and produce wrong counts.
+    // ─────────────────────────────────────────────────────────────────────
+    it('isolates `ta.*` state across paths through a wrapper (ta.barssince)', async () => {
+        const code = `
+//@version=5
+indicator("ta path isolation")
+
+inner(bool cond) => ta.barssince(cond)
+w(bool cond)     => inner(cond)
+
+// Path A fires every 5 bars, path B fires every 3 bars.
+bs5 = w(bar_index % 5 == 0)
+bs3 = w(bar_index % 3 == 0)
+
+plot(bs5, "bs5")
+plot(bs3, "bs3")
+plot(bar_index, "bidx")
+`;
+        const { plots } = await makePineTS().run(code);
+        const bs5Data = plots['bs5'].data;
+        const bs3Data = plots['bs3'].data;
+        const bidxData = plots['bidx'].data;
+        expect(bs5Data.length).toEqual(bs3Data.length);
+        expect(bs5Data.length).toBeGreaterThan(15);
+
+        // Ground-truth values per path (independent ta state).
+        // bs5 = bar_index - (bar_index - bar_index % 5) = bar_index % 5
+        // bs3 = bar_index % 3
+        // Pre-fix, these collapse to a single sequence governed by the
+        // most-recent firing of EITHER condition — bs5 ends up tracking
+        // bs3's state on bars where bar_index % 3 == 0 but
+        // bar_index % 5 != 0 (e.g. bidx 3, 6, 9, 12, …).
+        let mismatches = 0;
+        for (let i = 0; i < bs5Data.length; i++) {
+            const bidx = bidxData[i].value;
+            const expected5 = bidx % 5;
+            const expected3 = bidx % 3;
+            if (bs5Data[i].value !== expected5) mismatches++;
+            if (bs3Data[i].value !== expected3) mismatches++;
+        }
+        expect(mismatches).toEqual(0);
+
+        // And confirm the two series actually differ (i.e. the test isn't
+        // vacuously satisfied by both being zero).
+        let differingBars = 0;
+        for (let i = 0; i < bs5Data.length; i++) {
+            if (bs5Data[i].value !== bs3Data[i].value) differingBars++;
+        }
+        expect(differingBars).toBeGreaterThan(5);
+    });
+});


### PR DESCRIPTION
## [0.9.15] - 2026-05-08 - Titled Enums, Call-Path Isolation & `request.security_lower_tf` Optimizations

### Added

- **Titled enums**: Support for enum declarations with explicit titles aligned with Pine Script (**transpiler / runtime**).

### Fixed

- **`transformFunctionArgument` + array expressions**: **`ArrayExpression`** arguments now recurse into non-**`Identifier`** elements (**`CallExpression`**, **`BinaryExpression`**, etc.) so nested identifiers (e.g. **`maLenInput`** inside **`request.security_lower_tf(..., [volume, ta.sma(volume, maLenInput)])`**) get proper scope rewrites instead of leaking bare names and throwing **`ReferenceError`** at runtime.
- **Transpiler “not defined” regressions**: Broader fixes for identifier / scope edge cases that surfaced as runtime **`ReferenceError`**s.
- **Per-call-path state for user functions**: **`Context.peekId()`** maintains a **cumulative path stack** so **`var`** / **`let`** slots and **`ta.*`** accumulators do not leak across different call paths through a shared parametrized wrapper.
- **`$.param(..., 'pN')` in nested calls**: Parameter slot ids inside function bodies are **path-prefixed with `$$.id`** so distinct call paths no longer share **`context.params[pN]`** (fixes wrong or missing internal lines in complex multi-path indicators).

### Changed

- **`request.security_lower_tf`**: Fetches a **bounded** number of lower-timeframe bars instead of over-fetching (**optimization**).
- **Secondary contexts**: **Drawing** helpers are **skipped** when running **`request.security`** / LTF evaluation so work and payload generation stay on the chart context.
- **`security_lower_tf` fast path**: When the expression only needs **market data** from the lower timeframe, execution takes a **lighter path** without full expression evaluation overhead.
