### PR TITLE
## [0.9.20] - 2026-06-08 - Indicator Class as SSOT — `.input` / `.prop` Runtime Overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## [0.9.20] - 2026-06-08 - Indicator Class as SSOT — `.input` / `.prop` Runtime Overrides
+
+### Added
+
+- **`Indicator` becomes the single source of truth for every per-script artifact**: refactored from a 12-line tuple `{source, inputs}` into the owner of the transpiled function, AST, parsed input schema, parsed declaration-prop schema, viewport-detection flag, and LTF slices. All PineTS entry points (**`run`**, **`stream`**, **`update`**) now route through **`Indicator.from(arg).prepare()`** so raw strings and raw functions get auto-wrapped in a throwaway Indicator. **`prepare()`** is lazy and cached — re-using the same Indicator across multiple **`pine.run()`** calls compiles the script **once**.
+- **`Indicator.input` — title-keyed Proxy for input overrides**: read or mutate `input.*` values per key (**`ind.input["Length"] = 50`**). The container itself is frozen (**`ind.input = {...}`** throws); per-key writes validate against the input's schema (type / options / minval / maxval) and throw tailored messages on violations or unknown titles. Constructor **`inputs`** map kept for back-compat; **`.input`** writes layer on top.
+- **`Indicator.getInputsMeta(): IPineInput[]`**: parsed input schema for UI builders. Captures **`type`**, **`defval`**, **`title`**, **`tooltip`**, **`group`**, **`inline`**, **`display`**, **`active`**, **`confirm`**, **`options`**, **`minval`**, **`maxval`**, **`step`** for every **`input.*(...)`** declaration in the source.
+- **`Indicator.prop` — name-keyed Proxy for `indicator()` / `strategy()` declaration overrides**: read or mutate declaration arguments (**`ind.prop["initial_capital"] = 75000`**, **`ind.prop["pyramiding"] = 5`**) before **`pine.run()`**. Same frozen-container + per-key validation semantics as **`.input`**. Excludes **`title`** / **`shorttitle`** from writes (still present in the meta with **`mutable: false`** so UIs can render them).
+- **Source-code defaults seeded into `.prop`**: when reading **`ind.prop["X"]`**, the value is layered as **spec default ← source code value ← user override**. Pine source like **`strategy("X", initial_capital=50000, currency=currency.EUR)`** seeds **`ind.prop["initial_capital"]` → 50000** and **`ind.prop["currency"] → "EUR"`** before any user write. Enum constants (**`currency.EUR`**, **`strategy.percent_of_equity`**, **`strategy.commission.cash_per_order`**) resolve via the rightmost-identifier rule to match what TradingView's runtime sees.
+- **`Indicator.getPropsMeta(): IPineProp[]`** & **`Indicator.getDeclarationType()`**: schema introspection filtered to props applicable to the detected script type (**`'indicator'`** vs **`'strategy'`**). Type detection falls back to **`'indicator'`** if no declaration call is found.
+- **Top-level exports `INDICATOR_PROPS` / `STRATEGY_PROPS` / `propsForDeclaration(type)`**: complete prop schemas (17 / 33 entries respectively) for UI code that needs the full list independent of any Indicator instance. Each enum-typed entry has a one-line comment in [**`src/Indicator/propsSchema.ts`**](src/Indicator/propsSchema.ts) enumerating accepted values and pointing to the corresponding exported Pine enum in **`src/namespaces/Types.ts`**.
+- **`scanDeclaration.ts`**: detects **`indicator()`** / **`strategy()`** in both Pine source (via existing **`pineToJS`** AST) and JS-function source (via **`acorn.parse`**). Decodes positional + named arguments and resolves namespace constants.
+- **`keyedProxy.ts`**: shared backend for **`.input`** and **`.prop`** Proxies — single source of validation + custom error messages. Replaces the previous duplicate Proxy code in **`inputProxy.ts`**.
+- **`Context._propOverrides`**: name-keyed map of user prop overrides populated in **`_initializeContext`** from **`ind.getRuntimePropOverrides()`**. Read by **`Core.indicator()`** and **`initializeStrategy()`** to merge on top of source-code declaration args (**`{ ...defaults, ...sourceArgs, ...userOverrides }`**).
+- **`docs/indicator.md`** (new): dedicated page covering Quickstart, Constructor, **`Indicator.from()`**, visible-range detection, the full **`.input`** / **`getInputsMeta()`** surface, the full **`.prop`** / **`getPropsMeta()`** surface (incl. source-default seeding, enum resolution, validation), reuse across runs, JS-function source caveats, and backward compatibility with the constructor **`inputs`** map. Every code example verified end-to-end against the live bundle before inclusion.
+- **Tests**: **`tests/Indicator/Indicator.test.ts`** (21 cases — input surface) and **`tests/Indicator/Indicator.props.test.ts`** (37 cases — prop surface including declaration detection, source-default seeding, indicator-vs-strategy cross-validation, enum/numeric bounds, end-to-end runtime override propagation).
+
+### Changed
+
+- **PineTS internals simplified**: **`_transpileCode`** and **`_detectViewportUsage`** moved off the **`PineTS`** class onto **`Indicator`** (where they conceptually belong — they're properties of the script, not the engine). **`_runComplete`** / **`_runPaginated`** now take an **`Indicator`** instance and call **`prepare()`** from inside their async bodies so transpile errors surface as Promise rejections (preserving the **`tests/transpiler/error-handling.test.ts`** contract).
+- **`docs/initialization-and-usage.md` — "Running with Runtime Inputs"**: rewritten to show both the new per-key **`ind.input["Length"] = 50`** form (preferred) and the legacy constructor map (still supported). Cross-links to the new [**Indicator**](docs/indicator.md) page for the full surface.
+- **`docs/strategy.md`**: Indicator-wrapper example now links to the dedicated [**Indicator**](docs/indicator.md) page in addition to **`initialization-and-usage.md`**.
+- **`docs/index.md`** + nav: added an Indicator entry at slot 4; bumped Alerts / Pagination / Data Providers / Syntax Guide / Strategy / Language Coverage / API Coverage down one slot each. Resolves two prior nav_order collisions (Alerts and Pagination were both at 4).
+
+---
+
 ## [0.9.19] - 2026-06-05 - Strategy Broker Emulator — Margin Calls, Drawdown/Runup & Exit Cadence
 
 ### Added

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Alerts
-nav_order: 4
+nav_order: 5
 permalink: /alerts/
 ---
 

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: API Coverage
-nav_order: 9
+nav_order: 11
 permalink: /api-coverage/
 has_children: true
 ---

--- a/docs/data-providers.md
+++ b/docs/data-providers.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Data Providers
-nav_order: 5
+nav_order: 7
 permalink: /data-providers/
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,10 @@ Learn the basics of converting Pine Script to PineTS and understand key differen
 
 Complete guide on how to initialize PineTS and run indicators with detailed API documentation, including all constructor parameters, run method options, and return value formats.
 
+### [Indicator](indicator.md)
+
+The `Indicator` class — wrapping a script for cached transpile, schema introspection (`getInputsMeta()` / `getPropsMeta()`), and runtime overrides via `.input["Title"] = value` and `.prop["name"] = value`.
+
 ### [Syntax Guide](syntax-guide.md)
 
 Detailed guide on PineTS syntax and how to write code equivalent to Pine Script, including variable declarations (`var` vs `let`), series access, and control structures.

--- a/docs/indicator.md
+++ b/docs/indicator.md
@@ -1,0 +1,394 @@
+---
+layout: default
+title: Indicator
+nav_order: 4
+permalink: /indicator/
+---
+
+# Indicator
+
+`Indicator` is the SSOT wrapper around a Pine/JS script. It owns the source code, the transpiled function, the parsed input schema, and the parsed declaration-prop schema. You typically pass an `Indicator` to `pine.run()` / `pine.stream()` instead of a raw string — that gives you:
+
+- Lazy, cached transpile (re-running the same Indicator across multiple `pine.run()` calls compiles the script **once**)
+- A title-keyed `.input` view to read or override input defaults
+- A name-keyed `.prop` view to read or override `indicator()` / `strategy()` declaration arguments
+- Schema introspection (`getInputsMeta()`, `getPropsMeta()`) for UI builders
+
+Every code snippet on this page is exercised by the verification harness at `PineTS/.scratchpad/indicator-doc-examples.cjs` (kept in lock-step with the docs during authoring). If something doesn't behave as documented, the harness fails.
+
+## Table of Contents
+
+- [Quickstart](#quickstart)
+- [Constructor](#constructor)
+- [Indicator.from()](#indicatorfrom)
+- [Visible-range detection](#visible-range-detection)
+- [Inputs — `.input` and `getInputsMeta()`](#inputs--input-and-getinputsmeta)
+- [Declaration props — `.prop` and `getPropsMeta()`](#declaration-props--prop-and-getpropsmeta)
+- [Reusing the same Indicator across runs](#reusing-the-same-indicator-across-runs)
+- [JS-function source](#js-function-source)
+- [Backward compatibility — constructor `inputs` map](#backward-compatibility--constructor-inputs-map)
+
+---
+
+## Quickstart
+
+The simplest path — wrap a Pine string in `new Indicator(...)`, pass it to `pine.run()`:
+
+```javascript
+const { PineTS, Indicator } = require('pinets');
+
+const code = `
+//@version=6
+indicator("SMA Demo")
+len = input.int(14, "Length")
+plot(ta.sma(close, len))
+`;
+
+const ind = new Indicator(code);
+const pine = new PineTS(/* market data or provider */);
+const ctx = await pine.run(ind);
+```
+
+Raw strings and raw functions also work — they get wrapped in a throwaway Indicator internally:
+
+```javascript
+await pine.run(code); // raw Pine string
+await pine.run(($) => {
+    /* ... */
+}); // raw JS function
+```
+
+You'd choose the explicit `Indicator` form when you want to:
+
+- Override input or prop values before the run.
+- Reuse the same compiled script across multiple `pine.run()` calls.
+- Inspect the script's schema from the host UI.
+
+---
+
+## Constructor
+
+```typescript
+new Indicator(source: string | Function, inputs?: Record<string, unknown>)
+```
+
+| Argument | Type                                             | Required | Notes                                                                                 |
+| -------- | ------------------------------------------------ | -------- | ------------------------------------------------------------------------------------- |
+| `source` | `string` (Pine code) or `Function` (JS callback) | Yes      | The script body.                                                                      |
+| `inputs` | `Record<string, unknown>`                        | No       | **Legacy** — title-keyed override map. Kept for back-compat; prefer the `.input` API. |
+
+Both forms accepted:
+
+```javascript
+// Pine string source
+const a = new Indicator(`
+//@version=6
+indicator("X")
+plot(close)
+`);
+
+// JS function source
+const b = new Indicator(($) => {
+    const { indicator, plot } = $.pine;
+    indicator('JS X');
+    plot($.data.close);
+});
+```
+
+---
+
+## Indicator.from()
+
+A static normalizer used by `pine.run()` and friends. Accepts any of the three input shapes and returns an `Indicator`:
+
+```javascript
+Indicator.from(code); // wraps the raw Pine string
+Indicator.from(($) => {
+    /* ... */
+}); // wraps the raw function
+Indicator.from(existingInd) === existingInd; // pass-through
+```
+
+Use it when you write code that needs to operate on Indicators regardless of how the user provided the source.
+
+---
+
+## Visible-range detection
+
+Statically tags whether the script references any host-bound built-in (`chart.left_visible_bar_time`, `chart.right_visible_bar_time`, …). Used by `pine.update()` to skip re-runs for non-viewport scripts.
+
+```javascript
+const vr = new Indicator(`
+//@version=6
+indicator("VR", overlay=true)
+left = chart.left_visible_bar_time
+plot(close)
+`);
+
+const noVR = new Indicator(`//@version=6\nindicator("Plain")\nplot(close)`);
+
+vr.usesVisibleRange(); // → true
+noVR.usesVisibleRange(); // → false
+```
+
+See **[Initialization and Usage → Host Environment (Visible Range)](initialization-and-usage.md#host-environment-visible-range)** for the full visible-range flow.
+
+---
+
+## Inputs — `.input` and `getInputsMeta()`
+
+### Reading and writing values
+
+`.input` is a title-keyed Proxy. Keys are the **`title`** argument of each `input.*(...)` call in the Pine source. The container itself is frozen — you can mutate values per key, but you can't replace the whole object.
+
+```javascript
+const code = `
+//@version=6
+indicator("Demo")
+length = input.int(14, "Length", minval=2, maxval=200)
+src    = input.source(close, "Source")
+maType = input.string("EMA", "MA Type", options=["EMA", "SMA", "WMA"])
+plot(close)
+`;
+const ind = new Indicator(code);
+
+ind.input['Length']; // → 14         (default from source)
+ind.input['Source']; // → "close"
+ind.input['MA Type']; // → "EMA"
+
+ind.input['Length'] = 50; // ✓ valid override
+ind.input['Length']; // → 50
+```
+
+When you pass the Indicator to `pine.run()`, the override flows into the runtime:
+
+```javascript
+const code = `
+//@version=6
+indicator("E2E")
+len = input.int(14, "Length")
+plot(ta.sma(close, len))
+`;
+const ind = new Indicator(code);
+ind.input['Length'] = 5;
+const ctx = await pine.run(ind);
+// ctx.inputs.Length === 5
+// the SMA in the script was computed with length=5
+```
+
+### Validation
+
+Writes are validated against the input's schema. Failures throw immediately with a tailored message:
+
+```javascript
+ind.input['Unknown'] = 1; // ✗ Error: [Indicator.input] unknown input title "Unknown". Known: Length, Source, MA Type
+ind.input['Length'] = 1; // ✗ Error: [Indicator.input] "Length" value 1 is below minval 2
+ind.input['MA Type'] = 'HMA'; // ✗ Error: [Indicator.input] "MA Type" value "HMA" is not one of: "EMA", "SMA", "WMA"
+ind.input = { foo: 1 }; // ✗ Error: [Indicator.input] .input cannot be replaced — mutate individual keys (…)
+```
+
+### Schema introspection — `getInputsMeta()`
+
+Returns the parsed schema as an array of `IPineInput`. Useful for UI builders that need to render input controls.
+
+```javascript
+const meta = ind.getInputsMeta();
+// [
+//   { type: 'int',    title: 'Length',  defval: 14,    minval: 2, maxval: 200 },
+//   { type: 'source', title: 'Source',  defval: 'close' },
+//   { type: 'string', title: 'MA Type', defval: 'EMA', options: ['EMA','SMA','WMA'] },
+// ]
+```
+
+Each entry carries everything the scanner harvested — `type`, `defval`, `title`, `tooltip`, `group`, `inline`, `display`, `options`, `minval`, `maxval`, `step`, `active`, `confirm`. The exported types `IPineInput`, `PineInputType`, and `PineInputDisplay` describe the shape.
+
+---
+
+## Declaration props — `.prop` and `getPropsMeta()`
+
+The script's `indicator(...)` or `strategy(...)` declaration takes its own set of arguments — `overlay`, `precision`, `initial_capital`, `pyramiding`, `currency`, etc. The `.prop` view exposes those for read/override, mirroring the `.input` API but keyed by **arg name** instead of title.
+
+### Reading source-code defaults
+
+When you construct an Indicator, the source's declaration call is parsed and its arg values seed `.prop`. Spec defaults from the Pine docs apply to args the source didn't set.
+
+```javascript
+const code = `
+//@version=6
+strategy("Demo Strat", overlay=true, initial_capital=50000, pyramiding=3,
+         currency=currency.EUR, default_qty_type=strategy.percent_of_equity,
+         commission_type=strategy.commission.cash_per_order)
+plot(close)
+`;
+const ind = new Indicator(code);
+
+ind.prop['overlay']; // → true         (from source)
+ind.prop['initial_capital']; // → 50000        (from source)
+ind.prop['pyramiding']; // → 3            (from source)
+ind.prop['currency']; // → "EUR"        (enum resolved to runtime string)
+ind.prop['default_qty_type']; // → "percent_of_equity"
+ind.prop['commission_type']; // → "cash_per_order"  (nested namespace resolved)
+ind.prop['slippage']; // → 0            (spec default — source didn't set it)
+```
+
+Namespaced enum constants (`currency.EUR`, `strategy.percent_of_equity`, `strategy.commission.cash_per_order`) are resolved to the bare runtime string — matching what TradingView's `str.tostring()` would print.
+
+### Writing overrides
+
+```javascript
+ind.prop['initial_capital'] = 75000;
+ind.prop['pyramiding'] = 4;
+
+const ctx = await pine.run(ind);
+// ctx.strategy.config.initial_capital === 75000   (override wins)
+// ctx.strategy.config.pyramiding      === 4
+// ctx.strategy.config.currency        === "EUR"   (source-only value still applies)
+```
+
+Indicator scripts work the same way against `ctx.indicator`:
+
+```javascript
+const code = `//@version=6\nindicator("E2E", overlay=false, precision=2)\nplot(close)`;
+const ind = new Indicator(code);
+ind.prop['overlay'] = true;
+ind.prop['precision'] = 6;
+const ctx = await pine.run(ind);
+// ctx.indicator.overlay   === true
+// ctx.indicator.precision === 6
+```
+
+### Validation
+
+Same strictness as `.input`:
+
+```javascript
+ind.prop['nope'] = 1; // ✗ Error: [Indicator.prop] unknown key "nope". Known: …
+ind.prop['currency'] = 'XYZ'; // ✗ Error: [Indicator.prop] "currency" value "XYZ" is not one of: …
+ind.prop['title'] = 'X'; // ✗ Error: [Indicator.prop] unknown key "title". Known: …   (title is mutable: false)
+ind.prop = { foo: 1 }; // ✗ Error: [Indicator] .prop cannot be replaced — (…)
+```
+
+### Schema introspection — `getPropsMeta()`
+
+Returns an `IPineProp[]` filtered to props applicable to the detected script type (`indicator` vs `strategy`). Includes `title` and `shorttitle` with `mutable: false` so UI builders can render them even though they're not writable.
+
+```javascript
+const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+const meta = ind.getPropsMeta();
+// Each entry: { name, type, defval, options?, minval?, maxval?, mutable, appliesTo, version? }
+
+const currency = meta.find((m) => m.name === 'currency');
+// {
+//   name: "currency",
+//   type: "enum",
+//   defval: "USD",
+//   options: ["AED", "ARS", "AUD", ..., "USDT", ..., "ZAR"],
+//   mutable: true,
+//   appliesTo: "strategy",
+// }
+```
+
+`getDeclarationType()` reports which schema the Indicator is using:
+
+```javascript
+new Indicator(`//@version=6\nstrategy("X")\nplot(close)`).getDeclarationType(); // → 'strategy'
+new Indicator(`//@version=6\nindicator("X")\nplot(close)`).getDeclarationType(); // → 'indicator'
+new Indicator(`//@version=6\nplot(close)`).getDeclarationType(); // → null  (falls back to indicator schema)
+```
+
+### Exported schemas for UI builders
+
+The complete prop schemas are also exported as top-level constants. UI code that wants the full list (independent of any Indicator instance) can import them directly:
+
+```javascript
+const { INDICATOR_PROPS, STRATEGY_PROPS, propsForDeclaration } = require('pinets');
+
+INDICATOR_PROPS; // IPineProp[]   — 17 entries (incl. title/shorttitle)
+STRATEGY_PROPS; // IPineProp[]   — 33 entries
+propsForDeclaration('strategy'); // → STRATEGY_PROPS
+propsForDeclaration(null); // → INDICATOR_PROPS (fallback)
+```
+
+Every enum-typed entry in [`propsSchema.ts`](https://github.com/LuxAlgo/PineTS/blob/main/src/Indicator/propsSchema.ts) has a one-line comment enumerating accepted values and pointing to the corresponding exported Pine enum (`enum format`, `enum scale`, `enum currency`, …) in [`src/namespaces/Types.ts`](https://github.com/LuxAlgo/PineTS/blob/main/src/namespaces/Types.ts) so you can import the source-of-truth values rather than hard-coding strings in UI code.
+
+---
+
+## Reusing the same Indicator across runs
+
+The transpiled function is cached on the Indicator instance, so passing the same Indicator to multiple `pine.run()` calls compiles the script **once**. Live overrides on `.input` / `.prop` between runs are picked up automatically.
+
+```javascript
+const code = `
+//@version=6
+indicator("Reusable")
+len = input.int(14, "Length")
+plot(ta.sma(close, len))
+`;
+const ind = new Indicator(code);
+ind.input['Length'] = 7;
+
+const ctxA = await new PineTS(dataA).run(ind); // first run: transpiles + scans
+const ctxB = await new PineTS(dataB).run(ind); // second run: reuses prepared artifact
+// Both runs computed ta.sma(close, 7)
+```
+
+This matters for hosts that run the same script across many datasets (e.g. a chart with multiple symbols, or a backtest sweep over parameter ranges).
+
+---
+
+## JS-function source
+
+When the source is a JS callback, the AST scan for inputs returns `[]` (Pine inputs are written in Pine syntax; the JS form expresses them differently). The `.input` view is empty and writes throw "unknown title". The legacy `inputs` constructor map still works for runtime overrides via the JS path.
+
+```javascript
+const fn = ($) => {
+    const { indicator, plot } = $.pine;
+    indicator('JS', { overlay: true, precision: 4 });
+    plot($.data.close);
+};
+const ind = new Indicator(fn);
+
+ind.getInputsMeta(); // → []
+ind.getDeclarationType(); // → 'indicator'    (acorn parse of the function body)
+ind.prop['overlay']; // → true           (from the JS call)
+ind.prop['precision']; // → 4              (from the JS call)
+```
+
+Declaration detection works for the JS path because the function body is parsed with `acorn`; the scanner walks for `CallExpression(indicator | strategy, ...)` regardless of whether it's destructured from `$.pine` first.
+
+---
+
+## Backward compatibility — constructor `inputs` map
+
+The legacy second constructor argument (a title-keyed override map) is still honored. It's most useful when you build an Indicator and want to ship a default override set up front, without touching `.input` later.
+
+```javascript
+const code = `
+//@version=6
+indicator("BC")
+len = input.int(14, "Length")
+plot(ta.sma(close, len))
+`;
+const ind = new Indicator(code, { Length: 21 });
+const ctx = await pine.run(ind);
+// ctx.inputs.Length === 21
+```
+
+Precedence rule when both are set: `.input` overrides win over the constructor map. The constructor map is the baseline; `.input` writes layer on top.
+
+```javascript
+const ind = new Indicator(code, { Length: 21 });
+ind.input['Length'] = 3;
+const ctx = await pine.run(ind);
+// ctx.inputs.Length === 3   ← .input wins
+```
+
+New code should prefer the `.input` API. The constructor `inputs` argument stays for callers that have existing code relying on it.
+
+---
+
+## Related
+
+- **[Initialization and Usage](initialization-and-usage.md)** — full surface of `pine.run()`, `pine.stream()`, `pine.update()`.
+- **[Strategy Namespace](strategy.md)** — `strategy.*` API surface (the Pine side of strategy props).
+- **[API Coverage](api-coverage.md)** — implementation status of every Pine `input.*` and namespace.

--- a/docs/initialization-and-usage.md
+++ b/docs/initialization-and-usage.md
@@ -266,7 +266,7 @@ const context = await pineTS.run(
 
 ### Running with Runtime Inputs
 
-To pass custom input values to your indicator at runtime, use the `Indicator` class:
+To pass custom input values to your indicator at runtime, wrap the source in an `Indicator` instance. Two equivalent forms — pick whichever is more ergonomic:
 
 ```typescript
 import { PineTS, Provider, Indicator } from 'pinets';
@@ -283,15 +283,18 @@ plot(ta.sma(src, len))
 // Initialize PineTS
 const pineTS = new PineTS(Provider.Binance, 'BTCUSDT', 'D', 100);
 
-// Create Indicator with custom inputs
-// Keys must match the 'title' argument in input.* calls
-const indicator = new Indicator(code, {
-    Length: 50, // Override default 14
-});
+// (a) Per-key override via .input — preferred, validates against the input's schema
+const ind = new Indicator(code);
+ind.input['Length'] = 50;
+const { result } = await pineTS.run(ind);
 
-// Run with inputs
-const { result } = await pineTS.run(indicator);
+// (b) Constructor overrides map — legacy, still supported
+const ind2 = new Indicator(code, { Length: 50 });
 ```
+
+In both forms, the keys must match the **`title`** argument of the corresponding `input.*` call in the source.
+
+The `Indicator` class also lets you override `indicator()` / `strategy()` declaration arguments (e.g. `initial_capital`, `pyramiding`, `overlay`) via `ind.prop["name"] = value`, and exposes the script's schema for UI builders via `getInputsMeta()` / `getPropsMeta()`. See **[Indicator](indicator.md)** for the complete API surface.
 
 ### Return Value
 

--- a/docs/lang-coverage.md
+++ b/docs/lang-coverage.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Language Coverage
-nav_order: 8
+nav_order: 10
 permalink: /lang-coverage/
 ---
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Pagination & Live Streaming
-nav_order: 4
+nav_order: 6
 permalink: /pagination/
 ---
 

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Strategy Namespace
-nav_order: 7
+nav_order: 9
 permalink: /strategy/
 ---
 
@@ -92,7 +92,7 @@ const ctx2 = await pine.run(new Indicator(code));                    // no overr
 const ctx3 = await pine.run(new Indicator(code, { Qty: 5 }));        // override input.int(1, "Qty")
 ```
 
-The `Indicator()` wrapper is the same one used for indicator scripts — strategies and indicators share the runtime, so there's nothing strategy-specific to do. See **[Initialization and Usage → Running with Runtime Inputs](initialization-and-usage.md#running-with-runtime-inputs)** for the full input-keying rules.
+The `Indicator()` wrapper is the same one used for indicator scripts — strategies and indicators share the runtime, so there's nothing strategy-specific to do. See **[Indicator](indicator.md)** for the full API (per-key overrides via `ind.input[...]` / `ind.prop[...]`, schema introspection, etc.), or **[Initialization and Usage → Running with Runtime Inputs](initialization-and-usage.md#running-with-runtime-inputs)** for a quick overview.
 
 ---
 

--- a/docs/syntax-guide.md
+++ b/docs/syntax-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Syntax Guide
-nav_order: 6
+nav_order: 8
 ---
 
 # PineTS Syntax Guide

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.19",
+    "version": "0.9.20",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -64,6 +64,11 @@ export class Context {
     /** Alert mode: 'realtime' = only fire on live bars (TV behavior), 'all' = fire on every bar (backtest). */
     public _alertMode: 'realtime' | 'all' = 'realtime';
 
+    /** Name-keyed map of declaration-prop overrides from `Indicator.prop`. Layered on top of
+     *  the source's `indicator()`/`strategy()` call args inside the per-bar handlers
+     *  (see Core.indicator and initializeStrategy). Empty object when no overrides are set. */
+    public _propOverrides: Record<string, unknown> = {};
+
     /** Monotonically increasing counter, incremented each time a bar starts executing.
      *  Used by alertcondition/AlertHelper to detect re-execution of the same bar. */
     public _execTick: number = 0;

--- a/src/Indicator.ts
+++ b/src/Indicator.ts
@@ -2,9 +2,12 @@
 // Copyright (C) 2025 Alaa-eddine KADDOURI
 
 export { Indicator } from './Indicator/Indicator.class';
+export { INDICATOR_PROPS, STRATEGY_PROPS, propsForDeclaration } from './Indicator/propsSchema';
 export type {
     IPineInput,
+    IPineProp,
     PineInputType,
     PineInputDisplay,
+    PinePropType,
     PreparedScript,
 } from './Indicator/types';

--- a/src/Indicator.ts
+++ b/src/Indicator.ts
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2025 Alaa-eddine KADDOURI
 
-export class Indicator {
-    public source: Function | String;
-    public inputs: Record<string, any>;
-
-    constructor(source: Function | String, inputs: Record<string, any> = {}) {
-        this.source = source;
-        this.inputs = inputs;
-    }
-}
+export { Indicator } from './Indicator/Indicator.class';
+export type {
+    IPineInput,
+    PineInputType,
+    PineInputDisplay,
+    PreparedScript,
+} from './Indicator/types';

--- a/src/Indicator/Indicator.class.ts
+++ b/src/Indicator/Indicator.class.ts
@@ -5,7 +5,10 @@ import { transpile } from '../transpiler/index';
 import { VIEWPORT_DEPENDENT_BUILTINS } from '../transpiler/settings';
 import { scanInputs } from './scanInputs';
 import { buildInputProxy } from './inputProxy';
-import type { IPineInput, PreparedScript } from './types';
+import { scanDeclaration } from './scanDeclaration';
+import { propsForDeclaration } from './propsSchema';
+import { buildPropProxy } from './propProxy';
+import type { IPineInput, IPineProp, PreparedScript } from './types';
 
 /**
  * The single owner of every per-script artifact. Holds the source, lazily
@@ -37,12 +40,24 @@ export class Indicator {
     // the getter.
     declare public readonly input: Record<string, unknown>;
 
+    // `.prop` mirrors `.input`: frozen container, name-keyed view of declaration
+    // args. Filtered to mutable entries only — title/shorttitle are excluded.
+    declare public readonly prop: Record<string, unknown>;
+
     // Lazy artifacts — populated on first prepare() call.
     private _prepared: PreparedScript | null = null;
     private _inputMeta: IPineInput[] | null = null;
     private _inputValues: Record<string, unknown> = {};
     private _explicitOverrides = new Set<string>(); // titles the user wrote via .input.X = ...
     private _inputProxy: Record<string, unknown> | null = null;
+
+    // Prop machinery — same lazy pattern as inputs.
+    private _propMeta: IPineProp[] | null = null;
+    private _propValues: Record<string, unknown> = {};
+    private _propProxy: Record<string, unknown> | null = null;
+    private _declarationType: 'indicator' | 'strategy' | null = null;
+    private _sourcePropArgs: Record<string, unknown> = {};
+    private _explicitPropOverrides = new Set<string>(); // names the user wrote via .prop.X = ...
 
     constructor(source: Function | string, inputs: Record<string, unknown> = {}) {
         this.source = source;
@@ -54,6 +69,16 @@ export class Indicator {
             get: () => this._getInputProxy(),
             set: () => {
                 throw new Error('[Indicator] .input cannot be replaced — mutate individual keys (e.g. ind.input["My Title"] = 20).');
+            },
+            enumerable: true,
+            configurable: false,
+        });
+
+        // `.prop` mirrors `.input` — frozen container, lazy proxy.
+        Object.defineProperty(this, 'prop', {
+            get: () => this._getPropProxy(),
+            set: () => {
+                throw new Error('[Indicator] .prop cannot be replaced — mutate individual keys (e.g. ind.prop["initial_capital"] = 50000).');
             },
             enumerable: true,
             configurable: false,
@@ -131,6 +156,41 @@ export class Indicator {
         return this._inputMeta!;
     }
 
+    /**
+     * Schema metadata for declaration props applicable to this script's type.
+     * Includes non-mutable entries (`title`, `shorttitle`) for completeness —
+     * UI builders can render them; writes to those keys via `.prop` still throw.
+     */
+    public getPropsMeta(): IPineProp[] {
+        this._ensurePropsScanned();
+        return this._propMeta!;
+    }
+
+    /**
+     * Name-keyed map of user-overridden props for the runtime to merge on top
+     * of the source-code's indicator()/strategy() call args. Only explicit
+     * writes via `.prop` are included — source-code values flow through the
+     * normal Pine call path.
+     */
+    public getRuntimePropOverrides(): Record<string, unknown> {
+        const out: Record<string, unknown> = {};
+        if (this._propMeta) {
+            for (const name of this._explicitPropOverrides) {
+                out[name] = this._propValues[name];
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Detected declaration type, or null if the source code has neither call.
+     * `.prop` falls back to the indicator schema in the null case.
+     */
+    public getDeclarationType(): 'indicator' | 'strategy' | null {
+        this._ensurePropsScanned();
+        return this._declarationType;
+    }
+
     // ── internals ───────────────────────────────────────────────────────
 
     private _ensureInputsScanned(): void {
@@ -144,6 +204,26 @@ export class Indicator {
     private _getInputProxy(): Record<string, unknown> {
         this._ensureInputsScanned();
         return this._inputProxy!;
+    }
+
+    private _ensurePropsScanned(): void {
+        if (this._propMeta) return;
+        const scanned = scanDeclaration(this.source);
+        this._declarationType = scanned.type;
+        this._sourcePropArgs = scanned.args;
+        this._propMeta = propsForDeclaration(scanned.type);
+        const built = buildPropProxy(
+            this._propMeta,
+            this._sourcePropArgs,
+            (name) => this._explicitPropOverrides.add(name),
+        );
+        this._propValues = built.values;
+        this._propProxy = built.proxy;
+    }
+
+    private _getPropProxy(): Record<string, unknown> {
+        this._ensurePropsScanned();
+        return this._propProxy!;
     }
 }
 

--- a/src/Indicator/Indicator.class.ts
+++ b/src/Indicator/Indicator.class.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import { transpile } from '../transpiler/index';
+import { VIEWPORT_DEPENDENT_BUILTINS } from '../transpiler/settings';
+import { scanInputs } from './scanInputs';
+import { buildInputProxy } from './inputProxy';
+import type { IPineInput, PreparedScript } from './types';
+
+/**
+ * The single owner of every per-script artifact. Holds the source, lazily
+ * transpiles + scans inputs on first `prepare()`, and caches the result so
+ * the same Indicator instance can be passed to multiple `pine.run()` calls
+ * without re-transpiling.
+ *
+ * Roles:
+ *   - `source`            — the original Pine string or JS callback.
+ *   - `input`             — live, title-keyed view of input values. Read or
+ *                            mutate per key; the container itself is frozen.
+ *   - `inputs`            — LEGACY title-keyed override map (constructor
+ *                            arg). Kept for back-compat; merged into the
+ *                            prepared inputs by `prepare()`.
+ *   - `prepare(opts?)`    — idempotent: transpiles, scans inputs, runs
+ *                            visible-range static analysis. Caches result.
+ *   - `usesVisibleRange()`— derived from the cached prepare() result.
+ *
+ * For JS-function source the AST scan returns `[]`, so `input` is empty and
+ * per-key writes throw "unknown title". The legacy `inputs` field still
+ * works for that path.
+ */
+export class Indicator {
+    public readonly source: Function | string;
+    public inputs: Record<string, unknown>;
+    // `.input` is installed via Object.defineProperty in the constructor (lazy
+    // getter + replacement-throws setter). `declare` keeps the public type
+    // visible to TS without re-emitting a field initializer that would shadow
+    // the getter.
+    declare public readonly input: Record<string, unknown>;
+
+    // Lazy artifacts — populated on first prepare() call.
+    private _prepared: PreparedScript | null = null;
+    private _inputMeta: IPineInput[] | null = null;
+    private _inputValues: Record<string, unknown> = {};
+    private _explicitOverrides = new Set<string>(); // titles the user wrote via .input.X = ...
+    private _inputProxy: Record<string, unknown> | null = null;
+
+    constructor(source: Function | string, inputs: Record<string, unknown> = {}) {
+        this.source = source;
+        this.inputs = inputs;
+
+        // `.input` is a frozen container. The Proxy itself is lazy — built on
+        // first access so we don't pay the AST scan when callers never touch it.
+        Object.defineProperty(this, 'input', {
+            get: () => this._getInputProxy(),
+            set: () => {
+                throw new Error('[Indicator] .input cannot be replaced — mutate individual keys (e.g. ind.input["My Title"] = 20).');
+            },
+            enumerable: true,
+            configurable: false,
+        });
+    }
+
+    /**
+     * Normalize ANY accepted run() argument into an Indicator. Raw functions
+     * and strings get wrapped in a throwaway Indicator; existing Indicators
+     * pass through. This is the single entry point used by PineTS's run /
+     * stream / update so the rest of the engine only deals with Indicators.
+     */
+    public static from(arg: Indicator | Function | string): Indicator {
+        if (arg instanceof Indicator) return arg;
+        return new Indicator(arg);
+    }
+
+    /**
+     * Idempotent transpile + scan + viewport detection. The result is cached
+     * on the instance, so passing the same Indicator to multiple `pine.run()`
+     * calls produces a single transpilation pass.
+     *
+     * NB: cache is keyed by *instance identity*, not by options. If you need
+     * different debug settings, create a new Indicator.
+     */
+    public prepare(opts: { debug?: boolean; ln?: boolean } = {}): PreparedScript {
+        if (this._prepared) return this._prepared;
+
+        const fn = transpile(this.source, { debug: !!opts.debug, ln: opts.ln });
+
+        const usesVisibleRange = detectViewportUsage(fn);
+        const ltfSlices = (fn as any)._ltfSlices;
+
+        this._prepared = {
+            fn,
+            inputs: this.getRuntimeInputs(),
+            usesVisibleRange,
+            ltfSlices,
+        };
+        return this._prepared;
+    }
+
+    /** True iff the script references any built-in in `VIEWPORT_DEPENDENT_BUILTINS`. */
+    public usesVisibleRange(): boolean {
+        return this.prepare().usesVisibleRange;
+    }
+
+    /**
+     * Title-keyed input map used by the runtime (read by
+     * `input.utils.resolveInput`). Composed at call time so live mutations
+     * to `.input` between `pine.run()` calls are picked up automatically.
+     *
+     * Precedence:
+     *   1. Legacy constructor `inputs`            (back-compat)
+     *   2. Explicit writes to `.input[...]`       (new API; takes priority)
+     *
+     * Defaults are NOT included — the runtime falls back to `defval` when a
+     * title is absent.
+     */
+    public getRuntimeInputs(): Record<string, unknown> {
+        const out: Record<string, unknown> = { ...(this.inputs ?? {}) };
+        if (this._inputMeta) {
+            for (const title of this._explicitOverrides) {
+                out[title] = this._inputValues[title];
+            }
+        }
+        return out;
+    }
+
+    /**
+     * AST-parsed input metadata. Lazy. Empty array for JS-function source.
+     */
+    public getInputsMeta(): IPineInput[] {
+        this._ensureInputsScanned();
+        return this._inputMeta!;
+    }
+
+    // ── internals ───────────────────────────────────────────────────────
+
+    private _ensureInputsScanned(): void {
+        if (this._inputMeta) return;
+        this._inputMeta = scanInputs(this.source);
+        const built = buildInputProxy(this._inputMeta, (title) => this._explicitOverrides.add(title));
+        this._inputValues = built.values;
+        this._inputProxy = built.proxy;
+    }
+
+    private _getInputProxy(): Record<string, unknown> {
+        this._ensureInputsScanned();
+        return this._inputProxy!;
+    }
+}
+
+/**
+ * Static analysis on the transpiled function body: regex-scan for any of the
+ * documented host-bound built-ins (currently visible-range; extensible via
+ * VIEWPORT_DEPENDENT_BUILTINS). Comments are stripped during pine2js so this
+ * scan is comment-safe.
+ *
+ * This used to live as `_detectViewportUsage` on PineTS; it's now owned by
+ * the Indicator since it's purely a property of the script.
+ */
+function detectViewportUsage(fn: Function): boolean {
+    const body = fn.toString();
+    return VIEWPORT_DEPENDENT_BUILTINS.some((name) => {
+        const escaped = name.replace(/\./g, '\\.');
+        return new RegExp(`\\b${escaped}\\b`).test(body);
+    });
+}

--- a/src/Indicator/inputProxy.ts
+++ b/src/Indicator/inputProxy.ts
@@ -2,25 +2,15 @@
 // Copyright (C) 2026 LuxAlgo
 
 import type { IPineInput } from './types';
+import { buildKeyedProxy, type KeyedSchemaEntry } from './keyedProxy';
 
 /**
- * Build the live `.input` view exposed on an `Indicator` instance. It looks
- * and behaves like a plain object keyed by Pine input *titles*, but enforces
- * the contract:
+ * Build the live `.input` view exposed on an `Indicator` instance.
+ * Title-keyed; entries without an explicit `title=` on the Pine source are
+ * excluded (Pine's runtime keys overrides by title, so a title-less input is
+ * not overridable).
  *
- *   - Read: returns the current value (default OR user-overridden) at that title.
- *   - Write: validates against the IPineInput meta — type, options, minval,
- *     maxval, step — and stores the override. Invalid writes THROW.
- *   - Unknown keys (set OR delete) throw.
- *   - `Object.keys()` / `for (const k in p)` / `console.log(p)` show only the
- *     real input titles + their current values.
- *
- * The container itself is sealed by the Indicator class via
- * `Object.defineProperty(this, 'input', { set: throws })`; this proxy just
- * enforces per-key invariants.
- *
- * Inputs without an explicit `title=` on the Pine source are excluded — Pine's
- * runtime keys overrides by title, so a title-less input is not overridable.
+ * Backing machinery lives in `keyedProxy.ts` and is shared with `.prop`.
  */
 export function buildInputProxy(
     metas: IPineInput[],
@@ -30,121 +20,20 @@ export function buildInputProxy(
     values: Record<string, unknown>;
     metaByTitle: Map<string, IPineInput>;
 } {
-    const values: Record<string, unknown> = {};
     const metaByTitle = new Map<string, IPineInput>();
-
+    const entries: KeyedSchemaEntry[] = [];
     for (const m of metas) {
         if (!m.title) continue;
         metaByTitle.set(m.title, m);
-        values[m.title] = m.defval;
+        entries.push({
+            key: m.title,
+            type: m.type,
+            defval: m.defval,
+            options: m.options,
+            minval: m.minval,
+            maxval: m.maxval,
+        });
     }
-
-    const proxy = new Proxy(values, {
-        get(target, prop) {
-            if (typeof prop === 'symbol') return (target as any)[prop];
-            return target[prop as string];
-        },
-        set(target, prop, value) {
-            if (typeof prop !== 'string') return false;
-            const meta = metaByTitle.get(prop);
-            if (!meta) {
-                throw new Error(`[Indicator.input] unknown input title "${prop}". Known: ${[...metaByTitle.keys()].join(', ') || '(none)'}`);
-            }
-            validate(meta, value);
-            target[prop] = value;
-            onSet?.(prop);
-            return true;
-        },
-        deleteProperty(target, prop) {
-            throw new Error(`[Indicator.input] cannot delete "${String(prop)}" — input keys are fixed by the script's source.`);
-        },
-        defineProperty() {
-            throw new Error("[Indicator.input] cannot define new properties — input keys are fixed by the script's source.");
-        },
-        // ownKeys/getOwnPropertyDescriptor make Object.keys(), spread, and
-        // console.log show only real input titles with current values.
-        ownKeys(target) {
-            return Reflect.ownKeys(target);
-        },
-        getOwnPropertyDescriptor(target, prop) {
-            return Reflect.getOwnPropertyDescriptor(target, prop);
-        },
-        has(target, prop) {
-            return typeof prop === 'string' && prop in target;
-        },
-    });
-
+    const { proxy, values } = buildKeyedProxy(entries, 'Indicator.input', onSet, undefined, 'input title');
     return { proxy, values, metaByTitle };
-}
-
-/**
- * Per-meta validation. Throws on any rule violation — silent acceptance hides
- * bugs (and the user has explicitly opted into strict mode for this feature).
- */
-function validate(meta: IPineInput, value: unknown): void {
-    const title = meta.title ?? '<untitled>';
-
-    // Type coercion gate.
-    switch (meta.type) {
-        case 'int':
-            if (typeof value !== 'number' || !Number.isInteger(value)) {
-                throw new TypeError(`[Indicator.input] "${title}" expects an int; got ${describe(value)}`);
-            }
-            break;
-        case 'float':
-            if (typeof value !== 'number' || !Number.isFinite(value)) {
-                throw new TypeError(`[Indicator.input] "${title}" expects a float; got ${describe(value)}`);
-            }
-            break;
-        case 'bool':
-            if (typeof value !== 'boolean') {
-                throw new TypeError(`[Indicator.input] "${title}" expects a boolean; got ${describe(value)}`);
-            }
-            break;
-        case 'string':
-        case 'session':
-        case 'symbol':
-        case 'timeframe':
-        case 'text_area':
-        case 'color':
-        case 'enum':
-        case 'source':
-            if (typeof value !== 'string') {
-                throw new TypeError(`[Indicator.input] "${title}" expects a string; got ${describe(value)}`);
-            }
-            break;
-        case 'price':
-        case 'time':
-            if (typeof value !== 'number' || !Number.isFinite(value)) {
-                throw new TypeError(`[Indicator.input] "${title}" expects a number; got ${describe(value)}`);
-            }
-            break;
-    }
-
-    // options whitelist (if present)
-    if (meta.options && !meta.options.some((opt) => optionEquals(opt, value))) {
-        throw new RangeError(`[Indicator.input] "${title}" value ${describe(value)} is not one of: ${meta.options.map(describe).join(', ')}`);
-    }
-
-    // Numeric bounds
-    if (typeof value === 'number') {
-        if (typeof meta.minval === 'number' && value < meta.minval) {
-            throw new RangeError(`[Indicator.input] "${title}" value ${value} is below minval ${meta.minval}`);
-        }
-        if (typeof meta.maxval === 'number' && value > meta.maxval) {
-            throw new RangeError(`[Indicator.input] "${title}" value ${value} is above maxval ${meta.maxval}`);
-        }
-    }
-}
-
-function optionEquals(a: unknown, b: unknown): boolean {
-    if (a === b) return true;
-    if (typeof a === 'number' && typeof b === 'number') return Math.abs(a - b) < 1e-12;
-    return false;
-}
-
-function describe(v: unknown): string {
-    if (v === null) return 'null';
-    if (typeof v === 'string') return JSON.stringify(v);
-    return String(v);
 }

--- a/src/Indicator/inputProxy.ts
+++ b/src/Indicator/inputProxy.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import type { IPineInput } from './types';
+
+/**
+ * Build the live `.input` view exposed on an `Indicator` instance. It looks
+ * and behaves like a plain object keyed by Pine input *titles*, but enforces
+ * the contract:
+ *
+ *   - Read: returns the current value (default OR user-overridden) at that title.
+ *   - Write: validates against the IPineInput meta — type, options, minval,
+ *     maxval, step — and stores the override. Invalid writes THROW.
+ *   - Unknown keys (set OR delete) throw.
+ *   - `Object.keys()` / `for (const k in p)` / `console.log(p)` show only the
+ *     real input titles + their current values.
+ *
+ * The container itself is sealed by the Indicator class via
+ * `Object.defineProperty(this, 'input', { set: throws })`; this proxy just
+ * enforces per-key invariants.
+ *
+ * Inputs without an explicit `title=` on the Pine source are excluded — Pine's
+ * runtime keys overrides by title, so a title-less input is not overridable.
+ */
+export function buildInputProxy(
+    metas: IPineInput[],
+    onSet?: (title: string) => void,
+): {
+    proxy: Record<string, unknown>;
+    values: Record<string, unknown>;
+    metaByTitle: Map<string, IPineInput>;
+} {
+    const values: Record<string, unknown> = {};
+    const metaByTitle = new Map<string, IPineInput>();
+
+    for (const m of metas) {
+        if (!m.title) continue;
+        metaByTitle.set(m.title, m);
+        values[m.title] = m.defval;
+    }
+
+    const proxy = new Proxy(values, {
+        get(target, prop) {
+            if (typeof prop === 'symbol') return (target as any)[prop];
+            return target[prop as string];
+        },
+        set(target, prop, value) {
+            if (typeof prop !== 'string') return false;
+            const meta = metaByTitle.get(prop);
+            if (!meta) {
+                throw new Error(`[Indicator.input] unknown input title "${prop}". Known: ${[...metaByTitle.keys()].join(', ') || '(none)'}`);
+            }
+            validate(meta, value);
+            target[prop] = value;
+            onSet?.(prop);
+            return true;
+        },
+        deleteProperty(target, prop) {
+            throw new Error(`[Indicator.input] cannot delete "${String(prop)}" — input keys are fixed by the script's source.`);
+        },
+        defineProperty() {
+            throw new Error("[Indicator.input] cannot define new properties — input keys are fixed by the script's source.");
+        },
+        // ownKeys/getOwnPropertyDescriptor make Object.keys(), spread, and
+        // console.log show only real input titles with current values.
+        ownKeys(target) {
+            return Reflect.ownKeys(target);
+        },
+        getOwnPropertyDescriptor(target, prop) {
+            return Reflect.getOwnPropertyDescriptor(target, prop);
+        },
+        has(target, prop) {
+            return typeof prop === 'string' && prop in target;
+        },
+    });
+
+    return { proxy, values, metaByTitle };
+}
+
+/**
+ * Per-meta validation. Throws on any rule violation — silent acceptance hides
+ * bugs (and the user has explicitly opted into strict mode for this feature).
+ */
+function validate(meta: IPineInput, value: unknown): void {
+    const title = meta.title ?? '<untitled>';
+
+    // Type coercion gate.
+    switch (meta.type) {
+        case 'int':
+            if (typeof value !== 'number' || !Number.isInteger(value)) {
+                throw new TypeError(`[Indicator.input] "${title}" expects an int; got ${describe(value)}`);
+            }
+            break;
+        case 'float':
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                throw new TypeError(`[Indicator.input] "${title}" expects a float; got ${describe(value)}`);
+            }
+            break;
+        case 'bool':
+            if (typeof value !== 'boolean') {
+                throw new TypeError(`[Indicator.input] "${title}" expects a boolean; got ${describe(value)}`);
+            }
+            break;
+        case 'string':
+        case 'session':
+        case 'symbol':
+        case 'timeframe':
+        case 'text_area':
+        case 'color':
+        case 'enum':
+        case 'source':
+            if (typeof value !== 'string') {
+                throw new TypeError(`[Indicator.input] "${title}" expects a string; got ${describe(value)}`);
+            }
+            break;
+        case 'price':
+        case 'time':
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                throw new TypeError(`[Indicator.input] "${title}" expects a number; got ${describe(value)}`);
+            }
+            break;
+    }
+
+    // options whitelist (if present)
+    if (meta.options && !meta.options.some((opt) => optionEquals(opt, value))) {
+        throw new RangeError(`[Indicator.input] "${title}" value ${describe(value)} is not one of: ${meta.options.map(describe).join(', ')}`);
+    }
+
+    // Numeric bounds
+    if (typeof value === 'number') {
+        if (typeof meta.minval === 'number' && value < meta.minval) {
+            throw new RangeError(`[Indicator.input] "${title}" value ${value} is below minval ${meta.minval}`);
+        }
+        if (typeof meta.maxval === 'number' && value > meta.maxval) {
+            throw new RangeError(`[Indicator.input] "${title}" value ${value} is above maxval ${meta.maxval}`);
+        }
+    }
+}
+
+function optionEquals(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (typeof a === 'number' && typeof b === 'number') return Math.abs(a - b) < 1e-12;
+    return false;
+}
+
+function describe(v: unknown): string {
+    if (v === null) return 'null';
+    if (typeof v === 'string') return JSON.stringify(v);
+    return String(v);
+}

--- a/src/Indicator/keyedProxy.ts
+++ b/src/Indicator/keyedProxy.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+/**
+ * Generic title/name-keyed Proxy with per-key validation. Shared backend for
+ * both `Indicator.input` (keyed by input title) and `Indicator.prop` (keyed
+ * by declaration arg name).
+ *
+ * Contract:
+ *   - Read:    returns current value (default OR user-overridden) at the key.
+ *   - Write:   validates against the entry's meta — type, options, minval,
+ *              maxval — and stores the override. Invalid writes THROW with
+ *              a tailored message.
+ *   - Delete:  throws.
+ *   - Unknown key write: throws, listing the known keys.
+ *   - Object.keys() / spread / console.log show real keys with current values.
+ */
+
+export type KeyedType =
+    | 'int' | 'float' | 'bool' | 'string'
+    | 'source' | 'color' | 'enum'
+    | 'price' | 'time' | 'session'
+    | 'symbol' | 'timeframe' | 'text_area';
+
+export interface KeyedSchemaEntry {
+    key:      string;             // 'Length' for an input title, 'pyramiding' for a prop name
+    type:     KeyedType;
+    defval:   unknown;
+    options?: unknown[];
+    minval?:  number;
+    maxval?:  number;
+}
+
+export interface BuildKeyedProxyResult {
+    proxy:       Record<string, unknown>;
+    values:      Record<string, unknown>;
+    entryByKey:  Map<string, KeyedSchemaEntry>;
+}
+
+/**
+ * Build a keyed proxy view.
+ *
+ * @param entries  schema entries — defaults seeded into `values`
+ * @param label    display label for error messages, e.g. 'Indicator.input' or 'Indicator.prop'
+ * @param onSet    optional callback fired after a successful write (for explicit-override tracking)
+ * @param seedValues  optional initial values overriding entry defvals (used by .prop to seed
+ *                    source-code defaults on top of spec defaults)
+ * @param keyNoun  noun for the unknown-key message, defaults to 'key'. Inputs use 'input title'.
+ */
+export function buildKeyedProxy(
+    entries: KeyedSchemaEntry[],
+    label: string,
+    onSet?: (key: string) => void,
+    seedValues?: Record<string, unknown>,
+    keyNoun: string = 'key',
+): BuildKeyedProxyResult {
+    const values: Record<string, unknown> = {};
+    const entryByKey = new Map<string, KeyedSchemaEntry>();
+
+    for (const e of entries) {
+        entryByKey.set(e.key, e);
+        values[e.key] = seedValues && e.key in seedValues ? seedValues[e.key] : e.defval;
+    }
+
+    const proxy = new Proxy(values, {
+        get(target, prop) {
+            if (typeof prop === 'symbol') return (target as any)[prop];
+            return target[prop as string];
+        },
+        set(target, prop, value) {
+            if (typeof prop !== 'string') return false;
+            const entry = entryByKey.get(prop);
+            if (!entry) {
+                throw new Error(`[${label}] unknown ${keyNoun} "${prop}". Known: ${[...entryByKey.keys()].join(', ') || '(none)'}`);
+            }
+            validate(entry, value, label);
+            target[prop] = value;
+            onSet?.(prop);
+            return true;
+        },
+        deleteProperty(_target, prop) {
+            throw new Error(`[${label}] cannot delete "${String(prop)}" — keys are fixed by the script's source.`);
+        },
+        defineProperty() {
+            throw new Error(`[${label}] cannot define new properties — keys are fixed by the script's source.`);
+        },
+        ownKeys(target) { return Reflect.ownKeys(target); },
+        getOwnPropertyDescriptor(target, prop) { return Reflect.getOwnPropertyDescriptor(target, prop); },
+        has(target, prop) { return typeof prop === 'string' && prop in target; },
+    });
+
+    return { proxy, values, entryByKey };
+}
+
+/**
+ * Per-entry write validation. Throws on any rule violation.
+ */
+export function validate(entry: KeyedSchemaEntry, value: unknown, label: string): void {
+    const k = entry.key;
+
+    // Type gate
+    switch (entry.type) {
+        case 'int':
+            if (typeof value !== 'number' || !Number.isInteger(value)) {
+                throw new TypeError(`[${label}] "${k}" expects an int; got ${describe(value)}`);
+            }
+            break;
+        case 'float':
+        case 'price':
+        case 'time':
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                throw new TypeError(`[${label}] "${k}" expects a number; got ${describe(value)}`);
+            }
+            break;
+        case 'bool':
+            if (typeof value !== 'boolean') {
+                throw new TypeError(`[${label}] "${k}" expects a boolean; got ${describe(value)}`);
+            }
+            break;
+        case 'string':
+        case 'session':
+        case 'symbol':
+        case 'timeframe':
+        case 'text_area':
+        case 'color':
+        case 'enum':
+        case 'source':
+            if (typeof value !== 'string') {
+                throw new TypeError(`[${label}] "${k}" expects a string; got ${describe(value)}`);
+            }
+            break;
+    }
+
+    // options whitelist
+    if (entry.options && !entry.options.some((opt) => optionEquals(opt, value))) {
+        throw new RangeError(`[${label}] "${k}" value ${describe(value)} is not one of: ${entry.options.map(describe).join(', ')}`);
+    }
+
+    // Numeric bounds
+    if (typeof value === 'number') {
+        if (typeof entry.minval === 'number' && value < entry.minval) {
+            throw new RangeError(`[${label}] "${k}" value ${value} is below minval ${entry.minval}`);
+        }
+        if (typeof entry.maxval === 'number' && value > entry.maxval) {
+            throw new RangeError(`[${label}] "${k}" value ${value} is above maxval ${entry.maxval}`);
+        }
+    }
+}
+
+function optionEquals(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    if (typeof a === 'number' && typeof b === 'number') return Math.abs(a - b) < 1e-12;
+    return false;
+}
+
+function describe(v: unknown): string {
+    if (v === null) return 'null';
+    if (typeof v === 'string') return JSON.stringify(v);
+    return String(v);
+}

--- a/src/Indicator/propProxy.ts
+++ b/src/Indicator/propProxy.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import type { IPineProp } from './types';
+import { buildKeyedProxy, type KeyedSchemaEntry } from './keyedProxy';
+
+/**
+ * Build the live `.prop` view exposed on an `Indicator` instance.
+ * Name-keyed; non-mutable entries (`title`, `shorttitle`) are excluded.
+ *
+ * `sourceArgs` seeds source-code defaults on top of spec defaults so the
+ * read view matches what TradingView's runtime would see before any user
+ * override. Layer order: spec.defval ← sourceArgs ← user `.prop` writes.
+ *
+ * Backing machinery lives in `keyedProxy.ts` and is shared with `.input`.
+ */
+export function buildPropProxy(
+    props: IPineProp[],
+    sourceArgs: Record<string, unknown>,
+    onSet?: (name: string) => void,
+): {
+    proxy: Record<string, unknown>;
+    values: Record<string, unknown>;
+    propByName: Map<string, IPineProp>;
+} {
+    const propByName = new Map<string, IPineProp>();
+    const entries: KeyedSchemaEntry[] = [];
+    for (const p of props) {
+        propByName.set(p.name, p);
+        if (!p.mutable) continue;
+        // Map `enum` and other PinePropTypes onto KeyedType — they overlap directly.
+        entries.push({
+            key: p.name,
+            type: p.type as any,
+            defval: p.defval,
+            options: p.options,
+            minval: p.minval,
+            maxval: p.maxval,
+        });
+    }
+    const { proxy, values } = buildKeyedProxy(entries, 'Indicator.prop', onSet, sourceArgs);
+    return { proxy, values, propByName };
+}

--- a/src/Indicator/propsSchema.ts
+++ b/src/Indicator/propsSchema.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import type { IPineProp } from './types';
+
+/**
+ * Schema for `indicator()` / `strategy()` declaration arguments.
+ *
+ * Curated from the Pine v6 reference. Each entry includes a one-line comment
+ * enumerating the accepted runtime values and (where applicable) a pointer
+ * to the corresponding exported TypeScript enum so UI builders can import
+ * the same source of truth.
+ *
+ * `title` and `shorttitle` are included with `mutable: false` — they appear
+ * in `getPropsMeta()` for completeness but are filtered out of `.prop` writes.
+ */
+
+// ── Shared between indicator() and strategy() ─────────────────────────
+const SHARED_PROPS: IPineProp[] = [
+    // any const string — script title
+    { name: 'title', type: 'string', defval: '', mutable: false, appliesTo: 'both' },
+
+    // any const string — display name (overrides title in chart UI)
+    { name: 'shorttitle', type: 'string', defval: '', mutable: false, appliesTo: 'both' },
+
+    // true | false
+    { name: 'overlay', type: 'bool', defval: false, mutable: true, appliesTo: 'both' },
+
+    // 'inherit' | 'price' | 'volume' | 'percent' | 'mintick' — see `enum format` in src/namespaces/Types.ts
+    { name: 'format', type: 'enum', defval: 'inherit',
+      options: ['inherit', 'price', 'volume', 'percent', 'mintick'],
+      mutable: true, appliesTo: 'both' },
+
+    // 0..16 — number of fractional digits shown for plotted values
+    { name: 'precision', type: 'int', defval: 10, minval: 0, maxval: 16, mutable: true, appliesTo: 'both' },
+
+    // 'right' | 'left' | 'none' — see `enum scale` in src/namespaces/Types.ts
+    { name: 'scale', type: 'enum', defval: 'right',
+      options: ['right', 'left', 'none'],
+      mutable: true, appliesTo: 'both' },
+
+    // 0..5000 — minimum historical buffer length
+    { name: 'max_bars_back', type: 'int', defval: 0, minval: 0, maxval: 5000, mutable: true, appliesTo: 'both' },
+
+    // true | false — draw plots in script declaration order
+    { name: 'explicit_plot_zorder', type: 'bool', defval: false, mutable: true, appliesTo: 'both' },
+
+    // 1..500 — max line drawings retained
+    { name: 'max_lines_count', type: 'int', defval: 50, minval: 1, maxval: 500, mutable: true, appliesTo: 'both' },
+
+    // 1..500 — max label drawings retained
+    { name: 'max_labels_count', type: 'int', defval: 50, minval: 1, maxval: 500, mutable: true, appliesTo: 'both' },
+
+    // 1..500 — max box drawings retained
+    { name: 'max_boxes_count', type: 'int', defval: 50, minval: 1, maxval: 500, mutable: true, appliesTo: 'both' },
+
+    // 0..N — initial calculation limited to the last N historical bars (0 = all)
+    { name: 'calc_bars_count', type: 'int', defval: 0, minval: 0, mutable: true, appliesTo: 'both' },
+
+    // 1..100 — max polyline drawings retained
+    { name: 'max_polylines_count', type: 'int', defval: 50, minval: 1, maxval: 100, mutable: true, appliesTo: 'both' },
+
+    // true | false — allow request.*() calls in conditional/loop scopes (v6+)
+    { name: 'dynamic_requests', type: 'bool', defval: true, mutable: true, appliesTo: 'both', version: 6 },
+
+    // true | false — draw script behind the chart (requires overlay=true; v6+)
+    { name: 'behind_chart', type: 'bool', defval: true, mutable: true, appliesTo: 'both', version: 6 },
+];
+
+// ── indicator()-only ─────────────────────────────────────────────────
+export const INDICATOR_PROPS: IPineProp[] = [
+    ...SHARED_PROPS.filter(p => p.appliesTo === 'both').map(p => ({ ...p, appliesTo: 'indicator' as const })),
+
+    // any valid Pine timeframe string — e.g. "1", "5", "60", "1D", "1W", "1M", or "" for chart timeframe
+    { name: 'timeframe', type: 'string', defval: '', mutable: true, appliesTo: 'indicator' },
+
+    // true | false — show plots only when new HTF data is available
+    { name: 'timeframe_gaps', type: 'bool', defval: true, mutable: true, appliesTo: 'indicator' },
+];
+
+// ── strategy()-only ──────────────────────────────────────────────────
+export const STRATEGY_PROPS: IPineProp[] = [
+    ...SHARED_PROPS.filter(p => p.appliesTo === 'both').map(p => ({ ...p, appliesTo: 'strategy' as const })),
+
+    // 0..N — max same-direction entries allowed (0 = single entry per direction)
+    { name: 'pyramiding', type: 'int', defval: 0, minval: 0, mutable: true, appliesTo: 'strategy' },
+
+    // true | false — recalculate after each order fill
+    { name: 'calc_on_order_fills', type: 'bool', defval: false, mutable: true, appliesTo: 'strategy' },
+
+    // true | false — recalculate on every realtime tick (causes repainting)
+    { name: 'calc_on_every_tick', type: 'bool', defval: false, mutable: true, appliesTo: 'strategy' },
+
+    // 0..N (ticks) — minimum tick excursion before limit orders fill
+    { name: 'backtest_fill_limits_assumption', type: 'int', defval: 0, minval: 0, mutable: true, appliesTo: 'strategy' },
+
+    // 'fixed' | 'cash' | 'percent_of_equity' — corresponds to strategy.fixed / .cash / .percent_of_equity
+    { name: 'default_qty_type', type: 'enum', defval: 'fixed',
+      options: ['fixed', 'cash', 'percent_of_equity'],
+      mutable: true, appliesTo: 'strategy' },
+
+    // >= 0 — default trade quantity in units determined by default_qty_type
+    { name: 'default_qty_value', type: 'float', defval: 1, minval: 0, mutable: true, appliesTo: 'strategy' },
+
+    // >= 0 — starting capital in `currency` units
+    { name: 'initial_capital', type: 'float', defval: 1000000, minval: 0, mutable: true, appliesTo: 'strategy' },
+
+    // any of currency.* — see `enum currency` in src/namespaces/Types.ts (40+ codes incl. 'USD', 'USDT', 'EUR', 'BTC', 'NONE', ...)
+    { name: 'currency', type: 'enum', defval: 'USD',
+      options: ['AED','ARS','AUD','BDT','BHD','BRL','BTC','CAD','CHF','CLP','CNY','COP','CZK','DKK','EGP','ETH','EUR','GBP','HKD','HUF','IDR','ILS','INR','ISK','JPY','KES','KRW','KWD','LKR','MAD','MXN','MYR','NGN','NOK','NONE','NZD','PEN','PHP','PKR','PLN','QAR','RON','RSD','RUB','SAR','SEK','SGD','THB','TND','TRY','TWD','USD','USDT','VES','VND','ZAR'],
+      mutable: true, appliesTo: 'strategy' },
+
+    // 0..N — slippage in ticks applied against fill direction
+    { name: 'slippage', type: 'int', defval: 0, minval: 0, mutable: true, appliesTo: 'strategy' },
+
+    // 'percent' | 'cash_per_contract' | 'cash_per_order' — corresponds to strategy.commission.percent / .cash_per_contract / .cash_per_order
+    { name: 'commission_type', type: 'enum', defval: 'percent',
+      options: ['percent', 'cash_per_contract', 'cash_per_order'],
+      mutable: true, appliesTo: 'strategy' },
+
+    // >= 0 — commission per leg in units determined by commission_type
+    { name: 'commission_value', type: 'float', defval: 0, minval: 0, mutable: true, appliesTo: 'strategy' },
+
+    // true | false — execute orders after each bar closes
+    { name: 'process_orders_on_close', type: 'bool', defval: false, mutable: true, appliesTo: 'strategy' },
+
+    // 'FIFO' | 'ANY' — order in which trades are closed (bare strings, NOT a namespace constant)
+    { name: 'close_entries_rule', type: 'enum', defval: 'FIFO',
+      options: ['FIFO', 'ANY'],
+      mutable: true, appliesTo: 'strategy' },
+
+    // 0..100 — % of long position covered by collateral (0 = unlimited, 100 = no leverage)
+    { name: 'margin_long', type: 'float', defval: 100, minval: 0, maxval: 100, mutable: true, appliesTo: 'strategy' },
+
+    // 0..100 — % of short position covered by collateral (0 = unlimited, 100 = no leverage)
+    { name: 'margin_short', type: 'float', defval: 100, minval: 0, maxval: 100, mutable: true, appliesTo: 'strategy' },
+
+    // any number — annual % return of zero-risk investment (Sharpe / Sortino denominator)
+    { name: 'risk_free_rate', type: 'float', defval: 2, mutable: true, appliesTo: 'strategy' },
+
+    // true | false — use lower-timeframe bars for more realistic fills (Premium+ only)
+    { name: 'use_bar_magnifier', type: 'bool', defval: false, mutable: true, appliesTo: 'strategy' },
+
+    // true | false — force standard OHLC fills on Heikin Ashi charts
+    { name: 'fill_orders_on_standard_ohlc', type: 'bool', defval: false, mutable: true, appliesTo: 'strategy' },
+];
+
+/**
+ * Pick the right schema for a detected declaration type. Returns the
+ * indicator schema when type is unknown (sensible fallback per spec).
+ */
+export function propsForDeclaration(type: 'indicator' | 'strategy' | null): IPineProp[] {
+    return type === 'strategy' ? STRATEGY_PROPS : INDICATOR_PROPS;
+}

--- a/src/Indicator/scanDeclaration.ts
+++ b/src/Indicator/scanDeclaration.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import * as acorn from 'acorn';
+import { pineToJS } from '../transpiler/pineToJS/pineToJS.index';
+import { INDICATOR_PROPS, STRATEGY_PROPS } from './propsSchema';
+import type { IPineProp } from './types';
+
+/**
+ * Detect whether a script is a `strategy()` or `indicator()`, and extract
+ * the actual values passed to that call from source so they can seed
+ * `.prop` defaults.
+ *
+ * Both source kinds are handled:
+ *   - Pine string  → pineToJS() AST → walk for the top-level CallExpression
+ *   - JS function  → acorn.parse(fn.toString()) → walk for CallExpression with
+ *                    callee Identifier matching 'indicator' / 'strategy'
+ *
+ * Enum-typed args are resolved by the "rightmost-identifier rule": for any
+ * `MemberExpression` the rightmost `Identifier` name is the runtime string.
+ * Holds for every Pine-namespace constant accepted by indicator()/strategy()
+ * (format.percent → "percent", currency.USD → "USD",
+ *  strategy.percent_of_equity → "percent_of_equity",
+ *  strategy.commission.percent → "percent").
+ *
+ * Returns `{ type, args }`:
+ *   - type   = 'indicator' | 'strategy' | null
+ *   - args   = name → resolved value extracted from the source call
+ *
+ * If the declaration call isn't found, returns `{ type: null, args: {} }`.
+ * The Indicator class falls back to the indicator schema in that case.
+ */
+export interface ScannedDeclaration {
+    type: 'indicator' | 'strategy' | null;
+    args: Record<string, unknown>;
+}
+
+export function scanDeclaration(source: unknown): ScannedDeclaration {
+    if (typeof source === 'string') {
+        return scanPineDeclaration(source);
+    }
+    if (typeof source === 'function') {
+        return scanJsDeclaration(source);
+    }
+    return { type: null, args: {} };
+}
+
+// ── Pine source path ──────────────────────────────────────────────────
+
+function scanPineDeclaration(source: string): ScannedDeclaration {
+    const parsed = pineToJS(source);
+    if (!parsed.success || !parsed.ast) return { type: null, args: {} };
+
+    let found: ScannedDeclaration | null = null;
+    walk(parsed.ast, (node) => {
+        if (found) return;
+        if (node.type !== 'ExpressionStatement' && node.type !== 'VariableDeclaration') return;
+        const callExpr = node.type === 'ExpressionStatement'
+            ? node.expression
+            : node.declarations?.[0]?.init;
+        if (!callExpr || callExpr.type !== 'CallExpression') return;
+        const callee = callExpr.callee;
+        if (callee?.type !== 'Identifier') return;
+        if (callee.name !== 'indicator' && callee.name !== 'strategy') return;
+        found = {
+            type: callee.name,
+            args: decodeArgs(callExpr.arguments ?? [], schemaFor(callee.name)),
+        };
+    });
+    return found ?? { type: null, args: {} };
+}
+
+// ── JS function path ──────────────────────────────────────────────────
+
+function scanJsDeclaration(fn: Function): ScannedDeclaration {
+    let parsed: any;
+    try {
+        parsed = acorn.parse(`(${fn.toString()})`, { ecmaVersion: 'latest' });
+    } catch {
+        return { type: null, args: {} };
+    }
+    let found: ScannedDeclaration | null = null;
+    walk(parsed, (node) => {
+        if (found) return;
+        if (node.type !== 'CallExpression') return;
+        const callee = node.callee;
+        if (callee?.type !== 'Identifier') return;
+        if (callee.name !== 'indicator' && callee.name !== 'strategy') return;
+        found = {
+            type: callee.name,
+            args: decodeArgs(node.arguments ?? [], schemaFor(callee.name)),
+        };
+    });
+    return found ?? { type: null, args: {} };
+}
+
+// ── Shared decoders ──────────────────────────────────────────────────
+
+function schemaFor(type: 'indicator' | 'strategy'): IPineProp[] {
+    return type === 'strategy' ? STRATEGY_PROPS : INDICATOR_PROPS;
+}
+
+/**
+ * Decode positional args by walking the schema (which is ordered to match
+ * the Pine signature), then merge any trailing object literal as named args.
+ * Named args override positional bindings (matches Pine semantics where
+ * positional + named is illegal anyway).
+ */
+function decodeArgs(args: any[], schema: IPineProp[]): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    const lastArg = args[args.length - 1];
+    const hasNamedObject = lastArg?.type === 'ObjectExpression';
+    const positionals = hasNamedObject ? args.slice(0, -1) : args.slice();
+
+    for (let i = 0; i < positionals.length && i < schema.length; i++) {
+        const name = schema[i].name;
+        out[name] = resolveValue(positionals[i]);
+    }
+
+    if (hasNamedObject) {
+        for (const p of lastArg.properties ?? []) {
+            if (p.type !== 'Property' || !p.key?.name) continue;
+            out[p.key.name] = resolveValue(p.value);
+        }
+    }
+
+    return out;
+}
+
+/**
+ * AST node → JS primitive. The rightmost-identifier rule handles every Pine
+ * namespace constant accepted by indicator()/strategy() — see file header.
+ */
+function resolveValue(node: any): unknown {
+    if (node == null) return undefined;
+    switch (node.type) {
+        case 'Literal':
+            return node.value;
+        case 'Identifier':
+            return node.name;
+        case 'MemberExpression': {
+            // Walk to the rightmost Identifier across any depth of nesting.
+            let n = node;
+            while (n?.type === 'MemberExpression') n = n.property;
+            return n?.type === 'Identifier' ? n.name : undefined;
+        }
+        case 'UnaryExpression':
+            if (node.operator === '-' && node.argument?.type === 'Literal' && typeof node.argument.value === 'number') {
+                return -node.argument.value;
+            }
+            return undefined;
+        case 'ArrayExpression':
+            return (node.elements ?? []).map(resolveValue);
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Generic AST walker — same shape used by scanInputs.
+ */
+function walk(node: any, visit: (n: any) => void): void {
+    if (!node || typeof node !== 'object') return;
+    visit(node);
+    for (const k of Object.keys(node)) {
+        const v = (node as any)[k];
+        if (k === 'loc' || k === 'range' || k === 'start' || k === 'end') continue;
+        if (Array.isArray(v)) for (const child of v) walk(child, visit);
+        else if (v && typeof v === 'object' && typeof v.type === 'string') walk(v, visit);
+    }
+}

--- a/src/Indicator/scanInputs.ts
+++ b/src/Indicator/scanInputs.ts
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import { pineToJS } from '../transpiler/pineToJS/pineToJS.index';
+import type { IPineInput, PineInputType, PineInputDisplay } from './types';
+
+/**
+ * Walk a Pine script's AST and harvest every top-level (or nested) `input.*`
+ * declaration into an `IPineInput[]`. Returns `[]` for invalid Pine or for
+ * source that's a JS function.
+ *
+ * Two-pass design:
+ *   1. Collect enum tables — `enum X { a = "Alpha", b }` becomes
+ *      `{ "X.a": "Alpha", "X.b": "b" }` so we can later resolve
+ *      `MemberExpression(X, a)` references inside input.enum calls.
+ *   2. Walk for CallExpressions to `input.<fn>(...)`, decode positional +
+ *      named arguments into a typed `IPineInput`, resolving enum / source
+ *      identifier references to their runtime values.
+ *
+ * Inputs without an explicit `title=` keep `title === undefined`. The runtime
+ * lookup ALSO works keyed by `title`, so this is intentional — at runtime an
+ * input with no title isn't user-overridable (matches Pine semantics).
+ */
+
+const SOURCE_BUILTINS = new Set(['open', 'high', 'low', 'close', 'hl2', 'hlc3', 'ohlc4', 'hlcc4', 'volume']);
+
+// Per-function positional parameter order. Decoding rule: walk positional args
+// L→R; the Nth positional binds to the Nth param name here. Named args (any
+// trailing ObjectExpression) merge on top, overriding any positional binding.
+//
+// `input.float` / `input.int` have two overloads (options vs minval/maxval/step).
+// Both share the same first two params (`defval`, `title`); after that the
+// arguments are typically passed by name, so we only need to handle the
+// positional case via type-sniffing on the 3rd positional (array → options;
+// number → minval). Done in decodeIntFloatPositionals().
+const POSITIONAL_BY_FN: Record<string, readonly string[]> = {
+    // bare wrapper — auto-typed
+    '': ['defval', 'title', 'tooltip', 'inline', 'group', 'display', 'active'],
+    bool: ['defval', 'title', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    color: ['defval', 'title', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    enum: ['defval', 'title', 'options', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    price: ['defval', 'title', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    session: ['defval', 'title', 'options', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    source: ['defval', 'title', 'tooltip', 'inline', 'group', 'display', 'active', 'confirm'],
+    string: ['defval', 'title', 'options', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    symbol: ['defval', 'title', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    text_area: ['defval', 'title', 'tooltip', 'group', 'confirm', 'display', 'active'],
+    time: ['defval', 'title', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+    timeframe: ['defval', 'title', 'options', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'],
+};
+
+// Inferred type tag for each typed `input.<fn>(...)`. Bare `input(...)` is
+// detected from the defval (see inferAutoType).
+const TYPE_BY_FN: Record<string, PineInputType> = {
+    bool: 'bool',
+    color: 'color',
+    enum: 'enum',
+    float: 'float',
+    int: 'int',
+    price: 'price',
+    session: 'session',
+    source: 'source',
+    string: 'string',
+    symbol: 'symbol',
+    text_area: 'text_area',
+    time: 'time',
+    timeframe: 'timeframe',
+};
+
+type EnumTable = Map<string, unknown>; // "tz.utc" → "UTC"
+
+/**
+ * Public entry point. Returns `[]` for invalid Pine or for non-string source.
+ */
+export function scanInputs(source: unknown): IPineInput[] {
+    if (typeof source !== 'string') return [];
+
+    const parsed = pineToJS(source);
+    if (!parsed.success || !parsed.ast) return [];
+
+    const enumTable = collectEnumTable(parsed.ast);
+    const inputs: IPineInput[] = [];
+    const seenTitles = new Set<string>();
+    walk(parsed.ast, (node) => {
+        const meta = decodeInputCall(node, enumTable);
+        if (!meta) return;
+        if (meta.title !== undefined) {
+            if (seenTitles.has(meta.title)) {
+                // Pine allows multiple inputs sharing the same title (last wins
+                // at runtime). For the JS-side overview, the first one wins
+                // and we surface a warning so the collision is visible.
+                // eslint-disable-next-line no-console
+                console.warn(`[Indicator] duplicate input title "${meta.title}" — first declaration wins for .input access`);
+                return;
+            }
+            seenTitles.add(meta.title);
+        }
+        inputs.push(meta);
+    });
+    return inputs;
+}
+
+/**
+ * Pass 1: collect every enum's field-name → resolved-title mapping.
+ *
+ * After parser.parseEnumDefinition, `enum tz { utc = "UTC" }` is emitted as a
+ * VariableDeclaration whose declarator's `init` is an ObjectExpression with
+ * string-literal properties. We walk the program body once and record these.
+ */
+function collectEnumTable(ast: any): EnumTable {
+    const table: EnumTable = new Map();
+    walk(ast, (node) => {
+        if (node.type !== 'VariableDeclaration') return;
+        for (const decl of node.declarations ?? []) {
+            const enumName = decl?.id?.name;
+            const init = decl?.init;
+            if (!enumName || !init || init.type !== 'ObjectExpression') return;
+            // Every property must have a Literal string value — that's how
+            // parser.parseEnumDefinition emits it (vs. user-defined objects
+            // that may hold any expression).
+            const allStringLiterals = (init.properties ?? []).every((p: any) => p.value?.type === 'Literal' && typeof p.value.value === 'string');
+            if (!allStringLiterals || init.properties.length === 0) return;
+            for (const p of init.properties) {
+                table.set(`${enumName}.${p.key.name}`, p.value.value);
+            }
+        }
+    });
+    return table;
+}
+
+/**
+ * Decode a single AST node into an `IPineInput`, or return `null` if the node
+ * is not a top-level `input.<fn>(...)` call assigned to something.
+ *
+ * Recognized forms (after parser):
+ *   - `let len = input.int(14, "Len", ...)`  → VariableDeclaration → CallExpression
+ *   - `len = input.int(...)` is reassignment — also a VariableDeclaration because
+ *      Pine simple `=` lowers to `let` at the parser layer.
+ *
+ * Anything else returns null and is skipped.
+ */
+function decodeInputCall(node: any, enumTable: EnumTable): IPineInput | null {
+    if (node.type !== 'VariableDeclaration') return null;
+    for (const decl of node.declarations ?? []) {
+        const init = decl?.init;
+        if (!init || init.type !== 'CallExpression') continue;
+
+        // Match input.<fn>(...) or bare input(...).
+        const callee = init.callee;
+        let fnName: string | null = null;
+        if (
+            callee?.type === 'MemberExpression' &&
+            callee.object?.type === 'Identifier' &&
+            callee.object.name === 'input' &&
+            callee.property?.type === 'Identifier'
+        ) {
+            fnName = callee.property.name;
+        } else if (callee?.type === 'Identifier' && callee.name === 'input') {
+            fnName = ''; // bare wrapper
+        }
+        if (fnName === null) continue;
+        const isIntFloat = fnName === 'int' || fnName === 'float';
+        if (fnName !== '' && !isIntFloat && !(fnName in POSITIONAL_BY_FN)) continue;
+
+        // Split positionals from the trailing named-args ObjectExpression.
+        const args = init.arguments ?? [];
+        const lastArg = args[args.length - 1];
+        const hasNamed = lastArg?.type === 'ObjectExpression';
+        const positionals = hasNamed ? args.slice(0, -1) : args.slice();
+        const named: any[] = hasNamed ? (lastArg.properties ?? []) : [];
+
+        const raw: Record<string, any> = {};
+        if (fnName === 'int' || fnName === 'float') {
+            decodeIntFloatPositionals(positionals, named, raw);
+        } else {
+            decodePositionals(POSITIONAL_BY_FN[fnName], positionals, raw);
+        }
+        for (const p of named) {
+            if (p.type !== 'Property' || !p.key?.name) continue;
+            raw[p.key.name] = p.value;
+        }
+
+        // Now turn raw AST values into JS primitives, resolving enum + source refs.
+        const resolved: any = {};
+        for (const k of Object.keys(raw)) {
+            resolved[k] = resolveValue(raw[k], enumTable);
+        }
+
+        // Determine the type tag. For bare `input(...)`, infer from defval.
+        const type = fnName === '' ? inferAutoType(resolved.defval) : TYPE_BY_FN[fnName];
+        if (!type) continue;
+
+        const meta: IPineInput = { type, defval: resolved.defval };
+        if (resolved.title !== undefined) meta.title = String(resolved.title);
+        if (resolved.tooltip !== undefined) meta.tooltip = String(resolved.tooltip);
+        if (resolved.group !== undefined) meta.group = String(resolved.group);
+        if (resolved.inline !== undefined) meta.inline = String(resolved.inline);
+        if (resolved.confirm !== undefined) meta.confirm = Boolean(resolved.confirm);
+        if (resolved.active !== undefined) meta.active = Boolean(resolved.active);
+        if (resolved.display !== undefined) meta.display = normalizeDisplay(resolved.display);
+        if (resolved.options !== undefined && Array.isArray(resolved.options)) meta.options = resolved.options;
+        if (typeof resolved.minval === 'number') meta.minval = resolved.minval;
+        if (typeof resolved.maxval === 'number') meta.maxval = resolved.maxval;
+        if (typeof resolved.step === 'number') meta.step = resolved.step;
+
+        return meta;
+    }
+    return null;
+}
+
+/**
+ * Positional decoder for `input.int` / `input.float`. They share two
+ * overloads — the 3rd positional is either `options` (array) or `minval`
+ * (number). When the 3rd positional is an `ArrayExpression`, we treat it as
+ * the options overload (and bind positions [defval, title, options, tooltip,
+ * inline, group, confirm, display, active]). Otherwise we treat positions
+ * [3, 4, 5] as [minval, maxval, step].
+ */
+function decodeIntFloatPositionals(positionals: any[], named: any[], raw: Record<string, any>): void {
+    const namedNames = new Set(named.map((p) => p.key?.name).filter(Boolean));
+    const sniffOptionsOverload = namedNames.has('options') || positionals[2]?.type === 'ArrayExpression';
+    const layout = sniffOptionsOverload
+        ? ['defval', 'title', 'options', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active']
+        : ['defval', 'title', 'minval', 'maxval', 'step', 'tooltip', 'inline', 'group', 'confirm', 'display', 'active'];
+    decodePositionals(layout, positionals, raw);
+}
+
+function decodePositionals(layout: readonly string[], positionals: any[], raw: Record<string, any>): void {
+    for (let i = 0; i < positionals.length && i < layout.length; i++) {
+        const name = layout[i];
+        if (raw[name] === undefined) raw[name] = positionals[i];
+    }
+}
+
+/**
+ * AST node → JS primitive. Handles enum-field refs (MemberExpression),
+ * source-builtin refs (Identifier), arrays, and falls through to Literal.value.
+ *
+ * Anything we can't resolve becomes `undefined` — better than recording
+ * an opaque AST node that the JS caller can't inspect.
+ */
+function resolveValue(node: any, enumTable: EnumTable): unknown {
+    if (node == null) return undefined;
+    switch (node.type) {
+        case 'Literal':
+            return node.value;
+        case 'Identifier':
+            if (SOURCE_BUILTINS.has(node.name)) return node.name; // input.source(close, …)
+            // Could be a display constant if used without the `display.` prefix
+            // (rare but valid in Pine). Treat as the bare name.
+            return node.name;
+        case 'MemberExpression': {
+            // Enum field — tz.utc → "UTC"
+            const objName = node.object?.type === 'Identifier' ? node.object.name : null;
+            const propName = node.property?.type === 'Identifier' ? node.property.name : null;
+            if (objName && propName) {
+                const key = `${objName}.${propName}`;
+                if (enumTable.has(key)) return enumTable.get(key);
+                // display.none / display.all / etc. — keep the suffix
+                if (objName === 'display') return propName;
+                // color.red, color.blue, etc. — return as the qualified path,
+                // the caller-facing string is good enough for overrides.
+                return key;
+            }
+            return undefined;
+        }
+        case 'ArrayExpression':
+            return (node.elements ?? []).map((el: any) => resolveValue(el, enumTable));
+        case 'UnaryExpression':
+            // -3.14 ends up here for negative number literals.
+            if (node.operator === '-' && node.argument?.type === 'Literal' && typeof node.argument.value === 'number') {
+                return -node.argument.value;
+            }
+            return undefined;
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Infer the type tag of the bare `input(defval, ...)` wrapper from the defval.
+ * Mirrors Pine's own runtime auto-detection.
+ */
+function inferAutoType(defval: unknown): PineInputType | null {
+    if (typeof defval === 'boolean') return 'bool';
+    if (typeof defval === 'number') return Number.isInteger(defval) ? 'int' : 'float';
+    if (typeof defval === 'string') {
+        // Source built-ins resolved by resolveValue() come through as strings
+        if (SOURCE_BUILTINS.has(defval)) return 'source';
+        // Color hex literals start with '#'
+        if (defval.startsWith('#')) return 'color';
+        return 'string';
+    }
+    return null;
+}
+
+function normalizeDisplay(v: unknown): PineInputDisplay | undefined {
+    if (typeof v !== 'string') return undefined;
+    const m = v.startsWith('display.') ? v.slice(8) : v;
+    if (m === 'none' || m === 'data_window' || m === 'status_line' || m === 'all') return m;
+    return undefined;
+}
+
+/**
+ * Depth-first AST walker. Visits every plausible-host of nested declarations
+ * (Program, BlockStatement, IfStatement consequent/alternate, FunctionDeclaration
+ * body, For/While body). Bare `ASTNode`s without children are no-ops.
+ */
+function walk(node: any, visit: (n: any) => void): void {
+    if (!node || typeof node !== 'object') return;
+    visit(node);
+    if (Array.isArray(node.body)) {
+        for (const child of node.body) walk(child, visit);
+    } else if (node.body) {
+        walk(node.body, visit);
+    }
+    if (Array.isArray(node.consequent)) {
+        for (const child of node.consequent) walk(child, visit);
+    } else if (node.consequent) {
+        walk(node.consequent, visit);
+    }
+    if (node.alternate) walk(node.alternate, visit);
+    if (Array.isArray(node.declarations)) {
+        for (const child of node.declarations) walk(child, visit);
+    }
+}

--- a/src/Indicator/types.ts
+++ b/src/Indicator/types.ts
@@ -70,6 +70,42 @@ export interface IPineInput {
 }
 
 /**
+ * Pine Script declaration-arg typing classification (used by `IPineProp`).
+ *
+ * `enum` covers every Pine-namespace constant used as a declaration arg
+ * (e.g. `format.percent`, `currency.USD`, `strategy.percent_of_equity`).
+ * The scanner resolves these to bare strings via the rightmost-identifier
+ * rule, matching what the runtime sees.
+ */
+export type PinePropType = 'string' | 'int' | 'float' | 'bool' | 'enum';
+
+/**
+ * Schema entry for a single `indicator()` / `strategy()` declaration argument.
+ *
+ * The full set of entries is curated from the Pine v6 reference:
+ *   - https://www.tradingview.com/pine-script-reference/v6/#fun_indicator
+ *   - https://www.tradingview.com/pine-script-reference/v6/#fun_strategy
+ *
+ * `title` and `shorttitle` are present in the schema with `mutable: false`
+ * so UI consumers can render them, but are filtered out of `.prop` writes.
+ *
+ * For enum-typed entries, `options` enumerates the accepted runtime strings.
+ * The schema source file points to the corresponding exported Pine enum
+ * (e.g. `enum format` in Types.ts) so JS callers can import the same source.
+ */
+export interface IPineProp {
+    name:        string;                      // 'initial_capital', 'pyramiding', ...
+    type:        PinePropType;
+    defval:      unknown;                     // Pine-spec default
+    options?:    unknown[];                   // enum: accepted runtime values
+    minval?:     number;
+    maxval?:     number;
+    mutable:     boolean;                     // false for title/shorttitle
+    appliesTo:   'indicator' | 'strategy' | 'both';
+    version?:    5 | 6;                       // 6 = v6-only (behind_chart, dynamic_requests)
+}
+
+/**
  * Result of `Indicator.prepare()`. The single artifact handed to the engine.
  *
  * `inputs` is the title-keyed map the runtime already expects — built by

--- a/src/Indicator/types.ts
+++ b/src/Indicator/types.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+/**
+ * Pine Script `input.*` typing classification. Mirrors TradingView's input
+ * widget types 1:1. The bare `input()` wrapper auto-detects from `defval`
+ * and dispatches to one of these — there is no `'auto'` member.
+ *
+ * v6 adds `'enum'`. Everything else exists in both v5 and v6.
+ */
+export type PineInputType =
+    | 'int'
+    | 'float'
+    | 'bool'
+    | 'string'
+    | 'source'
+    | 'color'
+    | 'enum'
+    | 'price'
+    | 'time'
+    | 'session'
+    | 'symbol'
+    | 'timeframe'
+    | 'text_area';
+
+/**
+ * Value of an input's `display=` argument. Stored as the suffix (without the
+ * `display.` prefix), matching what the existing runtime parses into
+ * `InputOptions.display` at the call site.
+ */
+export type PineInputDisplay = 'none' | 'data_window' | 'status_line' | 'all';
+
+/**
+ * Parsed metadata for a single `input.*` declaration in a Pine script.
+ *
+ * Field presence matches the Pine reference (v6 superset):
+ *   - title, tooltip, group, display, active        — universal (all 14 fns)
+ *   - inline                                         — universal except text_area
+ *   - confirm                                        — universal except bare input()
+ *   - options                                        — enum, float, int, session, string, timeframe
+ *   - minval / maxval / step                         — float, int only
+ *
+ * `defval` is fully resolved at scan time — for enum inputs we resolve
+ * `tz.utc` → "UTC" (the field title) so JS callers see what TradingView's
+ * `str.tostring()` would print, never the AST path.
+ */
+export interface IPineInput {
+    // Always present
+    type: PineInputType;
+    defval: unknown;
+
+    // Universal optional
+    title?: string;
+    tooltip?: string;
+    group?: string;
+    display?: PineInputDisplay;
+    active?: boolean; // v6+ only
+
+    // Almost-universal — accepted by everything except bare input()
+    confirm?: boolean;
+
+    // Universal except input.text_area
+    inline?: string;
+
+    // Subset
+    options?: unknown[]; // enum/float/int/session/string/timeframe
+    minval?: number; // float/int
+    maxval?: number; // float/int
+    step?: number; // float/int
+}
+
+/**
+ * Result of `Indicator.prepare()`. The single artifact handed to the engine.
+ *
+ * `inputs` is the title-keyed map the runtime already expects — built by
+ * merging each `IPineInput`'s current value (post-user-override) into a
+ * flat `{ [title]: value }` object that `input.utils.resolveInput()` reads.
+ */
+export interface PreparedScript {
+    fn: Function;
+    inputs: Record<string, unknown>;
+    usesVisibleRange: boolean;
+    ltfSlices?: any[]; // request.security_lower_tf transpile-time slices
+}

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -1080,6 +1080,11 @@ export class PineTS {
         context.__maxLoops = this._maxLoops;
         context._alertMode = this._alertMode;
 
+        // User-explicit prop overrides flow from the Indicator to the runtime.
+        // Read by Core.indicator() and initializeStrategy/strategy.any() to
+        // merge on top of source-code declaration args.
+        context._propOverrides = this._currentIndicator?.getRuntimePropOverrides() ?? {};
+
         context.pineTSCode = pineTSCode;
         context.isSecondaryContext = isSecondary; // Set secondary context flag
         context.data.close = new Series([]);

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2025 Alaa-eddine KADDOURI
-import { transpile } from '@pinets/transpiler/index';
-import { VIEWPORT_DEPENDENT_BUILTINS } from '@pinets/transpiler/settings';
 import { IProvider, ISymbolInfo } from './marketData/IProvider';
 import { Context } from './Context.class';
 import { Series } from './Series';
@@ -65,6 +63,11 @@ export class PineTS {
         return this._transpiledCode;
     }
 
+    // Tracks the most recently prepared Indicator. Used by the back-compat
+    // forwarding paths (e.g. `usesVisibleRange()`) and by the internal
+    // _initializeContext to surface the original pineTSCode on the Context.
+    private _currentIndicator: Indicator | null = null;
+
     private _isSecondaryContext: boolean = false;
     public markAsSecondary() {
         this._isSecondaryContext = true;
@@ -116,7 +119,9 @@ export class PineTS {
     private _viewportLeft: number | undefined = undefined;
     private _viewportRight: number | undefined = undefined;
 
-    // Set by _transpileCode() via static analysis of the transpiled output.
+    // Set by `run()` from the prepared Indicator. Mirrors the Indicator's own
+    // `usesVisibleRange` flag on the PineTS instance so legacy callers of
+    // `pine.usesVisibleRange()` keep working.
     // True iff the script references any built-in in VIEWPORT_DEPENDENT_BUILTINS.
     // Consumers should check this before re-running on viewport changes — non-
     // viewport-dependent scripts produce identical output regardless of viewport.
@@ -313,22 +318,18 @@ export class PineTS {
      * @returns Context if pageSize is 0 or undefined, or AsyncGenerator<Context> if pageSize > 0
      */
     public run(pineTSCode: Indicator | Function | String, periods?: number, pageSize?: number): Promise<Context> | AsyncGenerator<Context> {
-        let code: Function | String;
-        let inputs: Record<string, any> = {};
-
-        if (pineTSCode instanceof Indicator) {
-            code = pineTSCode.source;
-            inputs = pineTSCode.inputs || {};
-        } else {
-            code = pineTSCode;
-        }
+        const ind = Indicator.from(pineTSCode as any);
+        this._currentIndicator = ind;
+        // NB: `ind.prepare()` may throw synchronously for malformed Pine /
+        // unparseable JS. We push it inside the async path so the throw
+        // surfaces as a Promise rejection (matches the pre-refactor contract:
+        // `await pine.run(badCode)` rejects, never throws synchronously).
 
         if (pageSize && pageSize > 0) {
-            // livemode is enabled if eDate is undefined and we're using a provider as a source
             const enableLiveStream = typeof this.eDate === 'undefined' && !Array.isArray(this.source);
-            return this._runPaginated(code, inputs, periods, pageSize, enableLiveStream);
+            return this._runPaginated(ind, periods, pageSize, enableLiveStream);
         } else {
-            return this._runComplete(code, inputs, periods);
+            return this._runComplete(ind, periods);
         }
     }
 
@@ -346,15 +347,10 @@ export class PineTS {
         const { live = true, interval = 1000 } = options;
         const pageSize = options.pageSize || this.data.length; // Default pageSize to full data if not provided
 
-        let code: Function | String;
-        let inputs: Record<string, any> = {};
-
-        if (pineTSCode instanceof Indicator) {
-            code = pineTSCode.source;
-            inputs = pineTSCode.inputs || {};
-        } else {
-            code = pineTSCode;
-        }
+        const ind = Indicator.from(pineTSCode as any);
+        this._currentIndicator = ind;
+        // prepare() is deferred to inside _runPaginated so transpile errors
+        // surface as Promise rejections on the stream's `error` event.
 
         const listeners: { [key: string]: Function[] } = { data: [], error: [], warning: [], alert: [] };
         let stopped = false;
@@ -389,7 +385,7 @@ export class PineTS {
 
                 // Pass undefined for periods to include all data
                 // We use the generator version directly to control enableLiveStream
-                const iterator = this._runPaginated(code, inputs, undefined, pageSize, enableLiveStream);
+                const iterator = this._runPaginated(ind, undefined, pageSize, enableLiveStream);
 
                 for await (const ctx of iterator) {
                     if (stopped) break;
@@ -465,7 +461,7 @@ export class PineTS {
         const slices = (transpiledFn as any)._ltfSlices;
         if (slices) (context as any)._ltfTruncatedBodies = slices;
 
-        await this._executeIterations(context, this._transpiledCode, this.data.length - periods, this.data.length);
+        await this._executeIterations(context, transpiledFn, this.data.length - periods, this.data.length);
 
         return context;
     }
@@ -480,18 +476,20 @@ export class PineTS {
      * occurred when var variables were modified in-place during re-execution.
      * @private
      */
-    private async _runComplete(pineTSCode: Function | String, inputs: Record<string, any>, periods?: number): Promise<Context> {
+    private async _runComplete(ind: Indicator, periods?: number): Promise<Context> {
         await this.ready();
         if (!periods) periods = this.data.length;
 
-        const context = this._initializeContext(pineTSCode, inputs, this._isSecondaryContext);
-        this._transpiledCode = this._transpileCode(pineTSCode);
+        const prepared = ind.prepare(this._debugSettings);
+        this._usesVisibleRange = prepared.usesVisibleRange;
+
+        const context = this._initializeContext(ind.source ?? null as any, prepared.inputs, this._isSecondaryContext);
+        this._transpiledCode = prepared.fn;
         // Propagate transpile-time slices (one per request.security_lower_tf
         // call site) onto the Context so the slow path of the LTF runtime
         // can pick the right truncated body to run in the secondary
         // instead of the FULL user script.
-        const slices = (this._transpiledCode as any)._ltfSlices;
-        if (slices) (context as any)._ltfTruncatedBodies = slices;
+        if (prepared.ltfSlices) (context as any)._ltfTruncatedBodies = prepared.ltfSlices;
 
         // Split execution: process all bars except the last, snapshot, then
         // process the last bar. This gives updateTail() a reliable restore
@@ -500,13 +498,13 @@ export class PineTS {
         const endIdx = this.data.length;
 
         if (endIdx - startIdx > 1) {
-            await this._executeIterations(context, this._transpiledCode, startIdx, endIdx - 1);
+            await this._executeIterations(context, prepared.fn, startIdx, endIdx - 1);
             (context as any)._varSnapshot = this._snapshotVarState(context);
-            await this._executeIterations(context, this._transpiledCode, endIdx - 1, endIdx);
+            await this._executeIterations(context, prepared.fn, endIdx - 1, endIdx);
         } else {
             // Single bar: no meaningful pre-last range to snapshot; execute directly.
             // updateTail() will fall back to _removeLastResult on this context.
-            await this._executeIterations(context, this._transpiledCode, startIdx, endIdx);
+            await this._executeIterations(context, prepared.fn, startIdx, endIdx);
         }
 
         return context;
@@ -519,8 +517,7 @@ export class PineTS {
      * @private
      */
     private async *_runPaginated(
-        pineTSCode: Function | String,
-        inputs: Record<string, any>,
+        ind: Indicator,
         periods: number | undefined,
         pageSize: number,
         enableLiveStream: boolean = false,
@@ -528,10 +525,12 @@ export class PineTS {
         await this.ready();
         if (!periods) periods = this.data.length;
 
-        const context = this._initializeContext(pineTSCode, inputs, this._isSecondaryContext);
-        this._transpiledCode = this._transpileCode(pineTSCode);
-        const slices = (this._transpiledCode as any)._ltfSlices;
-        if (slices) (context as any)._ltfTruncatedBodies = slices;
+        const prepared = ind.prepare(this._debugSettings);
+        this._usesVisibleRange = prepared.usesVisibleRange;
+
+        const context = this._initializeContext(ind.source ?? null as any, prepared.inputs, this._isSecondaryContext);
+        this._transpiledCode = prepared.fn;
+        if (prepared.ltfSlices) (context as any)._ltfTruncatedBodies = prepared.ltfSlices;
 
         const startIdx = this.data.length - periods;
         let processedUpToIdx = startIdx; // Track what we've fully processed
@@ -1098,39 +1097,6 @@ export class PineTS {
         context.length = this.data.length;
 
         return context;
-    }
-
-    /**
-     * Transpile the Pine Script code
-     * @private
-     */
-    private _transpileCode(pineTSCode: Function | String): Function {
-        const transformer = transpile.bind(this);
-        const fn = transformer(pineTSCode, this._debugSettings);
-        this._usesVisibleRange = this._detectViewportUsage(fn);
-        return fn;
-    }
-
-    /**
-     * Static analysis on the transpiled function body to detect references to
-     * host-bound built-ins (currently visible-range; extensible via
-     * VIEWPORT_DEPENDENT_BUILTINS). Comments are stripped during pine2js, so
-     * scanning the post-transpile output is comment-safe.
-     *
-     * Why post-transpile (not regex on Pine source): a `chart.left_visible_bar_time`
-     * literal inside a // comment would be a false positive at the source level.
-     * After pine2js, only live code remains.
-     *
-     * Why regex (not AST visitor): `chart` is a reserved namespace in
-     * KNOWN_NAMESPACES — Pine scripts cannot shadow it with a local identifier,
-     * so a whole-word match on `chart.<prop>` is unambiguous.
-     */
-    private _detectViewportUsage(fn: Function): boolean {
-        const body = fn.toString();
-        return VIEWPORT_DEPENDENT_BUILTINS.some((name) => {
-            const escaped = name.replace(/\./g, '\\.');
-            return new RegExp(`\\b${escaped}\\b`).test(body);
-        });
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export { computeNextPeriodStart, localTimeToUTC, computeSessionClose, TIMEFRAME_
 export { aggregateCandles, selectSubTimeframe, getAggregationRatio } from './marketData/aggregation';
 
 export { PineTS, Context, Provider, Indicator, PineRuntimeError };
+export type { IPineInput, PineInputType, PineInputDisplay, PreparedScript } from './Indicator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,5 @@ export { computeNextPeriodStart, localTimeToUTC, computeSessionClose, TIMEFRAME_
 export { aggregateCandles, selectSubTimeframe, getAggregationRatio } from './marketData/aggregation';
 
 export { PineTS, Context, Provider, Indicator, PineRuntimeError };
-export type { IPineInput, PineInputType, PineInputDisplay, PreparedScript } from './Indicator';
+export type { IPineInput, IPineProp, PineInputType, PineInputDisplay, PinePropType, PreparedScript } from './Indicator';
+export { INDICATOR_PROPS, STRATEGY_PROPS, propsForDeclaration } from './Indicator';

--- a/src/namespaces/Core.ts
+++ b/src/namespaces/Core.ts
@@ -229,7 +229,8 @@ export class Core {
             behind_chart: true,
         };
         //TODO : most of these values are not actually used by PineTS, future work should be done to implement them
-        this.context.indicator = { ...defaults, ...options };
+        // Layer order: spec defaults ← source call args ← user .prop overrides (latest wins).
+        this.context.indicator = { ...defaults, ...options, ...(this.context._propOverrides ?? {}) };
         return this.context.indicator;
     }
 

--- a/src/namespaces/strategy/methods/any.ts
+++ b/src/namespaces/strategy/methods/any.ts
@@ -15,8 +15,9 @@ export function any(context: any) {
         if (!context.strategy) {
             initializeStrategy(context, options);
         } else {
-            // Update config if called again (though this shouldn't happen normally)
-            context.strategy.config = { ...context.strategy.config, ...options };
+            // Update config if called again (though this shouldn't happen normally).
+            // User .prop overrides re-apply on top so the same layer order holds across calls.
+            context.strategy.config = { ...context.strategy.config, ...options, ...(context._propOverrides ?? {}) };
         }
 
         return context.strategy.config;

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -1474,7 +1474,8 @@ export function initializeStrategy(context: any, config: any): void {
         fill_orders_on_standard_ohlc: false,
     };
 
-    const finalConfig = { ...defaults, ...config };
+    // Layer order: spec defaults ← source call args ← user .prop overrides (latest wins).
+    const finalConfig = { ...defaults, ...config, ...(context._propOverrides ?? {}) };
     const initialCapital = finalConfig.initial_capital;
 
     context.strategy = {

--- a/tests/Indicator/Indicator.props.test.ts
+++ b/tests/Indicator/Indicator.props.test.ts
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import { describe, it, expect } from 'vitest';
+import { Indicator } from '../../src/Indicator';
+import { PineTS } from '../../src/PineTS.class';
+
+function makeData(n = 20) {
+    const out: any[] = [];
+    const t0 = new Date('2024-01-01T00:00:00Z').getTime();
+    const DAY = 86_400_000;
+    for (let i = 0; i < n; i++) {
+        const base = 100 + i * 0.6;
+        out.push({
+            openTime: t0 + i * DAY,
+            open: base, high: base + 1.5, low: base - 0.8, close: base + 0.4,
+            volume: 1000, closeTime: t0 + (i + 1) * DAY - 1,
+        });
+    }
+    return out;
+}
+
+describe('Indicator props', () => {
+
+    // ── Declaration-type detection ────────────────────────────────────
+    describe('detects declaration type', () => {
+        it('detects indicator() from Pine source', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            expect(ind.getDeclarationType()).toBe('indicator');
+        });
+
+        it('detects strategy() from Pine source', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            expect(ind.getDeclarationType()).toBe('strategy');
+        });
+
+        it('falls back to indicator schema when neither call is found', () => {
+            const ind = new Indicator(`//@version=6\nplot(close)`);
+            expect(ind.getDeclarationType()).toBe(null);
+            // schema fallback: indicator's mutable props are available
+            expect(typeof (ind.prop as any)['overlay']).toBe('boolean');
+        });
+
+        it('detects from JS-function source via acorn', () => {
+            const fn = ($: any) => {
+                const { strategy } = $.pine;
+                strategy('JS Strat', { initial_capital: 50000 });
+            };
+            const ind = new Indicator(fn);
+            expect(ind.getDeclarationType()).toBe('strategy');
+        });
+    });
+
+    // ── Source-code defaults flow into .prop ──────────────────────────
+    describe('seeds defaults from source code', () => {
+        it('reads positional + named args from strategy()', () => {
+            const code = `
+//@version=6
+strategy("My Strat", overlay=true, initial_capital=50000, pyramiding=3,
+         currency=currency.EUR, default_qty_type=strategy.percent_of_equity)
+plot(close)
+`;
+            const ind = new Indicator(code);
+            const view = ind.prop as any;
+            expect(view['overlay']).toBe(true);                        // from source (spec default false)
+            expect(view['initial_capital']).toBe(50000);               // from source
+            expect(view['pyramiding']).toBe(3);                        // from source
+            expect(view['currency']).toBe('EUR');                      // enum resolved via rightmost-identifier
+            expect(view['default_qty_type']).toBe('percent_of_equity'); // ditto
+            expect(view['slippage']).toBe(0);                          // spec default (source didn't set it)
+        });
+
+        it('resolves nested namespace constants (strategy.commission.percent)', () => {
+            const code = `
+//@version=6
+strategy("X", commission_type=strategy.commission.cash_per_order, commission_value=5)
+plot(close)
+`;
+            const view = new Indicator(code).prop as any;
+            expect(view['commission_type']).toBe('cash_per_order');
+            expect(view['commission_value']).toBe(5);
+        });
+
+        it('resolves format / scale namespace constants', () => {
+            const code = `
+//@version=6
+indicator("X", format=format.percent, scale=scale.left)
+plot(close)
+`;
+            const view = new Indicator(code).prop as any;
+            expect(view['format']).toBe('percent');
+            expect(view['scale']).toBe('left');
+        });
+    });
+
+    // ── getPropsMeta() filtering ──────────────────────────────────────
+    describe('getPropsMeta()', () => {
+        it('returns only indicator-applicable props for indicators', () => {
+            const meta = new Indicator(`//@version=6\nindicator("X")\nplot(close)`).getPropsMeta();
+            const names = meta.map((m) => m.name);
+            expect(names).toContain('overlay');
+            expect(names).toContain('timeframe');                  // indicator-only
+            expect(names).toContain('timeframe_gaps');
+            expect(names).not.toContain('pyramiding');             // strategy-only
+            expect(names).not.toContain('initial_capital');
+        });
+
+        it('returns only strategy-applicable props for strategies', () => {
+            const meta = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`).getPropsMeta();
+            const names = meta.map((m) => m.name);
+            expect(names).toContain('pyramiding');
+            expect(names).toContain('initial_capital');
+            expect(names).toContain('commission_type');
+            expect(names).not.toContain('timeframe');              // indicator-only
+            expect(names).not.toContain('timeframe_gaps');
+        });
+
+        it('includes title / shorttitle as mutable: false', () => {
+            const meta = new Indicator(`//@version=6\nindicator("X")\nplot(close)`).getPropsMeta();
+            const title = meta.find((m) => m.name === 'title');
+            expect(title?.mutable).toBe(false);
+            const shorttitle = meta.find((m) => m.name === 'shorttitle');
+            expect(shorttitle?.mutable).toBe(false);
+        });
+    });
+
+    // ── .prop proxy — frozen container, validation ────────────────────
+    describe('.prop proxy', () => {
+        const code = `//@version=6\nstrategy("X", initial_capital=100000)\nplot(close)`;
+
+        it('allows per-key mutation', () => {
+            const ind = new Indicator(code);
+            (ind.prop as any)['initial_capital'] = 50000;
+            expect((ind.prop as any)['initial_capital']).toBe(50000);
+        });
+
+        it('rejects replacement of the .prop container', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind as any).prop = { foo: 1 }; }).toThrow(/cannot be replaced/i);
+        });
+
+        it('rejects unknown prop names', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.prop as any)['nope'] = 1; }).toThrow(/unknown key/i);
+        });
+
+        it('rejects writes to title / shorttitle (excluded from proxy)', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.prop as any)['title'] = 'X'; }).toThrow(/unknown key/i);
+            expect(() => { (ind.prop as any)['shorttitle'] = 'X'; }).toThrow(/unknown key/i);
+        });
+
+        it('rejects values not in enum options (currency)', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.prop as any)['currency'] = 'XYZ'; }).toThrow(/not one of/i);
+        });
+
+        it('accepts valid enum value', () => {
+            const ind = new Indicator(code);
+            (ind.prop as any)['currency'] = 'EUR';
+            expect((ind.prop as any)['currency']).toBe('EUR');
+        });
+
+        it('rejects bool when given a number', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.prop as any)['overlay'] = 1; }).toThrow(/expects a boolean/i);
+        });
+
+        it('rejects int below minval (precision)', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.prop as any)['precision'] = -1; }).toThrow(/below minval/i);
+        });
+
+        it('rejects int above maxval (precision)', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.prop as any)['precision'] = 20; }).toThrow(/above maxval/i);
+        });
+    });
+
+    // ── Indicator-specific behavior ──────────────────────────────────
+    describe('indicator() props', () => {
+        it('seeds positional + named args from indicator() call', () => {
+            const code = `
+//@version=6
+indicator("X", "S", overlay=true, precision=4, max_lines_count=120,
+          timeframe="1D", timeframe_gaps=false,
+          format=format.percent, scale=scale.left)
+plot(close)
+`;
+            const v = new Indicator(code).prop as any;
+            // positional (after title/shorttitle)
+            expect(v['overlay']).toBe(true);
+            // named ints
+            expect(v['precision']).toBe(4);
+            expect(v['max_lines_count']).toBe(120);
+            // strings + bool
+            expect(v['timeframe']).toBe('1D');
+            expect(v['timeframe_gaps']).toBe(false);
+            // enums resolved via rightmost-identifier
+            expect(v['format']).toBe('percent');
+            expect(v['scale']).toBe('left');
+        });
+
+        it('rejects strategy-only prop names on an indicator script', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            expect(() => { (ind.prop as any)['pyramiding'] = 3; }).toThrow(/unknown key/i);
+            expect(() => { (ind.prop as any)['initial_capital'] = 50000; }).toThrow(/unknown key/i);
+            expect(() => { (ind.prop as any)['commission_type'] = 'percent'; }).toThrow(/unknown key/i);
+        });
+
+        it('rejects values outside max_lines_count bounds (1..500)', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            expect(() => { (ind.prop as any)['max_lines_count'] = 0; }).toThrow(/below minval/i);
+            expect(() => { (ind.prop as any)['max_lines_count'] = 501; }).toThrow(/above maxval/i);
+        });
+
+        it('rejects format value not in the enum', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            expect(() => { (ind.prop as any)['format'] = 'badformat'; }).toThrow(/not one of/i);
+        });
+
+        it('JS-function source detects indicator() and seeds defaults', () => {
+            const fn = ($: any) => {
+                const { indicator } = $.pine;
+                indicator('JS Ind', { overlay: true, precision: 2, timeframe: '60' });
+            };
+            const ind = new Indicator(fn);
+            expect(ind.getDeclarationType()).toBe('indicator');
+            expect((ind.prop as any)['overlay']).toBe(true);
+            expect((ind.prop as any)['precision']).toBe(2);
+            expect((ind.prop as any)['timeframe']).toBe('60');
+        });
+    });
+
+    // ── Strategy-only prop validations not covered above ─────────────
+    describe('strategy() props', () => {
+        it('rejects indicator-only prop names on a strategy script', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            expect(() => { (ind.prop as any)['timeframe'] = '1D'; }).toThrow(/unknown key/i);
+            expect(() => { (ind.prop as any)['timeframe_gaps'] = false; }).toThrow(/unknown key/i);
+        });
+
+        it('accepts every valid currency code', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            for (const code of ['USD', 'EUR', 'BTC', 'JPY', 'USDT', 'NONE']) {
+                (ind.prop as any)['currency'] = code;
+                expect((ind.prop as any)['currency']).toBe(code);
+            }
+        });
+
+        it('accepts each commission_type enum value', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            for (const v of ['percent', 'cash_per_order', 'cash_per_contract']) {
+                (ind.prop as any)['commission_type'] = v;
+                expect((ind.prop as any)['commission_type']).toBe(v);
+            }
+        });
+
+        it('accepts each default_qty_type enum value', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            for (const v of ['fixed', 'cash', 'percent_of_equity']) {
+                (ind.prop as any)['default_qty_type'] = v;
+                expect((ind.prop as any)['default_qty_type']).toBe(v);
+            }
+        });
+
+        it('accepts close_entries_rule "FIFO" / "ANY" (bare strings)', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            (ind.prop as any)['close_entries_rule'] = 'ANY';
+            expect((ind.prop as any)['close_entries_rule']).toBe('ANY');
+            expect(() => { (ind.prop as any)['close_entries_rule'] = 'LIFO'; }).toThrow(/not one of/i);
+        });
+
+        it('margin_long / margin_short bounds (0..100)', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            (ind.prop as any)['margin_long'] = 50;
+            expect((ind.prop as any)['margin_long']).toBe(50);
+            expect(() => { (ind.prop as any)['margin_long'] = 101; }).toThrow(/above maxval/i);
+            expect(() => { (ind.prop as any)['margin_short'] = -1; }).toThrow(/below minval/i);
+        });
+    });
+
+    // ── Cross-instance / reuse semantics ─────────────────────────────
+    describe('reuse across runs', () => {
+        it('same Indicator passed twice keeps prepare() cached', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X")\nplot(close)`);
+            const a = ind.prepare();
+            const b = ind.prepare();
+            expect(a).toBe(b);
+        });
+
+        it('source-default reads do NOT count as user overrides', async () => {
+            const code = `//@version=6\nstrategy("X", initial_capital=42000)\nplot(close)`;
+            const ind = new Indicator(code);
+            // Reading shouldn't trigger override tracking
+            void (ind.prop as any)['initial_capital'];
+            expect(ind.getRuntimePropOverrides()).toEqual({});
+            const ctx = await new PineTS(makeData()).run(ind);
+            expect(ctx.strategy.config.initial_capital).toBe(42000);   // from source
+        });
+
+        it('explicit override appears in getRuntimePropOverrides()', () => {
+            const ind = new Indicator(`//@version=6\nstrategy("X", initial_capital=42000)\nplot(close)`);
+            (ind.prop as any)['initial_capital'] = 99000;
+            expect(ind.getRuntimePropOverrides()).toEqual({ initial_capital: 99000 });
+        });
+    });
+
+    // ── End-to-end: override flows to runtime ─────────────────────────
+    describe('end-to-end runtime override', () => {
+        it('user-overridden initial_capital propagates to context.strategy.config', async () => {
+            const code = `//@version=6\nstrategy("E2E", initial_capital=10000)\nplot(close)`;
+            const ind = new Indicator(code);
+            (ind.prop as any)['initial_capital'] = 75000;
+
+            const ctx = await new PineTS(makeData()).run(ind);
+            expect(ctx.strategy.config.initial_capital).toBe(75000);
+            expect(ctx.strategy.initial_capital).toBe(75000);
+        });
+
+        it('user-overridden indicator pyramiding wins over source default', async () => {
+            const code = `//@version=6\nstrategy("E2E", pyramiding=1)\nplot(close)`;
+            const ind = new Indicator(code);
+            (ind.prop as any)['pyramiding'] = 5;
+            const ctx = await new PineTS(makeData()).run(ind);
+            expect(ctx.strategy.config.pyramiding).toBe(5);
+        });
+
+        it('source-only values still apply when no override is set', async () => {
+            const code = `//@version=6\nstrategy("E2E", initial_capital=42000)\nplot(close)`;
+            const ctx = await new PineTS(makeData()).run(new Indicator(code));
+            expect(ctx.strategy.config.initial_capital).toBe(42000);
+        });
+
+        it('indicator() prop overrides flow into context.indicator', async () => {
+            const code = `//@version=6\nindicator("E2E", overlay=false)\nplot(close)`;
+            const ind = new Indicator(code);
+            (ind.prop as any)['overlay'] = true;
+            const ctx = await new PineTS(makeData()).run(ind);
+            expect(ctx.indicator.overlay).toBe(true);
+        });
+    });
+});

--- a/tests/Indicator/Indicator.test.ts
+++ b/tests/Indicator/Indicator.test.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alaa-eddine KADDOURI
+
+import { describe, it, expect, vi } from 'vitest';
+import { Indicator } from '../../src/Indicator';
+import { PineTS } from '../../src/PineTS.class';
+
+function makeData(n = 30) {
+    const out: any[] = [];
+    const t0 = new Date('2024-01-01T00:00:00Z').getTime();
+    const DAY = 86_400_000;
+    for (let i = 0; i < n; i++) {
+        const base = 100 + i * 0.6;
+        out.push({
+            openTime: t0 + i * DAY,
+            open: base, high: base + 1.5, low: base - 0.8, close: base + 0.4,
+            volume: 1000, closeTime: t0 + (i + 1) * DAY - 1,
+        });
+    }
+    return out;
+}
+
+describe('Indicator', () => {
+
+    describe('input discovery from Pine source', () => {
+        it('harvests every input.* type with title-keyed defaults', () => {
+            const code = `
+//@version=6
+indicator("Test")
+len    = input.int(14, "Length")
+mult   = input.float(2.0, "Mult", minval=0.1, maxval=10.0, step=0.1)
+on     = input.bool(true, "On")
+src    = input.source(close, "Source")
+sym    = input.symbol("AAPL", "Symbol")
+tf     = input.timeframe("1D", "Timeframe")
+sess   = input.session("0930-1600", "Session")
+maType = input.string("EMA", "Type", options=["EMA", "SMA"])
+col    = input.color(#ff0000, "Color")
+msg    = input.text_area("hi", "Message")
+plot(close)
+`;
+            const ind = new Indicator(code);
+            const view = ind.input as Record<string, unknown>;
+
+            expect(view['Length']).toBe(14);
+            expect(view['Mult']).toBe(2);
+            expect(view['On']).toBe(true);
+            expect(view['Source']).toBe('close');
+            expect(view['Symbol']).toBe('AAPL');
+            expect(view['Timeframe']).toBe('1D');
+            expect(view['Session']).toBe('0930-1600');
+            expect(view['Type']).toBe('EMA');
+            expect(view['Color']).toBe('#ff0000');
+            expect(view['Message']).toBe('hi');
+        });
+
+        it('resolves enum field references to their titles (TradingView semantics)', () => {
+            const code = `
+//@version=6
+indicator("Test")
+
+enum tz
+    utc = "UTC"
+    ny  = "America/New_York"
+    lon = "Europe/London"
+
+selected = input.enum(tz.utc, "TZ", options=[tz.utc, tz.ny, tz.lon])
+plot(close)
+`;
+            const ind = new Indicator(code);
+            const meta = ind.getInputsMeta();
+            expect(meta).toHaveLength(1);
+            expect(meta[0].type).toBe('enum');
+            expect(meta[0].defval).toBe('UTC');
+            expect(meta[0].options).toEqual(['UTC', 'America/New_York', 'Europe/London']);
+            expect((ind.input as any)['TZ']).toBe('UTC');
+        });
+
+        it('auto-types bare input(defval, ...) from the defval', () => {
+            const code = `
+//@version=6
+indicator("Test")
+a = input(42, "Int")
+b = input(3.14, "Float")
+c = input("hi", "String")
+d = input(true, "Bool")
+plot(close)
+`;
+            const meta = new Indicator(code).getInputsMeta();
+            expect(meta.map((m) => m.type)).toEqual(['int', 'float', 'string', 'bool']);
+        });
+
+        it('returns an empty array for JS-function source', () => {
+            const ind = new Indicator(($: any) => { return $.data.close[0]; });
+            expect(ind.getInputsMeta()).toEqual([]);
+            expect(Object.keys(ind.input)).toEqual([]);
+        });
+    });
+
+    describe('input proxy: frozen container, mutable values', () => {
+        const code = `
+//@version=6
+indicator("X")
+len = input.int(14, "Length", minval=5, maxval=100)
+on  = input.bool(true, "On")
+ma  = input.string("EMA", "MA", options=["EMA", "SMA"])
+plot(close)
+`;
+
+        it('allows per-key mutation', () => {
+            const ind = new Indicator(code);
+            (ind.input as any)['Length'] = 20;
+            expect((ind.input as any)['Length']).toBe(20);
+        });
+
+        it('rejects replacement of the .input container', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind as any).input = { Length: 5 }; }).toThrow(/cannot be replaced/i);
+        });
+
+        it('rejects unknown titles', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.input as any)['Nope'] = 1; }).toThrow(/unknown input title/i);
+        });
+
+        it('rejects deletion', () => {
+            const ind = new Indicator(code);
+            expect(() => { delete (ind.input as any)['Length']; }).toThrow(/cannot delete/i);
+        });
+
+        it('rejects int when given a float', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.input as any)['Length'] = 3.7; }).toThrow(/expects an int/i);
+        });
+
+        it('rejects values outside minval/maxval', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.input as any)['Length'] = 4; }).toThrow(/below minval/i);
+            expect(() => { (ind.input as any)['Length'] = 101; }).toThrow(/above maxval/i);
+        });
+
+        it('rejects values not in options', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.input as any)['MA'] = 'WMA'; }).toThrow(/not one of/i);
+        });
+
+        it('rejects wrong type on bool input', () => {
+            const ind = new Indicator(code);
+            expect(() => { (ind.input as any)['On'] = 'yes'; }).toThrow(/expects a boolean/i);
+        });
+    });
+
+    describe('runtime inputs flow', () => {
+        it('propagates .input overrides to runtime resolveInput', async () => {
+            const code = `
+//@version=6
+indicator("LengthDemo")
+len = input.int(14, "Length")
+if not barstate.islast
+    log.info('{0}', len)
+`;
+            const ind = new Indicator(code);
+            (ind.input as any)['Length'] = 33;
+
+            const pine = new PineTS(makeData(5));
+            await pine.run(ind);
+
+            const inputs = ind.getRuntimeInputs();
+            expect(inputs['Length']).toBe(33);
+        });
+
+        it('explicit .input override takes priority over legacy constructor inputs', () => {
+            const code = `
+//@version=6
+indicator("Demo")
+len = input.int(14, "Length")
+plot(close)
+`;
+            const ind = new Indicator(code, { 'Length': 7 });
+            // Before any .input write, legacy wins.
+            expect(ind.getRuntimeInputs()['Length']).toBe(7);
+
+            // After explicit write, .input wins.
+            (ind.input as any)['Length'] = 20;
+            expect(ind.getRuntimeInputs()['Length']).toBe(20);
+        });
+    });
+
+    describe('prepare() caching', () => {
+        it('idempotent: calling prepare() twice returns the same artifact', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            const a = ind.prepare();
+            const b = ind.prepare();
+            expect(a).toBe(b);
+            expect(typeof a.fn).toBe('function');
+        });
+
+        it('detects visible-range usage', () => {
+            const code = `
+//@version=6
+indicator("VR", overlay=true)
+t = chart.left_visible_bar_time
+plot(close)
+`;
+            const ind = new Indicator(code);
+            expect(ind.usesVisibleRange()).toBe(true);
+        });
+
+        it('reports false for non-viewport scripts', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            expect(ind.usesVisibleRange()).toBe(false);
+        });
+    });
+
+    describe('Indicator.from()', () => {
+        it('wraps raw functions', () => {
+            const fn = ($: any) => $.data.close[0];
+            const ind = Indicator.from(fn);
+            expect(ind.source).toBe(fn);
+        });
+
+        it('wraps raw strings', () => {
+            const src = `//@version=6\nindicator("X")\nplot(close)`;
+            const ind = Indicator.from(src);
+            expect(ind.source).toBe(src);
+        });
+
+        it('passes through existing Indicators', () => {
+            const ind = new Indicator(`//@version=6\nindicator("X")\nplot(close)`);
+            expect(Indicator.from(ind)).toBe(ind);
+        });
+    });
+
+    describe('duplicate-title collision', () => {
+        it('warns and keeps the first declaration', () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                const code = `
+//@version=6
+indicator("Dup")
+a = input.int(14, "Length")
+b = input.int(20, "Length")
+plot(close)
+`;
+                const meta = new Indicator(code).getInputsMeta();
+                expect(meta).toHaveLength(1);
+                expect(meta[0].defval).toBe(14);
+                expect(warn).toHaveBeenCalled();
+            } finally {
+                warn.mockRestore();
+            }
+        });
+    });
+});


### PR DESCRIPTION
## [0.9.20] - 2026-06-08 - Indicator Class as SSOT — `.input` / `.prop` Runtime Overrides

### Added

- **`Indicator` becomes the single source of truth for every per-script artifact**: refactored from a 12-line tuple `{source, inputs}` into the owner of the transpiled function, AST, parsed input schema, parsed declaration-prop schema, viewport-detection flag, and LTF slices. All PineTS entry points (**`run`**, **`stream`**, **`update`**) now route through **`Indicator.from(arg).prepare()`** so raw strings and raw functions get auto-wrapped in a throwaway Indicator. **`prepare()`** is lazy and cached — re-using the same Indicator across multiple **`pine.run()`** calls compiles the script **once**.
- **`Indicator.input` — title-keyed Proxy for input overrides**: read or mutate `input.*` values per key (**`ind.input["Length"] = 50`**). The container itself is frozen (**`ind.input = {...}`** throws); per-key writes validate against the input's schema (type / options / minval / maxval) and throw tailored messages on violations or unknown titles. Constructor **`inputs`** map kept for back-compat; **`.input`** writes layer on top.
- **`Indicator.getInputsMeta(): IPineInput[]`**: parsed input schema for UI builders. Captures **`type`**, **`defval`**, **`title`**, **`tooltip`**, **`group`**, **`inline`**, **`display`**, **`active`**, **`confirm`**, **`options`**, **`minval`**, **`maxval`**, **`step`** for every **`input.*(...)`** declaration in the source.
- **`Indicator.prop` — name-keyed Proxy for `indicator()` / `strategy()` declaration overrides**: read or mutate declaration arguments (**`ind.prop["initial_capital"] = 75000`**, **`ind.prop["pyramiding"] = 5`**) before **`pine.run()`**. Same frozen-container + per-key validation semantics as **`.input`**. Excludes **`title`** / **`shorttitle`** from writes (still present in the meta with **`mutable: false`** so UIs can render them).
- **Source-code defaults seeded into `.prop`**: when reading **`ind.prop["X"]`**, the value is layered as **spec default ← source code value ← user override**. Pine source like **`strategy("X", initial_capital=50000, currency=currency.EUR)`** seeds **`ind.prop["initial_capital"]` → 50000** and **`ind.prop["currency"] → "EUR"`** before any user write. Enum constants (**`currency.EUR`**, **`strategy.percent_of_equity`**, **`strategy.commission.cash_per_order`**) resolve via the rightmost-identifier rule to match what TradingView's runtime sees.
- **`Indicator.getPropsMeta(): IPineProp[]`** & **`Indicator.getDeclarationType()`**: schema introspection filtered to props applicable to the detected script type (**`'indicator'`** vs **`'strategy'`**). Type detection falls back to **`'indicator'`** if no declaration call is found.
- **Top-level exports `INDICATOR_PROPS` / `STRATEGY_PROPS` / `propsForDeclaration(type)`**: complete prop schemas (17 / 33 entries respectively) for UI code that needs the full list independent of any Indicator instance. Each enum-typed entry has a one-line comment in [**`src/Indicator/propsSchema.ts`**](src/Indicator/propsSchema.ts) enumerating accepted values and pointing to the corresponding exported Pine enum in **`src/namespaces/Types.ts`**.
- **`scanDeclaration.ts`**: detects **`indicator()`** / **`strategy()`** in both Pine source (via existing **`pineToJS`** AST) and JS-function source (via **`acorn.parse`**). Decodes positional + named arguments and resolves namespace constants.
- **`keyedProxy.ts`**: shared backend for **`.input`** and **`.prop`** Proxies — single source of validation + custom error messages. Replaces the previous duplicate Proxy code in **`inputProxy.ts`**.
- **`Context._propOverrides`**: name-keyed map of user prop overrides populated in **`_initializeContext`** from **`ind.getRuntimePropOverrides()`**. Read by **`Core.indicator()`** and **`initializeStrategy()`** to merge on top of source-code declaration args (**`{ ...defaults, ...sourceArgs, ...userOverrides }`**).
- **`docs/indicator.md`** (new): dedicated page covering Quickstart, Constructor, **`Indicator.from()`**, visible-range detection, the full **`.input`** / **`getInputsMeta()`** surface, the full **`.prop`** / **`getPropsMeta()`** surface (incl. source-default seeding, enum resolution, validation), reuse across runs, JS-function source caveats, and backward compatibility with the constructor **`inputs`** map. Every code example verified end-to-end against the live bundle before inclusion.
- **Tests**: **`tests/Indicator/Indicator.test.ts`** (21 cases — input surface) and **`tests/Indicator/Indicator.props.test.ts`** (37 cases — prop surface including declaration detection, source-default seeding, indicator-vs-strategy cross-validation, enum/numeric bounds, end-to-end runtime override propagation).

### Changed

- **PineTS internals simplified**: **`_transpileCode`** and **`_detectViewportUsage`** moved off the **`PineTS`** class onto **`Indicator`** (where they conceptually belong — they're properties of the script, not the engine). **`_runComplete`** / **`_runPaginated`** now take an **`Indicator`** instance and call **`prepare()`** from inside their async bodies so transpile errors surface as Promise rejections (preserving the **`tests/transpiler/error-handling.test.ts`** contract).
- **`docs/initialization-and-usage.md` — "Running with Runtime Inputs"**: rewritten to show both the new per-key **`ind.input["Length"] = 50`** form (preferred) and the legacy constructor map (still supported). Cross-links to the new [**Indicator**](docs/indicator.md) page for the full surface.
- **`docs/strategy.md`**: Indicator-wrapper example now links to the dedicated [**Indicator**](docs/indicator.md) page in addition to **`initialization-and-usage.md`**.
- **`docs/index.md`** + nav: added an Indicator entry at slot 4; bumped Alerts / Pagination / Data Providers / Syntax Guide / Strategy / Language Coverage / API Coverage down one slot each. Resolves two prior nav_order collisions (Alerts and Pagination were both at 4).