### PR TITLE
[0.9.21] - 2026-06-10 - Strategy Broker Emulator — Close-on-Flat, 100% Margin, Trailing Stop & v6 Declaration Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [0.9.21] - 2026-06-10 - Strategy Broker Emulator — Close-on-Flat, 100% Margin, Trailing Stop & v6 Declaration Parsing
+
+### Fixed
+
+- **`strategy.close_all()` and `strategy.close(id)` no-op when nothing to close at queue time**: Both methods previously queued an exit order unconditionally. On the next bar the queued order survived (via `from_entry = ''` for `close_all` or matching `from_entry = id` for `close`) and caught a fresh entry at its entry price, closing it for **$0 PnL**. Hits common patterns like `if exit_signal: strategy.close_all("close")` — the exit signal can become true on a bar where the book is already flat (after a prior `close_all` fired), queuing a stale order that catches the next reversal entry. Both methods now early-return when `opentrades.length === 0` (close_all) or no matching `entry_id` exists (close).
+- **Pre-trade margin rejection and `processMarginCall` now run for ALL `margin_long` / `margin_short` percentages, not only `< 100`**: Both were previously gated on `marginPct < 100` with the comment "No leverage → no margin call" — incorrect, since the broker still requires the trader to post full notional as collateral at 100% margin. Pre-trade check in `processStrategyOrders` and intra-bar adverse-extreme liquidation in `processMarginCall` now apply unconditionally. The underlying math (`requiredMargin = qty × price × pointvalue × marginPct/100`) was already correct — only the guards needed removal.
+- **`strategy.exit(trail_points=N, trail_offset=M)` accumulates state across bars and fires per the intra-bar segment model**: Two coordinated fixes. (1) In `exit.ts`, `trail_armed` and `trail_peak` now carry over across same-id-replace — they're engine-accumulated state (running high for a long / running low for a short), not user-supplied parameters, and were previously reset to `false` / `NaN` every bar so the trail never accumulated past a single bar's range. (2) In `processExitOrders`, `checkTrail` replaces eager peak update + gap-fill at open with an intra-bar segment model. Four cases handled: favorable-first already-armed (update peak → check trigger), adverse-first already-armed (segment 1 with OLD peak's trigger → update → segment 3 close-vs-NEW-trigger), favorable-first arm-this-bar (peak set at arming → check phase-2 descent), adverse-first arm-this-bar (peak set after the adverse extreme → only phase-3 close-vs-trigger). Fill is the **literal trigger price** in all cases — gap-fill at bar open removed for trail because the open precedes any peak update relevant to this trade.
+- **`parseStrategyOptions` handles Pine v6 `(title, shorttitle, opts)` signature**: Previously only recognized `strategy("title")` and `strategy("title", { opts })`. When the script used `strategy("title", "shorttitle", overlay=true, commission_type=..., commission_value=...)` — a common v6 pattern — the second arg was a string (shorttitle), so the parser returned just `{ title }` and silently dropped the trailing named-args object. Result: `commission_type` / `commission_value` / `overlay` and every other named arg were ignored. New implementation walks all positional string args (capturing `title` then `shorttitle`) and merges any trailing object as named args.
+
+### Notes for users
+
+- **`strategy.netprofit` during open trades**: Entry commission is deducted from `netprofit` at fill time (matching real-broker cash flow). Final aggregate values are unaffected; intermediate per-bar values during an open trade will differ from references that defer commission to close time by the open trade's entry commission. `strategy.opentrades.commission(i)` exposes the open trade's entry commission for inspection.
+- **`strategy.max_drawdown` is the intrabar variant**: Uses bar H/L excursions of surviving positions in addition to realized equity peaks. Reference platforms may expose two drawdown fields (intrabar and close-to-close); only the intrabar is computed here, and it's the conservative number.
+
+---
+
 ## [0.9.20] - 2026-06-08 - Indicator Class as SSOT — `.input` / `.prop` Runtime Overrides
 
 ### Added
@@ -31,7 +47,7 @@
 ### Added
 
 - **Margin-call liquidation (`processMarginCall`)**: After entries and user-defined exits each bar, the engine checks whether intra-bar adverse movement (low for longs, high for shorts) would push equity below required maintenance margin when **`margin_long` / `margin_short` < 100**. If so, all open positions are force-liquidated at the bar's adverse extreme with **`exit_id` / `exit_comment` = `"Margin call"`**. Skipped when no leverage is configured. Helpers **`computeRequiredMargin`**, **`computeEquityAtPrice`**, **`computeHeldMargin`** model collateral in account currency via **`syminfo.pointvalue`**.
-- **Pre-trade margin rejection**: Entry orders that would require more margin than available equity at fill time are silently dropped (TV broker emulator — verified against margin QA oracles).
+- **Pre-trade margin rejection**: Entry orders that would require more margin than available equity at fill time are silently dropped
 - **`finalizeStrategyBar()`**: End-of-bar hook latches **`strategy.max_drawdown`** / **`strategy.max_runup`** once, after all fills settle, so TP/SL closes contribute realized P&L instead of phantom intra-bar excursions against raw H/L.
 - **`roundToMintick()`**: Stop/limit/trail prices on **`strategy.entry`** and **`strategy.exit`** snap to **`syminfo.mintick`** away from the reference close (broker placement convention).
 - **`CALLSITE_ID_NAMESPACES`**: Centralized transpiler list for trailing **`{ __callsiteId }`** injection; **`strategy.exit`** added for per-call-site cadence detection (persistent vs ephemeral exit-parameter capture). Documented known unification gaps with **`plot`**, **`ta.*`**, and **`alert`** patterns in **`settings.ts`**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.20",
+    "version": "0.9.21",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/namespaces/strategy/methods/close.ts
+++ b/src/namespaces/strategy/methods/close.ts
@@ -42,6 +42,17 @@ export function close(context: any) {
         const targetId = parsed.id;
         if (targetId === undefined || targetId === null) return;
 
+        // TV semantic: strategy.close(id) called with no open trades matching
+        // that entry id is a no-op. Without this guard the queued order
+        // survives to a later bar and can close a fresh entry that fills at
+        // its entry price (zero PnL). Same shape as the close_all() guard,
+        // scoped to the matching from_entry. Has to happen at QUEUE time;
+        // by fill time the new entry has already filled.
+        const hasMatching = context.strategy.opentrades.some(
+            (t: any) => t.entry_id === targetId,
+        );
+        if (!hasMatching) return;
+
         // TV semantic: strategy.close() supersedes any pending conditional
         // strategy.exit() orders that target the same entry id. Without this
         // cancellation, both the close market and the exit (TP/SL/trail)

--- a/src/namespaces/strategy/methods/close_all.ts
+++ b/src/namespaces/strategy/methods/close_all.ts
@@ -26,6 +26,18 @@ export function close_all(context: any) {
         }
         const parsed = parseArgsForPineParams<any>(args, CLOSE_ALL_SIGNATURES, CLOSE_ALL_ARGS_TYPES);
 
+        // TV semantic: strategy.close_all() called with no open positions is
+        // a no-op. Without this guard, the queued order survives to the next
+        // bar and closes the next entry that fills at its entry price (zero
+        // PnL), because from_entry='' matches any new trade. Notably this
+        // affects scripts that call close_all on indicator conditions that
+        // can fire when the position is already flat (e.g. exit-bar-count
+        // indicators where the count signal coincides with a fresh entry on
+        // the next bar). The position-state check has to happen at QUEUE
+        // time, not fill time — by fill time the new entry has already
+        // filled and would match.
+        if (context.strategy.opentrades.length === 0) return;
+
         // TV semantic: strategy.close_all() supersedes any pending conditional
         // strategy.exit() orders for the entire book. Without this, both the
         // close_all market and the conditional exits fire on the next bar,

--- a/src/namespaces/strategy/methods/exit.ts
+++ b/src/namespaces/strategy/methods/exit.ts
@@ -175,6 +175,18 @@ export function exit(context: any) {
         // later trade happens to satisfy the wrong-sided / stale-reversal
         // checks geometrically, the old order fires at a phantom price.
         // Same id + same from_entry scope is the replacement key.
+        //
+        // Trail state carry-over: `trail_armed` and `trail_peak` are NOT
+        // user-supplied parameters — they're engine-accumulated state that
+        // tracks the trail's progress across bars (running high for a long,
+        // running low for a short). When the user calls strategy.exit every
+        // bar (the canonical "persistent" pattern), naive replacement would
+        // reset these to false/NaN every bar, preventing the trail from ever
+        // accumulating beyond a single bar's range. TV's behavior is that
+        // the trail's state persists across re-calls — only the user-tunable
+        // parameters (trail_points, trail_offset, limit, stop, etc.) are
+        // refreshed. Mirror that by copying the trail state forward whenever
+        // the prior order had armed.
         const exitId = order.id;
         const list = context.strategy.pending_orders as Order[];
         for (let i = list.length - 1; i >= 0; i--) {
@@ -182,6 +194,10 @@ export function exit(context: any) {
             if (o.category === 'exit' && o.id === exitId &&
                 (o.from_entry ?? '') === (order.from_entry ?? '') &&
                 o.status === 'pending') {
+                if (o.trail_armed) {
+                    order.trail_armed = true;
+                    order.trail_peak  = o.trail_peak;
+                }
                 list.splice(i, 1);
             }
         }

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -8,26 +8,47 @@ import { Series } from '../../Series';
  * Parse strategy() function arguments
  */
 export function parseStrategyOptions(args: any[]): any {
+    // Pine v5/v6 strategy() signature:
+    //   strategy(title, shorttitle, overlay, format, precision, scale,
+    //            pyramiding, calc_on_order_fills, ...)
+    // The transpiler emits leading POSITIONAL strings (title, optionally
+    // shorttitle) followed by a trailing object with all named args.
+    // Three input shapes show up in practice:
+    //   1. strategy("title")                       — title only
+    //   2. strategy("title", { opts })             — title + named args
+    //   3. strategy("title", "shorttitle", {opts}) — Pine v6 with shorttitle
+    // The original implementation handled #1 and #2 but DROPPED the
+    // trailing options object in #3 (returning only { title }), which
+    // silently lost commission_type, commission_value, overlay, and every
+    // other named arg.
     if (args.length === 0) return {};
 
-    // If first arg is a string, it's the title
-    if (typeof args[0] === 'string') {
-        const options: any = { title: args[0] };
-
-        // If second arg is object, merge it
-        if (args.length > 1 && typeof args[1] === 'object') {
-            return { ...options, ...args[1] };
-        }
-
-        return options;
-    }
-
-    // If first arg is object, use it directly
-    if (typeof args[0] === 'object') {
+    // If first arg is itself an object, treat it as the whole options bag.
+    if (typeof args[0] === 'object' && args[0] !== null) {
         return args[0];
     }
 
-    return {};
+    const options: any = {};
+    if (typeof args[0] === 'string') options.title = args[0];
+
+    // Walk remaining args. Strings are positional (so far only shorttitle
+    // is observed in this position). The LAST object encountered is the
+    // named-args bundle — its keys win over positional fields if there's
+    // overlap (matching Pine's behavior of named args overriding positional).
+    let trailingOptions: any = null;
+    for (let i = 1; i < args.length; i++) {
+        const a = args[i];
+        if (typeof a === 'string') {
+            // Currently only shorttitle slots in as a positional string.
+            // If future Pine versions add more positional strings, extend
+            // here.
+            if (options.shorttitle === undefined) options.shorttitle = a;
+        } else if (typeof a === 'object' && a !== null) {
+            trailingOptions = a;
+        }
+    }
+    if (trailingOptions) Object.assign(options, trailingOptions);
+    return options;
 }
 
 /**
@@ -302,10 +323,15 @@ export function processStrategyOrders(context: any): void {
             // succeeds (frees its prior margin) and only the new open leg
             // is checked. For pyramiding (same-direction adds), held
             // margin from existing positions stays locked.
+            //
+            // Runs for ALL margin percentages. At 100% margin the required
+            // margin equals the full notional (qty * price * pointValue * 1),
+            // matching TV's broker-emulator behavior of rejecting entries
+            // whose notional exceeds available equity even with no leverage.
             const marginPct = direction === 1
                 ? (strategy.config.margin_long  ?? 100)
                 : (strategy.config.margin_short ?? 100);
-            if (marginPct < 100) {
+            {
                 const oldSize = strategy.position_size;
                 const oldSign = Math.sign(oldSize);
                 const isReversal = oldSign !== 0 && oldSign !== direction;
@@ -1236,18 +1262,19 @@ export function processExitOrders(context: any): void {
                     trailArmedThisBar = true;
                 }
             }
-        } else if (order.trail_armed) {
-            // Already armed — update peak.
-            if (isLong) order.trail_peak = Math.max(order.trail_peak ?? -Infinity, highPrice);
-            else order.trail_peak = Math.min(order.trail_peak ?? Infinity, lowPrice);
         }
+        // Peak update is now deferred to checkTrail so we can split it
+        // around the intra-bar segment that TV's broker emulator assumes
+        // (favorable-first: peak updates BEFORE trigger check;
+        //  adverse-first: peak updates AFTER segment-1 check against the
+        //  OLD peak's trigger). Eager peak update produced phantom early
+        //  fires on adverse-first bars where the bar's high established
+        //  the new peak only AFTER the low had already passed.
 
-        let trailTrigger: number | undefined;
-        if (order.trail_armed && order.trail_peak !== undefined && order.trail_offset !== undefined) {
-            trailTrigger = isLong
-                ? order.trail_peak - order.trail_offset * mintick
-                : order.trail_peak + order.trail_offset * mintick;
-        }
+        // The trail trigger is now computed inside checkTrail's
+        // segment branches (using OLD peak for segment 1, NEW peak for
+        // segment 3 on adverse-first; new peak unconditionally on
+        // favorable-first). See checkTrail below.
 
         // Evaluate triggers against this bar.
         //
@@ -1290,13 +1317,95 @@ export function processExitOrders(context: any): void {
             }
         };
         const checkTrail = () => {
-            if (triggered || trailTrigger === undefined || trailArmedThisBar) return;
-            const trailHit = isLong ? lowPrice <= trailTrigger : highPrice >= trailTrigger;
-            if (trailHit) {
-                triggered = true;
-                const openPastTrail = isLong ? openPrice <= trailTrigger : openPrice >= trailTrigger;
-                triggerPrice = openPastTrail ? openPrice : trailTrigger;
-                triggerKind = 'trailing';
+            if (triggered) return;
+            if (!order.trail_armed || order.trail_offset === undefined) return;
+
+            // Intra-bar segment model (TV broker emulator):
+            //
+            // Favorable-first (open closer to high for long; open closer to
+            // low for short):
+            //   Phase 1: open → favorable extreme (price rides to bar H for
+            //            long / bar L for short). Peak updates to that.
+            //   Phase 2: favorable extreme → adverse extreme. Trigger
+            //            (= NEW peak ± offset) may be crossed.
+            //   Phase 3: adverse extreme → close. (Already covered.)
+            //
+            // Adverse-first (open closer to adverse extreme):
+            //   Phase 1: open → adverse extreme. Peak is still PRIOR. Check
+            //            trigger using OLD peak; if crossed, fire there.
+            //   Phase 2: adverse → favorable extreme. Peak updates now.
+            //   Phase 3: favorable → close. If close descends/rises
+            //            through the NEW trigger, fire at the NEW trigger.
+            //
+            // Arming THIS bar is a sub-case: the peak was JUST established
+            // at the arming moment (bar's H for long / L for short). The
+            // segment-1 check with OLD peak doesn't apply (trail wasn't
+            // armed yet). Only phase 2 (favorable-first) or phase 3
+            // (adverse-first) can fire on the arming bar.
+            //
+            // The fill is always the LITERAL trigger price — gap-fill at
+            // open is incorrect for trail (the bar's open precedes any
+            // peak update for this trade).
+            const updatePeak = () => {
+                if (isLong) order.trail_peak = Math.max(order.trail_peak ?? -Infinity, highPrice);
+                else        order.trail_peak = Math.min(order.trail_peak ?? Infinity, lowPrice);
+            };
+            const triggerFromPeak = (): number => isLong
+                ? (order.trail_peak as number) - (order.trail_offset as number) * mintick
+                : (order.trail_peak as number) + (order.trail_offset as number) * mintick;
+
+            if (trailArmedThisBar) {
+                // Peak is already the bar's favorable extreme (set by the
+                // arming logic). Don't update again.
+                const trig = triggerFromPeak();
+                if (favorableFirst) {
+                    // Phase 2 (favorable extreme → adverse extreme): low for
+                    // long / high for short crosses trigger.
+                    const hit = isLong ? lowPrice <= trig : highPrice >= trig;
+                    if (hit) {
+                        triggered = true;
+                        triggerPrice = trig;
+                        triggerKind = 'trailing';
+                    }
+                } else {
+                    // Phase 3 (favorable extreme → close): close past trigger.
+                    const seg3 = isLong ? closePrice < trig : closePrice > trig;
+                    if (seg3) {
+                        triggered = true;
+                        triggerPrice = trig;
+                        triggerKind = 'trailing';
+                    }
+                }
+                return;
+            }
+
+            // Already armed in a prior bar. Use the full segment model.
+            if (favorableFirst) {
+                updatePeak();
+                const trig = triggerFromPeak();
+                const hit = isLong ? lowPrice <= trig : highPrice >= trig;
+                if (hit) {
+                    triggered = true;
+                    triggerPrice = trig;
+                    triggerKind = 'trailing';
+                }
+            } else {
+                const oldTrig = triggerFromPeak();
+                const seg1 = isLong ? lowPrice <= oldTrig : highPrice >= oldTrig;
+                if (seg1) {
+                    triggered = true;
+                    triggerPrice = oldTrig;
+                    triggerKind = 'trailing';
+                    return;
+                }
+                updatePeak();
+                const newTrig = triggerFromPeak();
+                const seg3 = isLong ? closePrice < newTrig : closePrice > newTrig;
+                if (seg3) {
+                    triggered = true;
+                    triggerPrice = newTrig;
+                    triggerKind = 'trailing';
+                }
             }
         };
         const checkTp = () => {
@@ -1376,8 +1485,12 @@ export function processExitOrders(context: any): void {
  * pessimistic broker model — the trader is assumed to be liquidated at
  * the worst intra-bar price, since intra-bar tick order is unknown.
  *
- * Skipped entirely when the position's `margin_pct >= 100` (no leverage)
- * or when there are no open positions.
+ * Runs for ALL margin percentages including 100%. At 100% margin the
+ * trader still needs full notional collateral; adverse price movement
+ * that drops account equity below the position's current notional
+ * triggers a margin call. This matches TV's broker-emulator behavior
+ * (the "Margin calls" stat in the Strategy Tester is non-zero on 100%
+ * margin runs whenever a position's mark-to-market loss exceeds equity).
  */
 export function processMarginCall(context: any): void {
     const strategy: StrategyState = context.strategy;
@@ -1389,7 +1502,6 @@ export function processMarginCall(context: any): void {
     const marginPct = positionDir === 1
         ? (strategy.config.margin_long  ?? 100)
         : (strategy.config.margin_short ?? 100);
-    if (marginPct >= 100) return;  // No leverage → no margin call.
 
     const highPrice   = Series.from(context.data.high).get(0);
     const lowPrice    = Series.from(context.data.low).get(0);


### PR DESCRIPTION
## [0.9.21] - 2026-06-10 - Strategy Broker Emulator — Close-on-Flat, 100% Margin, Trailing Stop & v6 Declaration Parsing

### Fixed

- **`strategy.close_all()` and `strategy.close(id)` no-op when nothing to close at queue time**: Both methods previously queued an exit order unconditionally. On the next bar the queued order survived (via `from_entry = ''` for `close_all` or matching `from_entry = id` for `close`) and caught a fresh entry at its entry price, closing it for **$0 PnL**. Hits common patterns like `if exit_signal: strategy.close_all("close")` — the exit signal can become true on a bar where the book is already flat (after a prior `close_all` fired), queuing a stale order that catches the next reversal entry. Both methods now early-return when `opentrades.length === 0` (close_all) or no matching `entry_id` exists (close).
- **Pre-trade margin rejection and `processMarginCall` now run for ALL `margin_long` / `margin_short` percentages, not only `< 100`**: Both were previously gated on `marginPct < 100` with the comment "No leverage → no margin call" — incorrect, since the broker still requires the trader to post full notional as collateral at 100% margin. Pre-trade check in `processStrategyOrders` and intra-bar adverse-extreme liquidation in `processMarginCall` now apply unconditionally. The underlying math (`requiredMargin = qty × price × pointvalue × marginPct/100`) was already correct — only the guards needed removal.
- **`strategy.exit(trail_points=N, trail_offset=M)` accumulates state across bars and fires per the intra-bar segment model**: Two coordinated fixes. (1) In `exit.ts`, `trail_armed` and `trail_peak` now carry over across same-id-replace — they're engine-accumulated state (running high for a long / running low for a short), not user-supplied parameters, and were previously reset to `false` / `NaN` every bar so the trail never accumulated past a single bar's range. (2) In `processExitOrders`, `checkTrail` replaces eager peak update + gap-fill at open with an intra-bar segment model. Four cases handled: favorable-first already-armed (update peak → check trigger), adverse-first already-armed (segment 1 with OLD peak's trigger → update → segment 3 close-vs-NEW-trigger), favorable-first arm-this-bar (peak set at arming → check phase-2 descent), adverse-first arm-this-bar (peak set after the adverse extreme → only phase-3 close-vs-trigger). Fill is the **literal trigger price** in all cases — gap-fill at bar open removed for trail because the open precedes any peak update relevant to this trade.
- **`parseStrategyOptions` handles Pine v6 `(title, shorttitle, opts)` signature**: Previously only recognized `strategy("title")` and `strategy("title", { opts })`. When the script used `strategy("title", "shorttitle", overlay=true, commission_type=..., commission_value=...)` — a common v6 pattern — the second arg was a string (shorttitle), so the parser returned just `{ title }` and silently dropped the trailing named-args object. Result: `commission_type` / `commission_value` / `overlay` and every other named arg were ignored. New implementation walks all positional string args (capturing `title` then `shorttitle`) and merges any trailing object as named args.