### PR TITLE
[0.9.23] - 2026-06-16 - Strategy Pyramiding Parity, Indicator Input varId & Sharpe/Sortino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Change Log
 
+## [0.9.23] - 2026-06-16 - Strategy Pyramiding Parity, Indicator Input varId & Sharpe/Sortino
+
+### Added
+
+- **`context.strategy.sharpe_ratio` / `sortino_ratio`**: Report-only risk-adjusted performance ratios computed once at end-of-run in `finalizeStrategyRun`, from the monthly equity curve accumulated across the bar loop. Matching TradingView's documented formula — simple monthly returns anchored at `initial_capital`, population SD / downside deviation, no annualization. Not Pine built-ins — available on `context.strategy` after the run only, not inside the run callback.
+- **`risk_free_rate` strategy declaration option** (default `2`, annual %): Converted to a monthly figure (`rate / 100 / 12`) as the denominator input for Sharpe / Sortino.
+- **`.input` keyed by `varId`**: The primary override key is now the variable each input is assigned to (`length = input.int(…)` → `"length"`). The input's **`title`** still resolves as a secondary alias. Recommended for scripts with empty or duplicated titles — `ind.input['slow']` targets the second `"Length"` input precisely while `ind.input['Length']` aliases the first.
+- **`varId` in `getInputsMeta()` / `IPineInput`**: Every scanned input carries its assigned variable name; `Object.keys(ind.input)` enumerates varIds.
+- **Transpiler `{ __varId }` injection**: `input.*(...)` calls in Pine source get a trailing varId sentinel so the runtime resolves overrides by varId before title.
+- **Color default normalization in input scanner**: `color`-typed inputs report `defval` as a canonical **8-digit RGBA hex `#RRGGBBAA`** (uppercase) regardless of source form — hex literals, named constants (`color.red` → `#F23645FF`), or statically evaluable `color.new()` / `color.rgb()` calls. Gives UI color pickers a single parseable format.
+- **Constant resolution in `scanInputs`**: When an input argument references a top-level constant or simple variable (`const DEF = 14; len = input.int(DEF, …)`), the scanner resolves `defval`, `group`, `inline`, `tooltip`, `options`, etc. to the declared value rather than the bare identifier.
+- **Tests**: `indicator_inputs.test.ts` (varId keying, color normalization, constant resolution), `close-snapshot.test.ts`, `equity-peak-basis.test.ts`, `margin-call.test.ts`, `risk-adjusted.test.ts`, `trailing-parity.test.ts`.
+- **Docs**: `docs/indicator.md` rewritten for varId-first `.input` API; `docs/strategy.md` gains Sharpe / Sortino section and `risk_free_rate` in the options table.
+
+### Fixed
+
+- **`strategy.close_all()` snapshot binding**: TV binds `close_all` / `close(id)` to the position at **call time**. When a reversal entry queued the same bar fills first on the next bar's open — implicitly closing the snapshotted trades — the pending `close_all` is now **cancelled** instead of catching the freshly-opened reversal trade at its entry price for **$0 PnL**. Implemented via `_intended_trade_ids` captured at queue time and re-checked in `processExitOrders`. (QA close_all xlsx, BTCUSDT 1D — trade #13's $5,512.65 divergence.)
+- **`strategy.position_avg_price` ghost position after partial liquidation**: Fractional qty residuals from margin-call partial liquidations left `position_avg_price` alive on a near-zero position. Epsilon-snap to flat (`|newSize| < 1e-9 → 0`) now sets `position_avg_price = NaN` and clears `position_entry_name`, preventing phantom TP/SL exits at the next entry's own price. (QA pyramiding xlsx, 2021-11-09 BTCUSDC.)
+- **Pyramiding tick-based exit brackets per trade**: When `strategy.exit()` matches multiple open trades, TP/SL levels in ticks are now computed from **each trade's own entry price**, not `strategy.position_avg_price`. Verified against QA pyramiding xlsx (BTCUSDC 1D).
+- **Equity peak basis for `max_drawdown`**: Peak latch now uses realized equity **plus open entry commissions** (excludes the commission deduction from the peak side). Trough basis keeps commission deducted. Fixes a degeneracy that hid the bug on constant-commission QA data but diverged on reversal bars with different entry commissions. (QA margin_calls xlsx — matches TV to the cent.)
+- **Margin-call partial liquidation (TV 4× rule)**: Intra-bar adverse movement now liquidates **4× the contracts needed to cover the deficit** (floored), not the entire position — remainder stays open.
+- **Reversal close-leg margin semantics**: When a reversal entry's **open** leg fails the pre-trade margin check, the **close** leg of the reversal still executes.
+- **Deferred close margin call (`applyPendingCloseMarginCall`)**: Phantom re-check scheduled on the previous bar fills at that bar's close, before entries — so a reversal queued at that close overshoots by exactly the deferred quantity, as TV does.
+- **Intra-bar margin checkpoint ordering**: Margin checks now run at the bar **open** (after entries fill) and at the **adverse extreme** — before exit fills on adverse-first bars, after them on favorable-first bars (`isAdverseFirstBar`). Exit processing moved to an explicit `'intrabar'` phase in `processExitOrders`.
+- **Trailing stop adverse-first segment model** (PR #213): On bars where the adverse extreme precedes the favorable move, an already-armed trail now checks segment 1 against the **old** peak's trigger, updates the peak, then checks segment 3 against the **new** trigger — keeping the order pending when both segments miss. Fill price remains the literal trigger level.
+
+### Changed
+
+- **`.input` override precedence**: Runtime resolves **varId before title**. A varId-keyed `.input['len'] = 3` write wins over a constructor-map `{ Length: 21 }` title override. Both keys coexist in `ctx.inputs`; the script picks up the varId one.
+- **Bar-loop strategy processing order**: Entries → deferred close margin call → open checkpoint → (adverse-first extreme checkpoint) → intrabar exits → (favorable-first extreme checkpoint) → `finalizeStrategyBar` peak latch → end-of-run `finalizeStrategyRun` for Sharpe / Sortino.
+
+---
+
 ## [0.9.22] - 2026-06-11 - Strategy Hotfix for Close-on-Flat and Margin calls
 
 This is a hotfix release for v0.9.21 which did not include the right fixes

--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ Thanks to all PineTS contributors:
 <a href="https://github.com/amoradi"><img src="https://avatars.githubusercontent.com/u/6855005?v=4&s=64" width="64" height="64" alt="amoradi" title="amoradi" style="border-radius: 50%;"/></a>
 <a href="https://github.com/smack369"><img src="https://avatars.githubusercontent.com/u/126825390?v=4&s=64" width="64" height="64" alt="smack369" title="smack369" style="border-radius: 50%;"/></a>
 <a href="https://github.com/NexusAlien"><img src="https://avatars.githubusercontent.com/u/181855714?v=4&s=64" width="64" height="64" alt="NexusAlien" title="NexusAlien" style="border-radius: 50%;"/></a>
+<a href="https://github.com/yoonbae81"><img src="https://avatars.githubusercontent.com/u/20147594?v=4&s=64" width="64" height="64" alt="yoonbae81" title="yoonbae81" style="border-radius: 50%;"/></a>
+
 </p>
 
 ---

--- a/docs/indicator.md
+++ b/docs/indicator.md
@@ -139,7 +139,7 @@ See **[Initialization and Usage → Host Environment (Visible Range)](initializa
 
 ### Reading and writing values
 
-`.input` is a title-keyed Proxy. Keys are the **`title`** argument of each `input.*(...)` call in the Pine source. The container itself is frozen — you can mutate values per key, but you can't replace the whole object.
+`.input` is a Proxy keyed primarily by **`varId`** — the variable each input is assigned to (`length = input.int(…)` → `"length"`). **Keying by varId is the recommended way to read and override inputs**: the variable name is always present and always unique, so it works even when titles are empty or duplicated. The input's **`title`** also resolves as a *secondary alias* for the common case. The container is frozen — you mutate values per key, but you can't replace the whole object.
 
 ```javascript
 const code = `
@@ -152,13 +152,20 @@ plot(close)
 `;
 const ind = new Indicator(code);
 
-ind.input['Length']; // → 14         (default from source)
-ind.input['Source']; // → "close"
-ind.input['MA Type']; // → "EMA"
+// Recommended: key by varId (the variable name).
+ind.input['length']; // → 14         (default from source)
+ind.input['src'];    // → "close"
+ind.input['maType']; // → "EMA"
 
-ind.input['Length'] = 50; // ✓ valid override
-ind.input['Length']; // → 50
+ind.input['length'] = 50; // ✓ valid override
+ind.input['length'];      // → 50
+
+// Title still works as a fallback alias (same underlying slot).
+ind.input['Length'];      // → 50
+ind.input['MA Type'] = 'SMA';
 ```
+
+> **varId takes priority.** Resolution tries the varId first, then falls back to title. If a varId and some other input's title happen to collide, the varId wins. `Object.keys(ind.input)` enumerates varIds; titles resolve but aren't listed.
 
 When you pass the Indicator to `pine.run()`, the override flows into the runtime:
 
@@ -170,10 +177,32 @@ len = input.int(14, "Length")
 plot(ta.sma(close, len))
 `;
 const ind = new Indicator(code);
-ind.input['Length'] = 5;
+ind.input['len'] = 5;              // by varId (recommended)
 const ctx = await pine.run(ind);
-// ctx.inputs.Length === 5
+// ctx.inputs.len === 5            (overrides are forwarded under the varId)
 // the SMA in the script was computed with length=5
+```
+
+### Empty or duplicated titles
+
+Because varId is the primary key, inputs that are awkward to address by title still have a stable handle:
+
+```javascript
+const code = `
+//@version=6
+indicator("Dup")
+fast = input.int(10, "Length")
+slow = input.int(20, "Length")   // same title as 'fast'
+hidden = input.int(5, "")        // empty title
+plot(close)
+`;
+const ind = new Indicator(code);
+
+ind.input['slow']   = 50;  // ✓ targets the second input precisely
+ind.input['hidden'] = 7;   // ✓ overridable despite the empty title
+ind.input['Length'];       // → 10  (a shared title aliases the FIRST input, 'fast')
+
+ind.getInputsMeta().length; // → 3  (duplicates and empty-titled inputs all appear)
 ```
 
 ### Validation
@@ -181,10 +210,10 @@ const ctx = await pine.run(ind);
 Writes are validated against the input's schema. Failures throw immediately with a tailored message:
 
 ```javascript
-ind.input['Unknown'] = 1; // ✗ Error: [Indicator.input] unknown input title "Unknown". Known: Length, Source, MA Type
-ind.input['Length'] = 1; // ✗ Error: [Indicator.input] "Length" value 1 is below minval 2
-ind.input['MA Type'] = 'HMA'; // ✗ Error: [Indicator.input] "MA Type" value "HMA" is not one of: "EMA", "SMA", "WMA"
-ind.input = { foo: 1 }; // ✗ Error: [Indicator.input] .input cannot be replaced — mutate individual keys (…)
+ind.input['nope'] = 1;      // ✗ Error: [Indicator.input] unknown input key "nope". Known: length, src, maType, Length, Source, MA Type
+ind.input['length'] = 1;    // ✗ Error: [Indicator.input] "length" value 1 is below minval 2
+ind.input['maType'] = 'HMA';// ✗ Error: [Indicator.input] "maType" value "HMA" is not one of: "EMA", "SMA", "WMA"
+ind.input = { foo: 1 };     // ✗ Error: [Indicator.input] .input cannot be replaced — mutate individual keys (…)
 ```
 
 ### Schema introspection — `getInputsMeta()`
@@ -194,19 +223,28 @@ Returns the parsed schema as an array of `IPineInput`. Useful for UI builders th
 ```javascript
 const meta = ind.getInputsMeta();
 // [
-//   { type: 'int',    title: 'Length',  defval: 14,    minval: 2, maxval: 200 },
-//   { type: 'source', title: 'Source',  defval: 'close' },
-//   { type: 'string', title: 'MA Type', defval: 'EMA', options: ['EMA','SMA','WMA'] },
+//   { type: 'int',    varId: 'length', title: 'Length',  defval: 14, minval: 2, maxval: 200 },
+//   { type: 'source', varId: 'src',    title: 'Source',  defval: 'close' },
+//   { type: 'string', varId: 'maType', title: 'MA Type', defval: 'EMA', options: ['EMA','SMA','WMA'] },
+//   { type: 'color',  varId: 'lineCol',title: 'Line',    defval: '#F23645FF' },
 // ]
 ```
 
-Each entry carries everything the scanner harvested — `type`, `defval`, `title`, `tooltip`, `group`, `inline`, `display`, `options`, `minval`, `maxval`, `step`, `active`, `confirm`. The exported types `IPineInput`, `PineInputType`, and `PineInputDisplay` describe the shape.
+Each entry carries everything the scanner harvested — `type`, `defval`, **`varId`**, `title`, `tooltip`, `group`, `inline`, `display`, `options`, `minval`, `maxval`, `step`, `active`, `confirm`. `varId` (the assigned variable name) is present for every scanned input and is the primary `.input` override key; `title` may be empty or repeated across inputs, but `varId` is unique. The exported types `IPineInput`, `PineInputType`, and `PineInputDisplay` describe the shape.
+
+**Color defaults are normalized.** `color`-typed inputs report `defval` as a canonical **8-digit RGBA hex string `#RRGGBBAA`** (uppercase; `FF` = fully opaque), regardless of how the source wrote it:
+
+- `#RRGGBB` / `#RRGGBBAA` hex literals
+- a named constant — `color.red` → `#F23645FF`
+- the constructor calls `color.new(col, transp)` and `color.rgb(r, g, b, transp?)`, statically evaluated (Pine's `transp` is 0–100 transparency, so `color.new(#26a69a, 50)` → `#26A69A80`, `color.rgb(6, 162, 47)` → `#06A22FFF`)
+
+Reading the same key back via `.input['Line']` returns the identical normalized string. This gives UI color pickers a single, parseable format to bind to. (The normalization is presentational — it doesn't affect what the running script computes when the input isn't overridden.) A color default that can't be resolved statically — e.g. one built from a runtime variable or `color.from_gradient(...)` — is reported as `undefined`.
 
 ---
 
 ## Declaration props — `.prop` and `getPropsMeta()`
 
-The script's `indicator(...)` or `strategy(...)` declaration takes its own set of arguments — `overlay`, `precision`, `initial_capital`, `pyramiding`, `currency`, etc. The `.prop` view exposes those for read/override, mirroring the `.input` API but keyed by **arg name** instead of title.
+The script's `indicator(...)` or `strategy(...)` declaration takes its own set of arguments — `overlay`, `precision`, `initial_capital`, `pyramiding`, `currency`, etc. The `.prop` view exposes those for read/override, mirroring the `.input` API but keyed by **arg name** (each arg name is unique, so there's no varId/title distinction here).
 
 ### Reading source-code defaults
 
@@ -338,7 +376,7 @@ This matters for hosts that run the same script across many datasets (e.g. a cha
 
 ## JS-function source
 
-When the source is a JS callback, the AST scan for inputs returns `[]` (Pine inputs are written in Pine syntax; the JS form expresses them differently). The `.input` view is empty and writes throw "unknown title". The legacy `inputs` constructor map still works for runtime overrides via the JS path.
+When the source is a JS callback, the AST scan for inputs returns `[]` (Pine inputs are written in Pine syntax; the JS form expresses them differently). The `.input` view is empty and writes throw "unknown input key". The legacy `inputs` constructor map still works for runtime overrides via the JS path.
 
 ```javascript
 const fn = ($) => {
@@ -360,7 +398,7 @@ Declaration detection works for the JS path because the function body is parsed 
 
 ## Backward compatibility — constructor `inputs` map
 
-The legacy second constructor argument (a title-keyed override map) is still honored. It's most useful when you build an Indicator and want to ship a default override set up front, without touching `.input` later.
+The legacy second constructor argument (a **title-keyed** override map) is still honored. It's most useful when you build an Indicator and want to ship a default override set up front, without touching `.input` later.
 
 ```javascript
 const code = `
@@ -369,21 +407,22 @@ indicator("BC")
 len = input.int(14, "Length")
 plot(ta.sma(close, len))
 `;
-const ind = new Indicator(code, { Length: 21 });
+const ind = new Indicator(code, { Length: 21 });   // keyed by title
 const ctx = await pine.run(ind);
-// ctx.inputs.Length === 21
+// ctx.inputs.Length === 21    (the runtime resolves it via the title fallback)
 ```
 
-Precedence rule when both are set: `.input` overrides win over the constructor map. The constructor map is the baseline; `.input` writes layer on top.
+Precedence when both are set: a `.input` write (varId-keyed) wins over the constructor map (title-keyed), because the runtime resolves **varId before title**. Both entries coexist in `ctx.inputs` — they're distinct keys — and the varId one is chosen:
 
 ```javascript
 const ind = new Indicator(code, { Length: 21 });
-ind.input['Length'] = 3;
+ind.input['len'] = 3;            // varId override
 const ctx = await pine.run(ind);
-// ctx.inputs.Length === 3   ← .input wins
+// ctx.inputs === { Length: 21, len: 3 }
+// resolveInput checks varId 'len' first → the script computes ta.sma(close, 3)
 ```
 
-New code should prefer the `.input` API. The constructor `inputs` argument stays for callers that have existing code relying on it.
+New code should prefer the **varId**-keyed `.input` API. The constructor `inputs` argument (and title-keyed `.input` access) stay for callers that have existing code relying on them.
 
 ---
 

--- a/docs/indicator.md
+++ b/docs/indicator.md
@@ -240,6 +240,17 @@ Each entry carries everything the scanner harvested — `type`, `defval`, **`var
 
 Reading the same key back via `.input['Line']` returns the identical normalized string. This gives UI color pickers a single, parseable format to bind to. (The normalization is presentational — it doesn't affect what the running script computes when the input isn't overridden.) A color default that can't be resolved statically — e.g. one built from a runtime variable or `color.from_gradient(...)` — is reported as `undefined`.
 
+**Constant arguments are resolved.** When an input argument references a top-level constant or simple variable rather than a literal, the scanner resolves it to the declared value — so `defval`, `group`, `inline`, `tooltip`, `options`, etc. report the value, not the variable name. This composes with the enum, color, and chained-const logic.
+
+```pine
+const string GRP = "Indicator Settings"
+const int    DEF = 14
+len = input.int(DEF, "Length", group = GRP)
+// → { type: 'int', varId: 'len', title: 'Length', defval: 14, group: 'Indicator Settings' }
+```
+
+References that can't be resolved to a static value (e.g. a computed series like `ta.sma(close, 5)`) fall back to the bare variable name.
+
 ---
 
 ## Declaration props — `.prop` and `getPropsMeta()`

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -26,6 +26,7 @@ Every example below is exercised by a verification harness at `PineTS/.scratchpa
 - [The `context.strategy` object](#the-contextstrategy-object)
 - [Trade collections](#trade-collections)
 - [Read-only getters](#read-only-getters)
+- [Risk-adjusted performance (Sharpe / Sortino)](#risk-adjusted-performance-sharpe--sortino)
 - [Constants](#constants)
 - [Risk management](#risk-management)
 - [Conversion helpers](#conversion-helpers)
@@ -133,6 +134,7 @@ After the call, `context.strategy.config` holds the merged options (defaults + y
 | `commission_value` | `number` | `0` | |
 | `slippage` | `number` | `0` | Ticks against trade direction |
 | `margin_long` / `margin_short` | `number` | `100` | Margin % (used by `margin_liquidation_price`) |
+| `risk_free_rate` | `number` | `2` | Annual %, denominator input for [Sharpe / Sortino](#risk-adjusted-performance-sharpe--sortino) |
 | `process_orders_on_close` | `boolean` | `false` | Affects `strategy.close({immediately: true})` |
 | `max_lines_count` / `max_labels_count` / `max_boxes_count` / `max_polylines_count` | `number` | `50` | Pass-through to drawing engine |
 
@@ -273,6 +275,12 @@ interface StrategyState {
     max_runup:        number;
     equity_peak:      number;           // internal high-water mark
     equity_trough:    number;
+
+    // Risk-adjusted performance — computed ONCE at end-of-run from the
+    // monthly equity curve (report-only; see the section below). These are
+    // NOT Pine built-in variables, so they're read off context.strategy only.
+    sharpe_ratio:     number;
+    sortino_ratio:    number;
 
     // Trade-stat counters
     wintrades:                number;
@@ -424,6 +432,53 @@ console.log('Max contracts held (long):', s.max_contracts_held_long);
 
 ---
 
+## Risk-adjusted performance (Sharpe / Sortino)
+
+PineTS reports the two risk-adjusted ratios from TradingView's **Risk-adjusted performance** panel:
+
+```javascript
+const ctx = await pine.run(/* ... */);
+const s = ctx.strategy;
+
+console.log('Sharpe ratio:',  s.sharpe_ratio);
+console.log('Sortino ratio:', s.sortino_ratio);
+```
+
+**These are report-only fields, not getters.** Unlike `netprofit` or `max_drawdown`, Sharpe and Sortino are **not** Pine built-in variables — TradingView surfaces them only in the Strategy Tester report (and xlsx export), never to scripts. So there is no `strategy.sharpe_ratio` accessor inside the run callback; the values live on `context.strategy` after the run and nowhere else.
+
+They are computed **once at the end of the run** (in `finalizeStrategyRun`), from the strategy's monthly equity curve.
+
+### How they're calculated
+
+Matching TradingView's documented methodology:
+
+1. **Sample equity monthly.** The mark-to-market `strategy.equity` is captured at the last bar of each calendar month.
+2. **Monthly returns.** Simple returns `rᵢ = Eᵢ / Eᵢ₋₁ − 1`, anchored at `initial_capital` (the first return runs from initial capital to the first month-end).
+3. **Risk-free rate.** `RFR = risk_free_rate / 100 / 12` — the annual `risk_free_rate` declaration option (default **2**, i.e. 2%) converted to a monthly figure.
+4. **Ratios** (no annualization):
+
+   ```
+   Sharpe  = (mean(r) − RFR) / SD
+   Sortino = (mean(r) − RFR) / DD
+
+   SD = √( Σ (rᵢ − mean(r))² / N )           — population standard deviation
+   DD = √( Σ min(0, rᵢ − RFR)²   / N )        — downside deviation over all N returns, target = RFR
+   ```
+
+Edge cases: with fewer than two monthly returns both ratios are `0`; a zero-variance (flat) curve yields Sharpe `0`; a curve with no downside (every return above the RFR) yields Sortino `0`.
+
+Set the risk-free rate via the declaration:
+
+```javascript
+strategy('RFR example', { initial_capital: 100000, risk_free_rate: 4 });  // 4% annual
+```
+
+### Accuracy
+
+The formula matches TradingView's exactly, but the ratios are **derivatives of the bar-by-bar equity curve** — so their fidelity rides on the engine's mark-to-market accuracy, not on the formula. Across the TV oracle datasets they land within roughly the second decimal (most within ~0.01; strategies with heavy margin-call activity diverge a little more, since their intra-month equity path is where PineTS and TV differ most even when final net profit matches). They are intended as a faithful summary metric, **not** a cent-exact reproduction like `netprofit`.
+
+---
+
 ## Constants
 
 PineTS exposes Pine's three sets of `strategy` constants. Inside the run callback they appear as bare strings; from plain JS you call them as factories.
@@ -512,5 +567,6 @@ The strategy namespace's surface is implemented 1:1 with TV. A subset of strateg
 - **OCA enforcement** — order objects carry `oca_name` / `oca_type` fields, but the engine doesn't yet auto-cancel or reduce siblings on fill. Deferred Phase 7.
 - **Commission rounding** — per-leg charges may differ from TV by sub-cent rounding in edge cases.
 - **Per-trade `max_drawdown` / `max_runup`** — PineTS tracks intra-bar high/low excursions, but TV's accounting differs for trades that open and close in adjacent bars.
+- **`strategy.sharpe_ratio` / `strategy.sortino_ratio`** — the formula matches TV exactly, but the ratios are computed off the monthly equity curve and therefore inherit any bar-by-bar mark-to-market path difference. They match TV to ~2 decimals (most datasets within ~0.01), not to the cent. See [Risk-adjusted performance](#risk-adjusted-performance-sharpe--sortino).
 
 For the complete checklist (every entry mapped to its implementation status) and the list of TV oracle scripts in use, see the **[Strategy API coverage page](api-coverage/strategy.md)**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.22",
+    "version": "0.9.23",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Indicator/Indicator.class.ts
+++ b/src/Indicator/Indicator.class.ts
@@ -5,6 +5,7 @@ import { transpile } from '../transpiler/index';
 import { VIEWPORT_DEPENDENT_BUILTINS } from '../transpiler/settings';
 import { scanInputs } from './scanInputs';
 import { buildInputProxy } from './inputProxy';
+import { normalizeColorToRgbaHex } from '../namespaces/color/PineColor';
 import { scanDeclaration } from './scanDeclaration';
 import { propsForDeclaration } from './propsSchema';
 import { buildPropProxy } from './propProxy';
@@ -127,22 +128,23 @@ export class Indicator {
     }
 
     /**
-     * Title-keyed input map used by the runtime (read by
+     * Input override map used by the runtime (read by
      * `input.utils.resolveInput`). Composed at call time so live mutations
      * to `.input` between `pine.run()` calls are picked up automatically.
      *
-     * Precedence:
-     *   1. Legacy constructor `inputs`            (back-compat)
-     *   2. Explicit writes to `.input[...]`       (new API; takes priority)
+     * Keys are mixed by design and resolved in this precedence by the runtime:
+     *   1. Legacy constructor `inputs` map        — TITLE-keyed (back-compat)
+     *   2. Explicit `.input[...]` writes          — VARID-keyed (canonical);
+     *      resolveInput checks varId before title, so these take priority.
      *
-     * Defaults are NOT included — the runtime falls back to `defval` when a
-     * title is absent.
+     * Defaults are NOT included — the runtime falls back to `defval` when no
+     * override key matches.
      */
     public getRuntimeInputs(): Record<string, unknown> {
         const out: Record<string, unknown> = { ...(this.inputs ?? {}) };
         if (this._inputMeta) {
-            for (const title of this._explicitOverrides) {
-                out[title] = this._inputValues[title];
+            for (const key of this._explicitOverrides) {
+                out[key] = this._inputValues[key];
             }
         }
         return out;
@@ -196,6 +198,17 @@ export class Indicator {
     private _ensureInputsScanned(): void {
         if (this._inputMeta) return;
         this._inputMeta = scanInputs(this.source);
+        // Present color-input defaults in one canonical form: an 8-digit
+        // RGBA hex string (#RRGGBBAA). The scanner records them verbatim —
+        // `#ff0000`, a `color.red` path, `rgb(...)`, etc. — so normalize
+        // here, before the proxy seeds its default values, so getInputsMeta()
+        // and `.input` reads agree. Runtime is unaffected (getRuntimeInputs()
+        // only forwards explicit overrides, never these defaults).
+        for (const m of this._inputMeta) {
+            if (m.type === 'color' && m.defval !== undefined) {
+                m.defval = normalizeColorToRgbaHex(m.defval);
+            }
+        }
         const built = buildInputProxy(this._inputMeta, (title) => this._explicitOverrides.add(title));
         this._inputValues = built.values;
         this._inputProxy = built.proxy;

--- a/src/Indicator/inputProxy.ts
+++ b/src/Indicator/inputProxy.ts
@@ -6,34 +6,41 @@ import { buildKeyedProxy, type KeyedSchemaEntry } from './keyedProxy';
 
 /**
  * Build the live `.input` view exposed on an `Indicator` instance.
- * Title-keyed; entries without an explicit `title=` on the Pine source are
- * excluded (Pine's runtime keys overrides by title, so a title-less input is
- * not overridable).
+ *
+ * Keyed by **varId** (the assigned variable name) as the canonical, primary
+ * override key, with the input's **title** registered as a secondary alias.
+ * This makes every input overridable by a stable, unique handle — robust to
+ * empty or duplicated titles — while `.input['Title']` keeps working for the
+ * common case (unique, non-empty titles). When two inputs share a title, the
+ * title aliases the first; the second is reachable only by its varId.
  *
  * Backing machinery lives in `keyedProxy.ts` and is shared with `.prop`.
  */
 export function buildInputProxy(
     metas: IPineInput[],
-    onSet?: (title: string) => void,
+    onSet?: (key: string) => void,
 ): {
     proxy: Record<string, unknown>;
     values: Record<string, unknown>;
-    metaByTitle: Map<string, IPineInput>;
+    metaByKey: Map<string, IPineInput>;
 } {
-    const metaByTitle = new Map<string, IPineInput>();
+    const metaByKey = new Map<string, IPineInput>();
     const entries: KeyedSchemaEntry[] = [];
     for (const m of metas) {
-        if (!m.title) continue;
-        metaByTitle.set(m.title, m);
+        const key = m.varId ?? m.title; // prefer varId; fall back to title
+        if (!key) continue;             // no handle at all → not overridable
+        const aliases = m.title && m.title !== key ? [m.title] : undefined;
+        metaByKey.set(key, m);
         entries.push({
-            key: m.title,
+            key,
             type: m.type,
             defval: m.defval,
             options: m.options,
             minval: m.minval,
             maxval: m.maxval,
+            aliases,
         });
     }
-    const { proxy, values } = buildKeyedProxy(entries, 'Indicator.input', onSet, undefined, 'input title');
-    return { proxy, values, metaByTitle };
+    const { proxy, values } = buildKeyedProxy(entries, 'Indicator.input', onSet, undefined, 'input key');
+    return { proxy, values, metaByKey };
 }

--- a/src/Indicator/keyedProxy.ts
+++ b/src/Indicator/keyedProxy.ts
@@ -23,12 +23,20 @@ export type KeyedType =
     | 'symbol' | 'timeframe' | 'text_area';
 
 export interface KeyedSchemaEntry {
-    key:      string;             // 'Length' for an input title, 'pyramiding' for a prop name
+    key:      string;             // canonical key — input varId, or prop name
     type:     KeyedType;
     defval:   unknown;
     options?: unknown[];
     minval?:  number;
     maxval?:  number;
+    /**
+     * Secondary keys that also resolve to this entry (e.g. an input's title
+     * aliasing its varId). The canonical `key` always takes priority; an alias
+     * is registered only if not already claimed by a canonical key or an
+     * earlier entry. Values/overrides are stored under the canonical key, so
+     * reading or writing via an alias hits the same slot.
+     */
+    aliases?: string[];
 }
 
 export interface BuildKeyedProxyResult {
@@ -57,14 +65,25 @@ export function buildKeyedProxy(
     const values: Record<string, unknown> = {};
     const entryByKey = new Map<string, KeyedSchemaEntry>();
 
+    // Canonical keys first (they win over any alias), values seeded under them.
     for (const e of entries) {
         entryByKey.set(e.key, e);
         values[e.key] = seedValues && e.key in seedValues ? seedValues[e.key] : e.defval;
+    }
+    // Then aliases — only where they don't shadow a canonical key or an
+    // already-registered alias (first entry wins the alias).
+    for (const e of entries) {
+        for (const alias of e.aliases ?? []) {
+            if (!alias || entryByKey.has(alias)) continue;
+            entryByKey.set(alias, e);
+        }
     }
 
     const proxy = new Proxy(values, {
         get(target, prop) {
             if (typeof prop === 'symbol') return (target as any)[prop];
+            const entry = entryByKey.get(prop as string);
+            if (entry) return target[entry.key]; // canonicalize alias → key
             return target[prop as string];
         },
         set(target, prop, value) {
@@ -74,8 +93,8 @@ export function buildKeyedProxy(
                 throw new Error(`[${label}] unknown ${keyNoun} "${prop}". Known: ${[...entryByKey.keys()].join(', ') || '(none)'}`);
             }
             validate(entry, value, label);
-            target[prop] = value;
-            onSet?.(prop);
+            target[entry.key] = value; // store under canonical key
+            onSet?.(entry.key);
             return true;
         },
         deleteProperty(_target, prop) {
@@ -84,9 +103,9 @@ export function buildKeyedProxy(
         defineProperty() {
             throw new Error(`[${label}] cannot define new properties — keys are fixed by the script's source.`);
         },
-        ownKeys(target) { return Reflect.ownKeys(target); },
+        ownKeys(target) { return Reflect.ownKeys(target); }, // canonical keys only
         getOwnPropertyDescriptor(target, prop) { return Reflect.getOwnPropertyDescriptor(target, prop); },
-        has(target, prop) { return typeof prop === 'string' && prop in target; },
+        has(_target, prop) { return typeof prop === 'string' && entryByKey.has(prop); },
     });
 
     return { proxy, values, entryByKey };

--- a/src/Indicator/scanInputs.ts
+++ b/src/Indicator/scanInputs.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 LuxAlgo
 
 import { pineToJS } from '../transpiler/pineToJS/pineToJS.index';
+import { resolveColorToRgba, rgbaToHex8 } from '../namespaces/color/PineColor';
 import type { IPineInput, PineInputType, PineInputDisplay } from './types';
 
 /**
@@ -80,20 +81,22 @@ export function scanInputs(source: unknown): IPineInput[] {
 
     const enumTable = collectEnumTable(parsed.ast);
     const inputs: IPineInput[] = [];
-    const seenTitles = new Set<string>();
+    const seenVarIds = new Set<string>();
     walk(parsed.ast, (node) => {
         const meta = decodeInputCall(node, enumTable);
         if (!meta) return;
-        if (meta.title !== undefined) {
-            if (seenTitles.has(meta.title)) {
-                // Pine allows multiple inputs sharing the same title (last wins
-                // at runtime). For the JS-side overview, the first one wins
-                // and we surface a warning so the collision is visible.
+        // De-duplicate by VARID (the variable name), not by title. Titles may
+        // legitimately be empty or repeated across inputs; the variable name is
+        // the unique handle. Two inputs sharing a title now both appear (with
+        // distinct varIds). A genuinely duplicated varId (pathological — e.g.
+        // the same name reassigned to another input) keeps the first and warns.
+        if (meta.varId !== undefined) {
+            if (seenVarIds.has(meta.varId)) {
                 // eslint-disable-next-line no-console
-                console.warn(`[Indicator] duplicate input title "${meta.title}" — first declaration wins for .input access`);
+                console.warn(`[Indicator] duplicate input variable "${meta.varId}" — first declaration wins for .input access`);
                 return;
             }
-            seenTitles.add(meta.title);
+            seenVarIds.add(meta.varId);
         }
         inputs.push(meta);
     });
@@ -191,6 +194,9 @@ function decodeInputCall(node: any, enumTable: EnumTable): IPineInput | null {
         if (!type) continue;
 
         const meta: IPineInput = { type, defval: resolved.defval };
+        // The assigned variable name — the primary override key. Only simple
+        // `name = input.*()` assignments carry one (Identifier id).
+        if (decl.id?.type === 'Identifier' && typeof decl.id.name === 'string') meta.varId = decl.id.name;
         if (resolved.title !== undefined) meta.title = String(resolved.title);
         if (resolved.tooltip !== undefined) meta.tooltip = String(resolved.tooltip);
         if (resolved.group !== undefined) meta.group = String(resolved.group);
@@ -261,6 +267,40 @@ function resolveValue(node: any, enumTable: EnumTable): unknown {
                 // color.red, color.blue, etc. — return as the qualified path,
                 // the caller-facing string is good enough for overrides.
                 return key;
+            }
+            return undefined;
+        }
+        case 'CallExpression': {
+            // Statically evaluate the two color-constructor calls that show
+            // up as input.color() defaults: color.new(col, transp) and
+            // color.rgb(r, g, b, transp?). Both yield an 8-digit RGBA hex so
+            // the meta defval is populated (the generic CallExpression case
+            // is otherwise unresolvable → undefined). transp is Pine's 0..100
+            // transparency (0 = opaque), so alpha = 1 − transp/100.
+            const callee = node.callee;
+            if (
+                callee?.type === 'MemberExpression' &&
+                callee.object?.type === 'Identifier' &&
+                callee.object.name === 'color' &&
+                callee.property?.type === 'Identifier'
+            ) {
+                const fn = callee.property.name;
+                const args = (node.arguments ?? []).map((a: any) => resolveValue(a, enumTable));
+                const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
+                if (fn === 'rgb') {
+                    const [r, g, b, transp] = args;
+                    if (typeof r === 'number' && typeof g === 'number' && typeof b === 'number') {
+                        const a = clamp01(1 - (typeof transp === 'number' ? transp : 0) / 100);
+                        return rgbaToHex8(r, g, b, a);
+                    }
+                } else if (fn === 'new') {
+                    const base = resolveColorToRgba(args[0]); // base color's [r,g,b,a]
+                    const transp = args[1];
+                    if (base && typeof transp === 'number') {
+                        // color.new REPLACES the base's transparency with transp.
+                        return rgbaToHex8(base[0], base[1], base[2], clamp01(1 - transp / 100));
+                    }
+                }
             }
             return undefined;
         }

--- a/src/Indicator/scanInputs.ts
+++ b/src/Indicator/scanInputs.ts
@@ -80,10 +80,11 @@ export function scanInputs(source: unknown): IPineInput[] {
     if (!parsed.success || !parsed.ast) return [];
 
     const enumTable = collectEnumTable(parsed.ast);
+    const constTable = collectConstTable(parsed.ast);
     const inputs: IPineInput[] = [];
     const seenVarIds = new Set<string>();
     walk(parsed.ast, (node) => {
-        const meta = decodeInputCall(node, enumTable);
+        const meta = decodeInputCall(node, enumTable, constTable);
         if (!meta) return;
         // De-duplicate by VARID (the variable name), not by title. Titles may
         // legitimately be empty or repeated across inputs; the variable name is
@@ -131,6 +132,34 @@ function collectEnumTable(ast: any): EnumTable {
     return table;
 }
 
+// Maps a local const/variable name → its initializer AST node. resolveValue
+// looks names up here and resolves the init recursively, so an input argument
+// written as `input.int(DEF_LENGTH, …)` reports the const's VALUE, not its name.
+type ConstTable = Map<string, any>;
+
+/**
+ * Collect top-level `name = <expr>` / `const T name = <expr>` declarations so
+ * input arguments referencing them resolve to the declared value. Stores the
+ * initializer AST node (not a pre-resolved value) so resolveValue composes the
+ * usual literal / enum / color / chained-const logic. First declaration wins.
+ *
+ * Enum objects and input-call declarations land here too, but are harmless:
+ * resolveValue returns `undefined` for an ObjectExpression or a non-color
+ * call, so such references just fall back to the bare name.
+ */
+function collectConstTable(ast: any): ConstTable {
+    const table: ConstTable = new Map();
+    walk(ast, (node) => {
+        if (node.type !== 'VariableDeclaration') return;
+        for (const decl of node.declarations ?? []) {
+            if (decl?.id?.type === 'Identifier' && decl.init && !table.has(decl.id.name)) {
+                table.set(decl.id.name, decl.init);
+            }
+        }
+    });
+    return table;
+}
+
 /**
  * Decode a single AST node into an `IPineInput`, or return `null` if the node
  * is not a top-level `input.<fn>(...)` call assigned to something.
@@ -142,7 +171,7 @@ function collectEnumTable(ast: any): EnumTable {
  *
  * Anything else returns null and is skipped.
  */
-function decodeInputCall(node: any, enumTable: EnumTable): IPineInput | null {
+function decodeInputCall(node: any, enumTable: EnumTable, constTable: ConstTable): IPineInput | null {
     if (node.type !== 'VariableDeclaration') return null;
     for (const decl of node.declarations ?? []) {
         const init = decl?.init;
@@ -186,7 +215,7 @@ function decodeInputCall(node: any, enumTable: EnumTable): IPineInput | null {
         // Now turn raw AST values into JS primitives, resolving enum + source refs.
         const resolved: any = {};
         for (const k of Object.keys(raw)) {
-            resolved[k] = resolveValue(raw[k], enumTable);
+            resolved[k] = resolveValue(raw[k], enumTable, constTable);
         }
 
         // Determine the type tag. For bare `input(...)`, infer from defval.
@@ -245,15 +274,24 @@ function decodePositionals(layout: readonly string[], positionals: any[], raw: R
  * Anything we can't resolve becomes `undefined` — better than recording
  * an opaque AST node that the JS caller can't inspect.
  */
-function resolveValue(node: any, enumTable: EnumTable): unknown {
+function resolveValue(node: any, enumTable: EnumTable, constTable?: ConstTable, visited: Set<string> = new Set()): unknown {
     if (node == null) return undefined;
     switch (node.type) {
         case 'Literal':
             return node.value;
         case 'Identifier':
             if (SOURCE_BUILTINS.has(node.name)) return node.name; // input.source(close, …)
-            // Could be a display constant if used without the `display.` prefix
-            // (rare but valid in Pine). Treat as the bare name.
+            // Resolve a local const/variable reference to its declared value,
+            // recursively (so chained consts, enum refs and color constructors
+            // compose). Cycle-guarded via `visited`.
+            if (constTable?.has(node.name) && !visited.has(node.name)) {
+                visited.add(node.name);
+                const resolved = resolveValue(constTable.get(node.name), enumTable, constTable, visited);
+                visited.delete(node.name);
+                if (resolved !== undefined) return resolved;
+            }
+            // Fallback: a display constant used without the `display.` prefix,
+            // or an unresolved reference — surface the bare name.
             return node.name;
         case 'MemberExpression': {
             // Enum field — tz.utc → "UTC"
@@ -285,7 +323,7 @@ function resolveValue(node: any, enumTable: EnumTable): unknown {
                 callee.property?.type === 'Identifier'
             ) {
                 const fn = callee.property.name;
-                const args = (node.arguments ?? []).map((a: any) => resolveValue(a, enumTable));
+                const args = (node.arguments ?? []).map((a: any) => resolveValue(a, enumTable, constTable, visited));
                 const clamp01 = (x: number) => Math.max(0, Math.min(1, x));
                 if (fn === 'rgb') {
                     const [r, g, b, transp] = args;
@@ -305,7 +343,7 @@ function resolveValue(node: any, enumTable: EnumTable): unknown {
             return undefined;
         }
         case 'ArrayExpression':
-            return (node.elements ?? []).map((el: any) => resolveValue(el, enumTable));
+            return (node.elements ?? []).map((el: any) => resolveValue(el, enumTable, constTable, visited));
         case 'UnaryExpression':
             // -3.14 ends up here for negative number literals.
             if (node.operator === '-' && node.argument?.type === 'Literal' && typeof node.argument.value === 'number') {

--- a/src/Indicator/types.ts
+++ b/src/Indicator/types.ts
@@ -49,6 +49,12 @@ export interface IPineInput {
     type: PineInputType;
     defval: unknown;
 
+    // Variable the input is assigned to (`len = input.int(…)` → "len"). Present
+    // for every scanned input (the scanner only captures `var = input.*()`
+    // forms). It is the PRIMARY, stable key for `.input[...]` overrides — title
+    // is a secondary alias (titles can be empty or duplicated; varId can't).
+    varId?: string;
+
     // Universal optional
     title?: string;
     tooltip?: string;

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -4,7 +4,7 @@ import { IProvider, ISymbolInfo } from './marketData/IProvider';
 import { Context } from './Context.class';
 import { Series } from './Series';
 import { Indicator } from './Indicator';
-import { processStrategyOrders, processExitOrders, processMarginCall, finalizeStrategyBar, isAdverseFirstBar, applyPendingCloseMarginCall } from './namespaces/strategy/utils';
+import { processStrategyOrders, processExitOrders, processMarginCall, finalizeStrategyBar, finalizeStrategyRun, isAdverseFirstBar, applyPendingCloseMarginCall } from './namespaces/strategy/utils';
 
 // ── Timeframe duration utility ──────────────────────────────────────
 //prettier-ignore
@@ -1228,6 +1228,13 @@ export class PineTS {
             if (context.lctx) {
                 context.lctx.forEach((lctx: any) => shiftVariables(lctx));
             }
+        }
+
+        // End-of-run: compute the risk-adjusted performance ratios
+        // (Sharpe / Sortino) from the monthly equity curve accumulated
+        // across the bar loop. Runs once, after the last bar.
+        if (context.strategy) {
+            finalizeStrategyRun(context);
         }
     }
 }

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -4,7 +4,7 @@ import { IProvider, ISymbolInfo } from './marketData/IProvider';
 import { Context } from './Context.class';
 import { Series } from './Series';
 import { Indicator } from './Indicator';
-import { processStrategyOrders, processExitOrders, processMarginCall, finalizeStrategyBar } from './namespaces/strategy/utils';
+import { processStrategyOrders, processExitOrders, processMarginCall, finalizeStrategyBar, isAdverseFirstBar, applyPendingCloseMarginCall } from './namespaces/strategy/utils';
 
 // ── Timeframe duration utility ──────────────────────────────────────
 //prettier-ignore
@@ -1129,18 +1129,38 @@ export class PineTS {
             context.data.bar_index.data.push(i);
 
             // Process strategy orders at the START of the bar (filling at Open).
-            // Entry-category orders fill first (market/limit/stop pending orders),
-            // then exit-category orders evaluate against the bar's open/high/low
-            // (conditional TP/SL/trailing exits + close()/close_all() markets).
+            // Entry-category orders fill first (market/limit/stop pending
+            // orders), then exit-category orders evaluate against the bar's
+            // open/high/low — so an exit gap-firing at the open covers trades
+            // that filled at that same open (entry-first precedence). TV
+            // evidence is majority-but-not-unanimous here: 3 of 4 gap events
+            // in the QA pyramiding xlsx (2021-02-24, 2021-09-08, 2024-02-29)
+            // catch the same-open entry; one (2024-03-21) spares it. The
+            // 'open' phase of processExitOrders implements the minority
+            // (exit-first) semantics and is currently not wired in.
             if (context.strategy) {
+                // Book a second margin call scheduled on the PREVIOUS bar
+                // by the phantom re-check (it fills at that bar's close,
+                // after its script evaluation — see processMarginCall and
+                // applyPendingCloseMarginCall). Must run before entries so
+                // a reversal queued at that close (qty frozen at queue
+                // time) overshoots by exactly the deferred quantity, as TV
+                // does.
+                applyPendingCloseMarginCall(context);
                 processStrategyOrders(context);
-                processExitOrders(context);
-                // Margin-call check (TV broker emulator): after user-defined
-                // exits, if intra-bar adverse movement would have pushed
-                // equity below required margin, FORCE LIQUIDATE all open
-                // positions at the bar's adverse extreme. Skipped when no
-                // leverage (margin_long / margin_short >= 100).
-                processMarginCall(context);
+                // Margin checkpoints along the intra-bar path (TV broker
+                // emulator): first at the OPEN right after entries fill;
+                // then at the adverse extreme — BEFORE exit fills when the
+                // bar's first move is adverse for the position (the
+                // extreme precedes the favorable exits on the path), AFTER
+                // them otherwise (favorable exits free margin first). The
+                // 'extreme' checkpoint may schedule a deferred second
+                // margin call at this bar's close (phantom re-check).
+                processMarginCall(context, 'open');
+                const adverseFirst = isAdverseFirstBar(context);
+                if (adverseFirst) processMarginCall(context, 'extreme');
+                processExitOrders(context, 'intrabar');
+                if (!adverseFirst) processMarginCall(context, 'extreme');
                 // Latch max_drawdown / max_runup ONCE at the end of the bar so
                 // trades closed mid-bar by TP / SL contribute their realized
                 // P&L (not phantom intra-bar excursions against the raw H/L).

--- a/src/namespaces/color/PineColor.ts
+++ b/src/namespaces/color/PineColor.ts
@@ -72,6 +72,51 @@ const COLOR_CONSTANTS = {
 } as const;
 
 /**
+ * Resolve any static color value to its `[r, g, b, a]` components (a in
+ * 0..1). Accepts:
+ *   - `#RRGGBB` / `#RRGGBBAA` hex
+ *   - `rgb(r,g,b)` / `rgba(r,g,b,a)` strings
+ *   - a named constant, with or without the namespace: `color.red` / `red`
+ * Returns null for anything it can't parse as a color.
+ */
+export function resolveColorToRgba(value: unknown): [number, number, number, number] | null {
+    if (typeof value !== 'string') return null;
+    let s = value.trim();
+    // Resolve a named constant first: "color.red" → "#F23645", or a bare "red".
+    const name = s.startsWith('color.') ? s.slice(6) : s;
+    if (Object.prototype.hasOwnProperty.call(COLOR_CONSTANTS, name)) {
+        s = (COLOR_CONSTANTS as Record<string, string>)[name];
+    }
+    return parseColorToRGBA(s);
+}
+
+/**
+ * Format `[r, g, b, a]` (a in 0..1) as a canonical 8-digit RGBA hex string
+ * `#RRGGBBAA` (uppercase, alpha byte ALWAYS present — `FF` = fully opaque).
+ */
+export function rgbaToHex8(r: number, g: number, b: number, a: number): string {
+    const byte = (n: number) =>
+        Math.round(Math.max(0, Math.min(255, n)))
+            .toString(16)
+            .padStart(2, '0');
+    return `#${byte(r)}${byte(g)}${byte(b)}${byte(a * 255)}`.toUpperCase();
+}
+
+/**
+ * Normalize any color value to a canonical 8-digit RGBA hex string
+ * `#RRGGBBAA` (see {@link rgbaToHex8}). Accepts every shape a color input
+ * can carry (hex, rgb()/rgba(), named constant). Values it can't parse as
+ * a color are returned unchanged, so non-color data passes through
+ * untouched. Used by `Indicator.getInputsMeta()` to present color-input
+ * defaults in a single canonical form.
+ */
+export function normalizeColorToRgbaHex(value: unknown): unknown {
+    const rgba = resolveColorToRgba(value);
+    if (!rgba) return value;
+    return rgbaToHex8(rgba[0], rgba[1], rgba[2], rgba[3]);
+}
+
+/**
  * Resolve a color argument: unwrap Series/functions to a raw value.
  */
 function resolveColor(color: any): any {

--- a/src/namespaces/input/types.ts
+++ b/src/namespaces/input/types.ts
@@ -13,4 +13,11 @@ export type InputOptions = {
     confirm?: boolean;
     display?: string;
     active?: boolean;
+    /**
+     * Transpiler-injected handle: the variable the input is assigned to
+     * (`len = input.int(…)` → "len"). Popped from the call args by
+     * parseInputOptions and used as the PRIMARY override key by resolveInput
+     * (title is the secondary fallback). Absent for non-transpiled JS calls.
+     */
+    __varId?: string;
 };

--- a/src/namespaces/input/utils.ts
+++ b/src/namespaces/input/utils.ts
@@ -23,16 +23,31 @@ const INPUT_ARGS_TYPES = {
 };
 
 export function parseInputOptions(args: any[]): Partial<InputOptions> {
-    return parseArgsForPineParams<Partial<InputOptions>>(args, INPUT_SIGNATURES, INPUT_ARGS_TYPES);
+    // Pop the transpiler-injected `{ __varId }` sentinel if present (always the
+    // last arg — added after param-wrapping, so it's a raw object literal). A
+    // Series or a real options object won't carry an own `__varId` property.
+    let varId: string | undefined;
+    const last = args[args.length - 1];
+    if (last && typeof last === 'object' && Object.prototype.hasOwnProperty.call(last, '__varId')) {
+        varId = (last as any).__varId;
+        args = args.slice(0, -1);
+    }
+    const options = parseArgsForPineParams<Partial<InputOptions>>(args, INPUT_SIGNATURES, INPUT_ARGS_TYPES);
+    if (varId !== undefined) options.__varId = varId;
+    return options;
 }
 
 export function resolveInput(context: any, options: Partial<InputOptions>) {
-    // If we have a runtime input value for this title, use it
-    // We check against context.inputs if it exists
+    // Override resolution, PRIMARY → fallback:
+    //   1. by varId   — the variable name; robust to empty/duplicate titles
+    //   2. by title   — back-compat (legacy constructor `inputs` map and
+    //                   title-keyed `.input` access both land here)
+    //   3. source default
+    if (options.__varId && context.inputs && context.inputs[options.__varId] !== undefined) {
+        return context.inputs[options.__varId];
+    }
     if (options.title && context.inputs && context.inputs[options.title] !== undefined) {
         return context.inputs[options.title];
     }
-    
-    // Otherwise return default value
     return options.defval;
 }

--- a/src/namespaces/strategy/methods/entry.ts
+++ b/src/namespaces/strategy/methods/entry.ts
@@ -115,7 +115,14 @@ export function entry(context: any) {
             oca_type: ocaType as 'cancel' | 'reduce' | 'none' | undefined,
             comment: commentValue,
             _isReversalEntry: isReversal,
-        };
+            // Ordered base size (before the reversal close-qty addition).
+            // executeOrder uses it to split a reversal OVERSHOOT into its
+            // own lot when a deferred close-margin-call shrank the
+            // position between queue and fill — TV books the base and the
+            // overshoot as two separate lots (xlsx 2021-10-02: 5 +
+            // 0.263108 longs at the same fill).
+            _base_qty: baseQty,
+        } as any;
 
         strategy.pending_orders.push(orderObj);
     };

--- a/src/namespaces/strategy/types.ts
+++ b/src/namespaces/strategy/types.ts
@@ -72,6 +72,14 @@ export interface Trade {
     max_drawdown?: number; // per-trade peak drawdown from entry
     max_runup?: number; // per-trade peak runup from entry
     status: 'open' | 'closed';
+    /**
+     * PHYSICAL entry price of this lot, immutable — used to compute
+     * per-lot exit-bracket levels (strategy.exit profit/loss ticks).
+     * Distinct from `entry_price`, which is the LEDGER value and can be
+     * swapped by FIFO entry/exit pairing when a newer lot's bracket fills
+     * before an older lot's (TV ledger convention).
+     */
+    _bracket_entry?: number;
 }
 
 /**

--- a/src/namespaces/strategy/types.ts
+++ b/src/namespaces/strategy/types.ts
@@ -245,6 +245,19 @@ export interface StrategyState {
     max_drawdown_percent_value: number;
     max_runup_percent_value: number;
 
+    // Risk-adjusted performance ratios (TV's "Risk-adjusted performance"
+    // panel). Computed ONCE at end-of-run by finalizeStrategyRun from the
+    // monthly equity curve — NOT Pine built-in variables (TV exposes them
+    // only in the Strategy Tester report / xlsx, not to scripts), so they
+    // live on the state object and are read via ctx.strategy.*.
+    sharpe_ratio: number;
+    sortino_ratio: number;
+    // Internal: mark-to-market equity at each calendar month's last bar,
+    // and the month key of the most recent bar (rollover detector). Feed
+    // the Sharpe / Sortino computation.
+    _monthly_equity?: number[];
+    _last_month_key?: number;
+
     // Trade-stat counters — updated each time a trade closes
     wintrades: number; // count of closed trades with profit > 0
     losstrades: number; // count of closed trades with profit < 0

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -1913,11 +1913,87 @@ export function processMarginCall(context: any, checkpoint: 'open' | 'extreme' |
  */
 export function finalizeStrategyBar(context: any): void {
     if (!context.strategy) return;
+    const strategy: StrategyState = context.strategy;
     const highPrice = Series.from(context.data.high).get(0);
     const lowPrice = Series.from(context.data.low).get(0);
     const closePrice = Series.from(context.data.close).get(0);
     markToMarket(context, closePrice);
     updateEquityPeaks(context, highPrice, lowPrice);
+
+    // Record the MARK-TO-MARKET equity at each calendar month's last bar,
+    // for the end-of-run Sharpe / Sortino ratios (see
+    // finalizeStrategyRun). TV samples the equity curve monthly regardless
+    // of the chart timeframe; we keep the last bar's equity per UTC
+    // calendar month (overwrite within a month, append on rollover).
+    const barTime = Series.from(context.data.openTime).get(0);
+    if (Number.isFinite(barTime)) {
+        const d = new Date(barTime);
+        const monthKey = d.getUTCFullYear() * 12 + d.getUTCMonth();
+        const series = (strategy._monthly_equity ??= []);
+        if (strategy._last_month_key === monthKey && series.length > 0) {
+            series[series.length - 1] = strategy.equity;
+        } else {
+            series.push(strategy.equity);
+            strategy._last_month_key = monthKey;
+        }
+    }
+}
+
+/**
+ * End-of-run finalize: compute the risk-adjusted performance ratios
+ * (Sharpe / Sortino) from the monthly equity curve captured during the
+ * run. Called ONCE after the last bar (see PineTS.class.ts).
+ *
+ * TV broker-emulator formula (confirmed against the Help Center docs and
+ * reverse-engineered to the third decimal across 7 QA datasets,
+ * 2026-06-15):
+ *   - Sample the MARK-TO-MARKET equity at each calendar month's close.
+ *   - Monthly simple returns rᵢ = Eᵢ / Eᵢ₋₁ − 1, anchored at the initial
+ *     capital (the first return runs from initial_capital to month 1).
+ *   - MR = mean(rᵢ);  RFR = risk_free_rate / 100 / 12 (annual % → monthly).
+ *   - Sharpe  = (MR − RFR) / SD,  SD = √(Σ(rᵢ − MR)² / N)   (population).
+ *   - Sortino = (MR − RFR) / DD,  DD = √(Σ min(0, rᵢ − RFR)² / N)
+ *     (downside deviation over ALL N returns, target = RFR — per TV's
+ *     documented DD = sqrt(sum(min(0, Xᵢ − T))² / N)).
+ *   - No annualization.
+ *
+ * Note: the ratios are only as accurate as the bar-by-bar equity path;
+ * they ride on the strategy engine's mark-to-market fidelity. With < 2
+ * monthly returns (very short backtests) they are left at 0.
+ */
+export function finalizeStrategyRun(context: any): void {
+    const strategy: StrategyState = context?.strategy;
+    if (!strategy) return;
+
+    const series = strategy._monthly_equity ?? [];
+    const equities = [strategy.initial_capital, ...series];
+    const returns: number[] = [];
+    for (let i = 1; i < equities.length; i++) {
+        const prev = equities[i - 1];
+        if (prev !== 0 && Number.isFinite(prev) && Number.isFinite(equities[i])) {
+            returns.push(equities[i] / prev - 1);
+        }
+    }
+
+    if (returns.length < 2) {
+        strategy.sharpe_ratio = 0;
+        strategy.sortino_ratio = 0;
+        return;
+    }
+
+    const rfrMonthly = (strategy.config.risk_free_rate ?? 2) / 100 / 12;
+    const n = returns.length;
+    const mean = returns.reduce((s, r) => s + r, 0) / n;
+    const excess = mean - rfrMonthly;
+
+    const variance = returns.reduce((s, r) => s + (r - mean) ** 2, 0) / n;
+    const sd = Math.sqrt(variance);
+
+    const downsideSq = returns.reduce((s, r) => s + Math.min(0, r - rfrMonthly) ** 2, 0) / n;
+    const dd = Math.sqrt(downsideSq);
+
+    strategy.sharpe_ratio = sd > 0 ? excess / sd : 0;
+    strategy.sortino_ratio = dd > 0 ? excess / dd : 0;
 }
 
 /**
@@ -2004,6 +2080,13 @@ export function initializeStrategy(context: any, config: any): void {
         equity_at_drawdown_peak: initialCapital,
         max_drawdown_percent_value: 0,
         max_runup_percent_value: 0,
+
+        // Risk-adjusted ratios (computed at end-of-run) + their internal
+        // monthly-equity accumulator.
+        sharpe_ratio: 0,
+        sortino_ratio: 0,
+        _monthly_equity: [],
+        _last_month_key: -1,
 
         // Trade-stat counters
         wintrades: 0,

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -1236,8 +1236,14 @@ export function processExitOrders(context: any): void {
                     trailArmedThisBar = true;
                 }
             }
-        } else if (order.trail_armed) {
-            // Already armed — update peak.
+        }
+
+        // Determine if open is closer to high vs low (Proximity Rule)
+        const openCloserToHigh = Math.abs(highPrice - openPrice) <= Math.abs(openPrice - lowPrice);
+        const favorableFirst = isLong ? openCloserToHigh : !openCloserToHigh;
+
+        if (order.trail_armed && !trailArmedThisBar && favorableFirst) {
+            // Favorable first: update peak before evaluation
             if (isLong) order.trail_peak = Math.max(order.trail_peak ?? -Infinity, highPrice);
             else order.trail_peak = Math.min(order.trail_peak ?? Infinity, lowPrice);
         }
@@ -1263,8 +1269,6 @@ export function processExitOrders(context: any): void {
         // For a short: open-near-high fires SL first, open-near-low fires TP first.
         // Trail is treated as an adverse-side trigger (it kicks in on a retrace
         // against the favorable peak), so it fires together with SL.
-        const openCloserToHigh = Math.abs(highPrice - openPrice) <= Math.abs(openPrice - lowPrice);
-        const favorableFirst = isLong ? openCloserToHigh : !openCloserToHigh;
 
         let triggered = false;
         let triggerPrice: number = NaN;
@@ -1297,6 +1301,20 @@ export function processExitOrders(context: any): void {
                 const openPastTrail = isLong ? openPrice <= trailTrigger : openPrice >= trailTrigger;
                 triggerPrice = openPastTrail ? openPrice : trailTrigger;
                 triggerKind = 'trailing';
+            } else if (!favorableFirst) {
+                // Adverse first & didn't hit: update peak now
+                if (isLong) order.trail_peak = Math.max(order.trail_peak ?? -Infinity, highPrice);
+                else order.trail_peak = Math.min(order.trail_peak ?? Infinity, lowPrice);
+
+                const updatedTrailTrigger = isLong
+                    ? order.trail_peak - order.trail_offset * mintick
+                    : order.trail_peak + order.trail_offset * mintick;
+                const segment3Hit = isLong ? closePrice <= updatedTrailTrigger : closePrice >= updatedTrailTrigger;
+                if (segment3Hit) {
+                    triggered = true;
+                    triggerPrice = updatedTrailTrigger;
+                    triggerKind = 'trailing';
+                }
             }
         };
         const checkTp = () => {

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -114,10 +114,9 @@ export function computeEquityAtPrice(context: any, atPrice: number): number {
     const strategy: StrategyState = context.strategy;
     const pointValue = context.pine?.syminfo?.pointvalue ?? 1;
     let unrealized = 0;
-    for (const trade of strategy.opentrades) {
-        const dir = Math.sign(trade.size);
-        const priceChange = dir === 1 ? atPrice - trade.entry_price : trade.entry_price - atPrice;
-        unrealized += priceChange * Math.abs(trade.size) * pointValue;
+    for (const lot of ledgerOpenLots(strategy)) {
+        const priceChange = lot.dir === 1 ? atPrice - lot.entry_price : lot.entry_price - atPrice;
+        unrealized += priceChange * lot.qty * pointValue;
     }
     return strategy.initial_capital + strategy.netprofit + unrealized;
 }
@@ -591,6 +590,7 @@ export function openTrade(
         // that by stamping the id as the entry comment when none is given.
         entry_comment: entryComment ?? entryId,
         entry_price: price,
+        _bracket_entry: price,
         entry_bar_index: context.idx,
         entry_time: time,
         size: direction * qty,   // SIGNED — matches Pine's closedtrades.size()
@@ -601,6 +601,19 @@ export function openTrade(
     };
 
     strategy.opentrades.push(trade);
+
+    // FIFO ledger-entry record for TV-style exit pairing (see
+    // consumeLedger / closePartialPosition): TV's xlsx pairs exit fills
+    // with entry records oldest-first, splitting at record boundaries.
+    ((strategy as any)._ledger_entries ??= []).push({
+        entry_id: entryId,
+        entry_price: price,
+        entry_time: time,
+        entry_bar_index: context.idx,
+        entry_comment: trade.entry_comment,
+        qty,
+        commission: entryCommission,
+    });
 
     // Realize the entry commission immediately as a cash outflow. TV reports
     // strategy.netprofit and strategy.grossloss net of entry commission the
@@ -735,8 +748,20 @@ function executeOrder(context: any, order: Order, fillPrice: number, fillTime: n
         });
 
         // If there is remaining quantity (reversal), open a new trade.
+        // When the close leg consumed LESS than the order anticipated at
+        // queue time (a deferred close-margin-call shrank the position
+        // between queue and fill), the remaining qty exceeds the ordered
+        // base size. TV books the intended base size and the overshoot as
+        // TWO separate lots (each with its own exit bracket and ledger
+        // row — xlsx 2021-10-02: longs 5 + 0.263108 at the same fill).
         if (remainingQty > 0) {
-            openTrade(context, order.id, direction, remainingQty, fillPrice, fillTime, order.comment, /* isReversalOpen */ true);
+            const baseQty = (order as any)._base_qty;
+            if (baseQty !== undefined && remainingQty > baseQty + 1e-9) {
+                openTrade(context, order.id, direction, baseQty, fillPrice, fillTime, order.comment, /* isReversalOpen */ true);
+                openTrade(context, order.id, direction, remainingQty - baseQty, fillPrice, fillTime, order.comment, /* isReversalOpen */ true);
+            } else {
+                openTrade(context, order.id, direction, remainingQty, fillPrice, fillTime, order.comment, /* isReversalOpen */ true);
+            }
         }
     } else {
         // We are increasing position or opening fresh
@@ -768,6 +793,53 @@ export interface CloseInfo {
     isImplicitReversal?: boolean;
 }
 
+/**
+ * Consume `qty` from the strategy's FIFO ledger-entry queue (records with
+ * the closing lot's entry_id), splitting records at boundaries. Returns
+ * the consumed slices (entry attributes + pro-rata entry commission).
+ * Falls back to the physical lot's own attributes for any quantity the
+ * queue cannot supply (hand-built test states have no queue records).
+ */
+function consumeLedger(
+    strategy: StrategyState,
+    physical: Trade,
+    qty: number,
+): Array<{ qty: number; entry_price: number; entry_time: number; entry_bar_index: number; entry_comment?: string; commission: number }> {
+    const out: Array<{ qty: number; entry_price: number; entry_time: number; entry_bar_index: number; entry_comment?: string; commission: number }> = [];
+    let need = qty;
+    const queue: any[] = (strategy as any)._ledger_entries ?? [];
+    for (const rec of queue) {
+        if (need <= 1e-9) break;
+        if (rec.entry_id !== physical.entry_id || rec.qty <= 1e-9) continue;
+        const take = Math.min(rec.qty, need);
+        const commShare = rec.qty > 0 ? rec.commission * (take / rec.qty) : 0;
+        out.push({
+            qty: take,
+            entry_price: rec.entry_price,
+            entry_time: rec.entry_time,
+            entry_bar_index: rec.entry_bar_index,
+            entry_comment: rec.entry_comment,
+            commission: commShare,
+        });
+        rec.qty -= take;
+        rec.commission -= commShare;
+        need -= take;
+    }
+    (strategy as any)._ledger_entries = queue.filter((r) => r.qty > 1e-9);
+    if (need > 1e-9) {
+        const physQty = Math.abs(physical.size);
+        out.push({
+            qty: need,
+            entry_price: physical.entry_price,
+            entry_time: physical.entry_time,
+            entry_bar_index: physical.entry_bar_index,
+            entry_comment: physical.entry_comment,
+            commission: physQty > 0 ? (physical.commission ?? 0) * (need / physQty) : 0,
+        });
+    }
+    return out;
+}
+
 export function closePartialPosition(
     context: any,
     qtyToClose: number,
@@ -794,142 +866,95 @@ export function closePartialPosition(
         const qtyClosing = Math.min(tradeQty, remainingQty);
         const tradeDirection = Math.sign(trade.size);
 
-        if (qtyClosing >= tradeQty) {
-            // Fully close this trade
+        // TV LEDGER PAIRING: exit fills pair against a FIFO queue of ENTRY
+        // RECORDS (per entry_id), SPLITTING at record boundaries — a fill
+        // of 5 contracts can consume 4.74018 of the oldest unpaired entry
+        // plus 0.25982 of the next, producing TWO ledger rows (TV xlsx
+        // 2021-11-16). Physical lots (this loop) only drive position,
+        // margin and bracket levels; the closed-trade ROWS and the
+        // financial aggregates follow the ledger slices. `consumeLedger`
+        // falls back to the physical lot's own attributes when no queue
+        // records exist (hand-built tests).
+        //
+        // Per-row semantics preserved from the previous implementation:
+        //   - netprofit increment = gross − exit-commission share (the
+        //     entry leg was realized at fill), per the TV convention
+        //     verified in the drawdown/margin QA sessions;
+        //   - grossloss rollback of the entry-commission share;
+        //   - SL/TP per-trade peak overrides (loss → max_runup = 0,
+        //     profit → max_drawdown = entry commission share);
+        //   - cash_per_order half-fee on implicit-reversal closes.
+        const emitClosedRows = (qtyClosed: number) => {
+            const commType = strategy.config.commission_type ?? 'percent';
+            const halveFlat = closeInfo?.isImplicitReversal && commType === 'cash_per_order';
+            const rawExitCommission = computeLegCommission(context, strategy, qtyClosed, exitPrice);
+            const exitCommTotal = halveFlat ? rawExitCommission / 2 : rawExitCommission;
+
+            const slices = consumeLedger(strategy, trade, qtyClosed);
+            for (const s of slices) {
+                const exitCommShare = exitCommTotal * (s.qty / qtyClosed);
+                const priceChange = tradeDirection === 1 ? exitPrice - s.entry_price : s.entry_price - exitPrice;
+                const gross = priceChange * s.qty * pointValue;
+
+                const row: Trade = {
+                    id: `trade_${strategy.opentrades.length + strategy.closedtrades.length + tradesToClose.length}`,
+                    entry_id: trade.entry_id,
+                    entry_comment: s.entry_comment,
+                    entry_price: s.entry_price,
+                    _bracket_entry: trade._bracket_entry,
+                    entry_bar_index: s.entry_bar_index,
+                    entry_time: s.entry_time,
+                    size: tradeDirection * s.qty,
+                    commission: s.commission + exitCommShare,
+                    max_drawdown: trade.max_drawdown,
+                    max_runup: trade.max_runup,
+                    status: 'closed',
+                    exit_price: exitPrice,
+                    exit_bar_index: context.idx,
+                    exit_time: exitTime,
+                    exit_id:      closeInfo?.exitId      ?? trade.exit_id,
+                    exit_comment: closeInfo?.exitComment ?? trade.exit_comment,
+                    profit: gross - s.commission - exitCommShare,
+                };
+                if (closeInfo?.triggerKind === 'loss')   row.max_runup    = 0;
+                if (closeInfo?.triggerKind === 'profit') row.max_drawdown = s.commission;
+
+                strategy.netprofit += gross - exitCommShare;
+                strategy.grossloss -= s.commission;
+                if (row.profit! > 0) {
+                    strategy.grossprofit += row.profit!;
+                    strategy.wintrades++;
+                    strategy.wintrades_total_profit += row.profit!;
+                } else if (row.profit! < 0) {
+                    strategy.grossloss += Math.abs(row.profit!);
+                    strategy.losstrades++;
+                    strategy.losstrades_total_loss += Math.abs(row.profit!);
+                } else {
+                    strategy.eventrades++;
+                }
+                strategy.closedtrades.push(row);
+            }
+        };
+
+        // Epsilon on the full-close decision: when the requested qty is a
+        // float hair short of the trade's size (fractional margin-call
+        // remainders), treat it as a full close instead of leaving a
+        // ~1e-15 ghost portion open.
+        if (qtyClosing >= tradeQty - 1e-9) {
+            // Fully close this physical lot.
             trade.status = 'closed';
             trade.exit_price = exitPrice;
             trade.exit_bar_index = context.idx;
             trade.exit_time = exitTime;
-
-            // Gross P&L from price change (direction-aware). PointValue
-            // converts the price-change × qty units into account currency.
-            const priceChange = tradeDirection === 1 ? exitPrice - trade.entry_price : trade.entry_price - exitPrice;
-            const grossPnL = priceChange * tradeQty * pointValue;
-
-            // Capture entry-only commission BEFORE adding the exit leg — used
-            // below for the TP-override on max_drawdown.
-            const entryOnlyComm = trade.commission ?? 0;
-
-            // Charge entry + exit commission legs and bank them on the trade.
-            // trade.commission already holds the entry leg charged in openTrade().
-            // Exception: for `cash_per_order` on a reversal close, the
-            // reversal order's flat fee is split 50/50 between the closing
-            // leg and the opening leg (matching TV — each side gets value/2).
-            const commType = strategy.config.commission_type ?? 'percent';
-            const halveFlatExit = closeInfo?.isImplicitReversal && commType === 'cash_per_order';
-            const rawExitCommission = computeLegCommission(context, strategy, tradeQty, exitPrice);
-            const exitCommission = halveFlatExit ? rawExitCommission / 2 : rawExitCommission;
-            trade.commission = entryOnlyComm + exitCommission;
-
-            // Override per-trade peaks based on which exit leg actually fired
-            // (TV semantic for SL/TP closes — TV assumes worst-case ordering
-            // and reports excursion only on the side that triggered):
-            //   loss     (SL fired)  → no favorable movement happened → mfe = 0
-            //   profit   (TP fired)  → no adverse movement happened, only the
-            //                          entry-commission baseline cost remains.
-            // Reversal / close()/close_all() leave triggerKind undefined and
-            // the trade's accumulated excursions stand.
-            if (closeInfo?.triggerKind === 'loss')   trade.max_runup    = 0;
-            if (closeInfo?.triggerKind === 'profit') trade.max_drawdown = entryOnlyComm;
-
-            // Stamp the exit metadata onto the closed trade. exit_id is the
-            // exit ORDER's id ('ExA' / 'ExB' / etc.); exit_comment is the
-            // resolved per-leg comment (comment_loss / comment_profit /
-            // comment_trailing) selected by the trigger kind.
-            if (closeInfo?.exitId !== undefined)      trade.exit_id      = closeInfo.exitId;
-            if (closeInfo?.exitComment !== undefined) trade.exit_comment = closeInfo.exitComment;
-
-            // Profit on the trade is NET of all commission (entry + exit).
-            trade.profit = grossPnL - trade.commission;
-
-            // netprofit: roll in the INCREMENTAL P&L from this close. The
-            // entry-leg commission was already realized at fill, so the
-            // close-time contribution is grossPnL − exitCommission.
-            const incremental = grossPnL - exitCommission;
-            strategy.netprofit += incremental;
-
-            // grossprofit / grossloss per Pine docs: total currency value of
-            // all COMPLETED winning / losing trades. So at close we ROLL
-            // BACK the entry-commission contribution to grossloss (which was
-            // added at fill) and partition the trade's total profit by sign.
-            // Open trades' entry commission stays in grossloss until they
-            // close (matches TV's commission_slippage behavior).
-            strategy.grossloss -= entryOnlyComm;
-            if (trade.profit > 0) {
-                strategy.grossprofit += trade.profit;
-                strategy.wintrades++;
-                strategy.wintrades_total_profit += trade.profit;
-            } else if (trade.profit < 0) {
-                strategy.grossloss += Math.abs(trade.profit);
-                strategy.losstrades++;
-                strategy.losstrades_total_loss += Math.abs(trade.profit);
-            } else {
-                strategy.eventrades++;
-            }
-
-            strategy.closedtrades.push(trade);
+            emitClosedRows(tradeQty);
             remainingQty -= qtyClosing;
         } else {
-            // Partially close this trade — split it into a closed portion + remaining open portion
-            const tradeNum = strategy.opentrades.length + strategy.closedtrades.length;
-
-            const priceChange = tradeDirection === 1 ? exitPrice - trade.entry_price : trade.entry_price - exitPrice;
-            const grossPnL = priceChange * qtyClosing * pointValue;
-
-            // Proportional entry-leg commission for the closed portion + full
-            // exit-leg commission. Same cash_per_order half-on-reversal rule
-            // as the full-close path above (each side gets value/2 of the
-            // reversal order's flat fee).
+            // Partially close this physical lot — emit ledger rows for the
+            // closed quantity, keep the remainder open with its residual
+            // PHYSICAL entry-commission share (used by the equity-peak
+            // basis and margin checks).
+            emitClosedRows(qtyClosing);
             const entryCommissionShare = (trade.commission ?? 0) * (qtyClosing / tradeQty);
-            const commTypePartial = strategy.config.commission_type ?? 'percent';
-            const halveFlatPartial = closeInfo?.isImplicitReversal && commTypePartial === 'cash_per_order';
-            const rawExitCommPartial = computeLegCommission(context, strategy, qtyClosing, exitPrice);
-            const exitCommission = halveFlatPartial ? rawExitCommPartial / 2 : rawExitCommPartial;
-            const closedCommission = entryCommissionShare + exitCommission;
-
-            const closedPortion: Trade = {
-                ...trade,
-                id: `trade_${tradeNum}`,
-                size: tradeDirection * qtyClosing,
-                status: 'closed',
-                exit_price: exitPrice,
-                exit_bar_index: context.idx,
-                exit_time: exitTime,
-                commission: closedCommission,
-                profit: grossPnL - closedCommission,
-                // Stamp exit metadata from the closing order.
-                exit_id:      closeInfo?.exitId      ?? trade.exit_id,
-                exit_comment: closeInfo?.exitComment ?? trade.exit_comment,
-            };
-
-            // Apply the same SL/TP per-trade peak overrides to the closed
-            // portion (full close path comments above explain the semantic).
-            if (closeInfo?.triggerKind === 'loss')   closedPortion.max_runup    = 0;
-            if (closeInfo?.triggerKind === 'profit') closedPortion.max_drawdown = entryCommissionShare;
-
-            // Incremental P&L from this partial close — entry-leg share was
-            // already realized at fill, so the close-time contribution to
-            // netprofit is grossPnL − exit commission only.
-            const incremental = grossPnL - exitCommission;
-            strategy.netprofit += incremental;
-
-            // grossprofit / grossloss: roll back the entry-share contribution
-            // to grossloss (added at fill) and partition the closed portion's
-            // total profit by sign (mirrors the full-close path).
-            strategy.grossloss -= entryCommissionShare;
-            if (closedPortion.profit! > 0) {
-                strategy.grossprofit += closedPortion.profit!;
-                strategy.wintrades++;
-                strategy.wintrades_total_profit += closedPortion.profit!;
-            } else if (closedPortion.profit! < 0) {
-                strategy.grossloss += Math.abs(closedPortion.profit!);
-                strategy.losstrades++;
-                strategy.losstrades_total_loss += Math.abs(closedPortion.profit!);
-            } else {
-                strategy.eventrades++;
-            }
-
-            strategy.closedtrades.push(closedPortion);
 
             // The remaining open portion keeps the residual entry commission share.
             trade.size = tradeDirection * (tradeQty - qtyClosing);
@@ -945,7 +970,15 @@ export function closePartialPosition(
     // Update flat position scalars from the (possibly shrunken) open-trade book
     const currentSize = strategy.position_size;
     const sizeReduction = Math.sign(currentSize) * qtyToClose; // Reduce magnitude
-    const newSize = currentSize - sizeReduction;
+    let newSize = currentSize - sizeReduction;
+
+    // Epsilon-snap to flat: fractional quantities (margin-call partial
+    // liquidations) leave float residuals (~1e-15) when the position fully
+    // unwinds. An exact `=== 0` check then misses the flatten, leaving
+    // position_avg_price alive on a ghost position — the script captures
+    // stale TP/SL prices from it and the next entry gets phantom-exited at
+    // its own entry price (QA pyramiding xlsx, 2021-11-09 BTCUSDC).
+    if (Math.abs(newSize) < 1e-9) newSize = 0;
 
     strategy.position_size = newSize;
     updateMaxContractsHeld(strategy);
@@ -954,22 +987,46 @@ export function closePartialPosition(
         strategy.position_avg_price = NaN;
         strategy.position_entry_name = '';
     } else if (strategy.opentrades.length > 0) {
-        // Recompute average entry price from remaining open trades.
-        // Crucial because closing older trades (FIFO) changes the weighted
-        // average if the position was built from multiple entries at
-        // different prices.
+        // Recompute average entry price from the remaining open book
+        // (LEDGER view — see ledgerOpenLots). Crucial because closing
+        // older entries (FIFO pairing) changes the weighted average if
+        // the position was built from multiple entries at different
+        // prices.
         let totalCost = 0;
         let totalQty = 0;
-        for (const t of strategy.opentrades) {
-            const tQty = Math.abs(t.size);
-            totalCost += tQty * t.entry_price;
-            totalQty += tQty;
+        for (const t of ledgerOpenLots(strategy)) {
+            totalCost += t.qty * t.entry_price;
+            totalQty += t.qty;
         }
         strategy.position_avg_price = totalCost / totalQty;
         // position_entry_name keeps pointing at whichever entry opened the
         // first still-open trade
         strategy.position_entry_name = strategy.opentrades[0].entry_id;
     }
+}
+
+/**
+ * The open book in LEDGER view: the FIFO entry records not yet paired
+ * with exit fills. ALL equity-side computations (unrealized PnL, average
+ * entry, open entry commissions) must use this view so they stay
+ * consistent with `netprofit`, whose increments follow the ledger slices
+ * — TV's equity is fully ledger-based, and mixing ledger-realized with
+ * physical-unrealized breaks total-equity invariance whenever exit
+ * pairing crosses lot boundaries. Falls back to the physical lots when
+ * no records exist (hand-built test states).
+ */
+function ledgerOpenLots(strategy: StrategyState): Array<{ qty: number; entry_price: number; commission: number; dir: number }> {
+    const records: any[] = (strategy as any)._ledger_entries ?? [];
+    const dir = Math.sign(strategy.position_size) || 1;
+    if (records.length > 0) {
+        return records.map((r) => ({ qty: r.qty, entry_price: r.entry_price, commission: r.commission, dir }));
+    }
+    return strategy.opentrades.map((t) => ({
+        qty: Math.abs(t.size),
+        entry_price: t.entry_price,
+        commission: t.commission ?? 0,
+        dir: Math.sign(t.size),
+    }));
 }
 
 /**
@@ -984,11 +1041,9 @@ function markToMarket(context: any, currentPrice: number): void {
     const strategy: StrategyState = context.strategy;
     const pointValue = context.pine?.syminfo?.pointvalue ?? 1;
     let unrealizedPnL = 0;
-    for (const trade of strategy.opentrades) {
-        const tradeQty = Math.abs(trade.size);
-        const tradeDirection = Math.sign(trade.size);
-        const priceChange = tradeDirection === 1 ? currentPrice - trade.entry_price : trade.entry_price - currentPrice;
-        unrealizedPnL += priceChange * tradeQty * pointValue;
+    for (const lot of ledgerOpenLots(strategy)) {
+        const priceChange = lot.dir === 1 ? currentPrice - lot.entry_price : lot.entry_price - currentPrice;
+        unrealizedPnL += priceChange * lot.qty * pointValue;
     }
     strategy.openprofit = unrealizedPnL;
     strategy.equity = strategy.initial_capital + strategy.netprofit + unrealizedPnL;
@@ -1028,9 +1083,10 @@ function updateEquityPeaks(context: any, highPrice: number, lowPrice: number): v
 
     const realizedEquity = strategy.initial_capital + strategy.netprofit;
 
-    // Open-trade entry commissions (already deducted from netprofit at fill).
+    // Open-book entry commissions (already deducted from netprofit at
+    // fill) — LEDGER view, consistent with netprofit's slice increments.
     let openCommission = 0;
-    for (const t of strategy.opentrades) openCommission += t.commission ?? 0;
+    for (const lot of ledgerOpenLots(strategy)) openCommission += lot.commission;
 
     // PEAK basis excludes the open trades' entry commissions. TV latches the
     // equity high-water on the intermediate funds state right after a close
@@ -1117,8 +1173,27 @@ export function closeMatching(
     exitPrice: number,
     exitTime: number,
     closeInfo?: CloseInfo,
+    specificTradeId?: string,
 ): void {
     const strategy: StrategyState = context.strategy;
+
+    // Per-LOT close (exit brackets): TV binds each bracket to the physical
+    // entry lot whose entry price computed its level — the fill closes
+    // THAT lot, not the oldest. FIFO entry/exit pairing for the ledger is
+    // handled inside closePartialPosition (see the ledger-swap there).
+    if (specificTradeId !== undefined) {
+        const target: Trade[] = [];
+        const others: Trade[] = [];
+        for (const t of strategy.opentrades) {
+            if (t.id === specificTradeId) target.push(t);
+            else others.push(t);
+        }
+        if (target.length === 0) return;
+        const targetQty = Math.abs(target[0].size);
+        strategy.opentrades = [...target, ...others];
+        closePartialPosition(context, Math.min(qtyToClose, targetQty), exitPrice, exitTime, closeInfo);
+        return;
+    }
 
     if (!fromEntry || fromEntry === '') {
         // No filter — close FIFO across all open trades.
@@ -1152,7 +1227,7 @@ export function closeMatching(
  *     triggers evaluated against current bar's high/low. Trailing-stop
  *     peak (trade.trail_peak) is updated each bar even when not triggered.
  */
-export function processExitOrders(context: any): void {
+export function processExitOrders(context: any, phase: 'open' | 'intrabar' = 'intrabar'): void {
     if (!context.strategy) return;
     const strategy: StrategyState = context.strategy;
     if (strategy.pending_orders.length === 0) return;
@@ -1164,6 +1239,26 @@ export function processExitOrders(context: any): void {
     const currentTime = Series.from(context.data.openTime).get(0);
     const mintick = context.pine?.syminfo?.mintick ?? 0.01;
 
+    // Two-phase evaluation (TV broker-emulator order precedence at the
+    // bar's open):
+    //   phase 'open'     — runs BEFORE entry fills. Only conditional-exit
+    //                      GAP-FILLS execute (the bar opened already past a
+    //                      bracket's trigger → fill at the open). Brackets
+    //                      consumed here never extend to entries filling at
+    //                      the same open.
+    //   phase 'intrabar' — runs AFTER entry fills. Everything else:
+    //                      market closes, intra-bar crossings, trail, and
+    //                      gap-fills for trades that ATTACHED at this bar's
+    //                      open (an exit order waiting on a not-yet-filled
+    //                      entry brackets it at fill time — if the open is
+    //                      already past the trigger it exits immediately).
+    //
+    // QA evidence (pyramiding avg_price xlsx, BTCUSDC 1D): a stop
+    // gap-firing at the open closes ONLY the prior stack — the pyramid
+    // entry filling at that same open survives (2024-03-21); while an exit
+    // order surviving to intra-bar crossing closes same-bar entries too
+    // (2020-12-17), and a waiting order attaches to a reversal entry and
+    // gap-exits it at its own fill price (2021-09-08).
     for (const order of strategy.pending_orders) {
         if (order.status !== 'pending') continue;
         if ((order.category ?? 'entry') !== 'exit') continue;
@@ -1185,8 +1280,12 @@ export function processExitOrders(context: any): void {
             matching = matching.filter((t) => snapshot.has(t.id));
         }
         if (matching.length === 0) {
-            // Nothing to exit — clear the order.
-            order.status = 'cancelled';
+            // Nothing to exit. In the pre-entry phase the order may be
+            // WAITING on an entry that fills at this bar's open (TV: exit
+            // orders placed before their entry wait for it) — leave it
+            // pending. After entries have filled (intrabar phase), an
+            // exit with no matching trades is dead — clear it.
+            if (phase === 'intrabar') order.status = 'cancelled';
             continue;
         }
 
@@ -1197,6 +1296,10 @@ export function processExitOrders(context: any): void {
         if (order.type === 'market' && order.profit === undefined && order.loss === undefined &&
             order.limit === undefined && order.stop === undefined &&
             order.trail_price === undefined && order.trail_points === undefined) {
+            // Market closes fill in the intrabar phase (after entries) —
+            // their interplay with reversal entries is governed by the
+            // _intended_trade_ids snapshot above.
+            if (phase === 'open') continue;
             // Skip orders placed on the current bar — they fill on the next bar's open.
             if (order.bar >= context.idx) continue;
 
@@ -1224,31 +1327,33 @@ export function processExitOrders(context: any): void {
         }
 
         // ---- Conditional exits from exit() ----
-        // Aggregate-position semantics: matching trades are treated as one
-        // composite position with weighted-avg entry. Each leg (TP / SL / trail)
-        // computes a trigger price off that avg.
+        // PER-TRADE exit brackets (TV broker-emulator semantics): when a
+        // strategy.exit matches multiple open trades (pyramiding), TV
+        // creates an independent exit bracket for EACH trade:
+        //   - profit / loss (tick) legs compute the trigger from THAT
+        //     trade's own entry price;
+        //   - limit / stop (absolute price) legs are shared by all trades.
+        // When several brackets trigger inside one bar, the fills execute
+        // in intra-bar crossing order and each fill closes the OLDEST
+        // remaining trades first (FIFO) — NOT necessarily the trade whose
+        // bracket computed the level. Verified against the QA pyramiding
+        // xlsx (BTCUSDC 1D, 2020-03-12 crash bar: five short TPs filled
+        // at five different prices, assigned to trades strictly
+        // oldest-first).
+        //
+        // Trailing legs stay COMPOSITE (one armed peak per order, armed
+        // against the weighted-avg entry) — no TV evidence for per-trade
+        // trail under pyramiding yet; single-trade behavior is identical
+        // either way.
         let totalCost = 0;
         for (const t of matching) totalCost += Math.abs(t.size) * t.entry_price;
         const avgEntry = totalCost / matchingQty;
         const isLong = matchingDir === 1;
 
-        // Compute trigger prices.
-        // profit (ticks) → absolute TP price
-        let tpPrice: number | undefined;
-        if (order.limit !== undefined) tpPrice = order.limit;
-        else if (order.profit !== undefined) {
-            tpPrice = isLong
-                ? avgEntry + order.profit * mintick
-                : avgEntry - order.profit * mintick;
-        }
-        // loss (ticks) → absolute SL price
-        let slPrice: number | undefined;
-        if (order.stop !== undefined) slPrice = order.stop;
-        else if (order.loss !== undefined) {
-            slPrice = isLong
-                ? avgEntry - order.loss * mintick
-                : avgEntry + order.loss * mintick;
-        }
+        // Shared absolute legs (validated below); per-trade tick legs are
+        // computed inside the bracket loop further down.
+        let absTp: number | undefined = order.limit;
+        let absSl: number | undefined = order.stop;
 
         // Validate trigger prices are on the correct side of avgEntry —
         // EPHEMERAL pattern only. A wrong-sided leg (e.g. SL below entry
@@ -1267,13 +1372,13 @@ export function processExitOrders(context: any): void {
         // the open is past the trigger. Dropping wrong-sided legs here
         // would miss that.
         if (!order._isPersistent) {
-            if (slPrice !== undefined) {
-                const slValid = isLong ? slPrice < avgEntry : slPrice > avgEntry;
-                if (!slValid) slPrice = undefined;
+            if (absSl !== undefined) {
+                const slValid = isLong ? absSl < avgEntry : absSl > avgEntry;
+                if (!slValid) absSl = undefined;
             }
-            if (tpPrice !== undefined) {
-                const tpValid = isLong ? tpPrice > avgEntry : tpPrice < avgEntry;
-                if (!tpValid) tpPrice = undefined;
+            if (absTp !== undefined) {
+                const tpValid = isLong ? absTp > avgEntry : absTp < avgEntry;
+                if (!tpValid) absTp = undefined;
             }
         }
 
@@ -1293,8 +1398,8 @@ export function processExitOrders(context: any): void {
         // drop the absolute legs (mirrors TV's NA-on-non-trigger-bar
         // path for if-block-scoped vars).
         if (order._attachedAtReversal && !order._isPersistent) {
-            if (order.limit !== undefined) tpPrice = undefined;
-            if (order.stop  !== undefined) slPrice = undefined;
+            if (order.limit !== undefined) absTp = undefined;
+            if (order.stop  !== undefined) absSl = undefined;
         }
 
         // Trailing-stop state.
@@ -1307,8 +1412,12 @@ export function processExitOrders(context: any): void {
         // bar. The arming bar establishes the running peak; the trigger
         // check is suppressed for that bar only. SL and TP triggers are
         // independent and still fire on the arming bar.
+        // Trail arming + evaluation are intra-bar phenomena — they run in
+        // the 'intrabar' phase only (arming twice per bar would corrupt
+        // trailArmedThisBar, making the segment model treat the arming bar
+        // as an armed-prior bar).
         let trailArmedThisBar = false;
-        if (!order.trail_armed && (order.trail_price !== undefined || order.trail_points !== undefined)) {
+        if (phase === 'intrabar' && !order.trail_armed && (order.trail_price !== undefined || order.trail_points !== undefined)) {
             let armPrice: number | undefined;
             if (order.trail_price !== undefined) armPrice = order.trail_price;
             else if (order.trail_points !== undefined) {
@@ -1355,59 +1464,120 @@ export function processExitOrders(context: any): void {
         const openCloserToHigh = Math.abs(highPrice - openPrice) <= Math.abs(openPrice - lowPrice);
         const favorableFirst = isLong ? openCloserToHigh : !openCloserToHigh;
 
-        let triggered = false;
-        let triggerPrice: number = NaN;
-        let triggerKind: 'profit' | 'loss' | 'trailing' | null = null;
+        // Per-trade bracket evaluation. Each triggered bracket becomes a
+        // fill EVENT; events execute in intra-bar crossing order, and each
+        // closes the oldest remaining matching trades first (FIFO).
+        //
+        // Gap-fill rule: if the bar's OPEN is already past a trigger, the
+        // fill price is the OPEN, not the literal trigger price. This
+        // mirrors real broker behavior — if you'd planned a stop at $100
+        // and the bar opens at $95, you fill at $95.
+        type FillEvent = { qty: number; price: number; kind: 'profit' | 'loss' | 'trailing'; tradeId?: string };
+        const tpEvents: FillEvent[] = [];
+        const slEvents: FillEvent[] = [];
 
-        // Gap-fill rule: if the bar's OPEN is already past the trigger
-        // (favorable side for the position), the actual fill price is the
-        // OPEN, not the literal trigger price. This mirrors real broker
-        // behavior — if you'd planned a stop at $100 and the bar opens at
-        // $95, you fill at $95, not $100. For favorable triggers (TP for
-        // long means open above limit; TP for short means open below limit)
-        // the trader gets the favorable gap. For adverse triggers (SL),
-        // same gap detection but on the adverse side.
-        const checkSl = () => {
-            if (triggered || slPrice === undefined) return;
-            const slHit = isLong ? lowPrice <= slPrice : highPrice >= slPrice;
-            if (slHit) {
-                triggered = true;
-                // Adverse-side gap: long SL with open below stop, or short SL with open above stop.
-                const openPastSl = isLong ? openPrice <= slPrice : openPrice >= slPrice;
-                triggerPrice = openPastSl ? openPrice : slPrice;
-                triggerKind = 'loss';
+        // Margin-call bracket lock: after a same-bar margin call, only the
+        // bracket of the lot the MC partially consumed stays working for
+        // the rest of the bar — the other lots' brackets are canceled and
+        // re-created by the next strategy.exit call (see processMarginCall
+        // for the QA evidence).
+        const mcLock = (strategy as any)._mc_exit_lock;
+        const mcLocked = mcLock && mcLock.bar === context.idx;
+
+        for (const t of matching) {
+            if (mcLocked && t.id !== mcLock.tradeId) continue;
+            // Tick legs compute from the lot's PHYSICAL entry — immutable
+            // under FIFO ledger pairing (see closePartialPosition).
+            const entry = t._bracket_entry ?? t.entry_price;
+            const tQty = Math.abs(t.size);
+            let tp = absTp;
+            if (tp === undefined && order.profit !== undefined) {
+                tp = isLong ? entry + order.profit * mintick : entry - order.profit * mintick;
             }
-        };
-        const checkTrail = () => {
-            if (triggered) return;
-            if (!order.trail_armed || order.trail_offset === undefined) return;
+            let sl = absSl;
+            if (sl === undefined && order.loss !== undefined) {
+                sl = isLong ? entry - order.loss * mintick : entry + order.loss * mintick;
+            }
 
-            // Intra-bar segment model (TV broker emulator):
-            //
-            // Favorable-first (open closer to high for long; open closer to
-            // low for short):
-            //   Phase 1: open → favorable extreme (price rides to bar H for
-            //            long / bar L for short). Peak updates to that.
-            //   Phase 2: favorable extreme → adverse extreme. Trigger
-            //            (= NEW peak ± offset) may be crossed.
-            //   Phase 3: adverse extreme → close. (Already covered.)
-            //
-            // Adverse-first (open closer to adverse extreme):
-            //   Phase 1: open → adverse extreme. Peak is still PRIOR. Check
-            //            trigger using OLD peak; if crossed, fire there.
-            //   Phase 2: adverse → favorable extreme. Peak updates now.
-            //   Phase 3: favorable → close. If close descends/rises
-            //            through the NEW trigger, fire at the NEW trigger.
-            //
-            // Arming THIS bar is a sub-case: the peak was JUST established
-            // at the arming moment (bar's H for long / L for short). The
-            // segment-1 check with OLD peak doesn't apply (trail wasn't
-            // armed yet). Only phase 2 (favorable-first) or phase 3
-            // (adverse-first) can fire on the arming bar.
-            //
-            // The fill is always the LITERAL trigger price — gap-fill at
-            // open is incorrect for trail (the bar's open precedes any
-            // peak update for this trade).
+            // In the pre-entry 'open' phase only GAP conditions count (the
+            // bar opened already past the trigger); intra-bar crossings
+            // belong to the 'intrabar' phase.
+            const tpHit = tp !== undefined && (phase === 'open'
+                ? (isLong ? openPrice >= tp : openPrice <= tp)
+                : (isLong ? highPrice >= tp : lowPrice <= tp));
+            const slHit = sl !== undefined && (phase === 'open'
+                ? (isLong ? openPrice <= sl : openPrice >= sl)
+                : (isLong ? lowPrice <= sl : highPrice >= sl));
+
+            // OCO per trade: when both legs are reachable within the bar,
+            // the leg crossed FIRST along the assumed intra-bar path wins
+            // (favorable-first → TP, adverse-first → SL).
+            let kind: 'profit' | 'loss' | null = null;
+            if (tpHit && slHit) kind = favorableFirst ? 'profit' : 'loss';
+            else if (tpHit) kind = 'profit';
+            else if (slHit) kind = 'loss';
+
+            if (kind === 'loss') {
+                const openPastSl = isLong ? openPrice <= (sl as number) : openPrice >= (sl as number);
+                // TV asymmetry (637-event census from the gap_precedence
+                // probe, BTCUSDT 1D): a BUY-stop — the SL leg of a SHORT
+                // position — that is already in-the-money at the open does
+                // NOT catch a trade that entered at that same open
+                // (spared 234/234), while sell-stops and both-side limits
+                // always catch (403/403). Suppress the stop leg for
+                // same-bar short entries gapped past at the open; the TP
+                // leg (if also reachable) still applies.
+                const buyStopSparesFreshEntry =
+                    !isLong && openPastSl && t.entry_bar_index === context.idx;
+                if (!buyStopSparesFreshEntry) {
+                    slEvents.push({ qty: tQty, price: openPastSl ? openPrice : (sl as number), kind: 'loss', tradeId: t.id });
+                } else if (tpHit) {
+                    kind = 'profit';
+                }
+            }
+            if (kind === 'profit') {
+                const openPastTp = isLong ? openPrice >= (tp as number) : openPrice <= (tp as number);
+                tpEvents.push({ qty: tQty, price: openPastTp ? openPrice : (tp as number), kind: 'profit', tradeId: t.id });
+            }
+        }
+
+        // Crossing order within each leg: the TP leg is crossed while
+        // price travels toward the FAVORABLE extreme (ascending prices for
+        // a long, descending for a short); the SL leg while traveling
+        // toward the ADVERSE extreme (the reverse). Gap-fills carry
+        // price = open and naturally sort to the front of their leg.
+        tpEvents.sort((a, b) => (isLong ? a.price - b.price : b.price - a.price));
+        slEvents.sort((a, b) => (isLong ? b.price - a.price : a.price - b.price));
+        // Composite trailing leg — same intra-bar segment model as before
+        // (TV broker emulator), emitting an event for the REMAINING qty
+        // instead of firing directly:
+        //
+        // Favorable-first (open closer to high for long; open closer to
+        // low for short):
+        //   Phase 1: open → favorable extreme (price rides to bar H for
+        //            long / bar L for short). Peak updates to that.
+        //   Phase 2: favorable extreme → adverse extreme. Trigger
+        //            (= NEW peak ± offset) may be crossed.
+        //   Phase 3: adverse extreme → close. (Already covered.)
+        //
+        // Adverse-first (open closer to adverse extreme):
+        //   Phase 1: open → adverse extreme. Peak is still PRIOR. Check
+        //            trigger using OLD peak; if crossed, fire there.
+        //   Phase 2: adverse → favorable extreme. Peak updates now.
+        //   Phase 3: favorable → close. If close descends/rises
+        //            through the NEW trigger, fire at the NEW trigger.
+        //
+        // Arming THIS bar is a sub-case: the peak was JUST established
+        // at the arming moment (bar's H for long / L for short). The
+        // segment-1 check with OLD peak doesn't apply (trail wasn't
+        // armed yet). Only phase 2 (favorable-first) or phase 3
+        // (adverse-first) can fire on the arming bar.
+        //
+        // The fill is always the LITERAL trigger price — gap-fill at
+        // open is incorrect for trail (the bar's open precedes any
+        // peak update for this trade).
+        let trailEvent: FillEvent | null = null;
+        if (phase === 'intrabar' && !mcLocked && order.trail_armed && order.trail_offset !== undefined) {
             const updatePeak = () => {
                 if (isLong) order.trail_peak = Math.max(order.trail_peak ?? -Infinity, highPrice);
                 else        order.trail_peak = Math.min(order.trail_peak ?? Infinity, lowPrice);
@@ -1415,6 +1585,9 @@ export function processExitOrders(context: any): void {
             const triggerFromPeak = (): number => isLong
                 ? (order.trail_peak as number) - (order.trail_offset as number) * mintick
                 : (order.trail_peak as number) + (order.trail_offset as number) * mintick;
+            const emitTrail = (price: number) => {
+                trailEvent = { qty: Infinity, price, kind: 'trailing' };
+            };
 
             if (trailArmedThisBar) {
                 // Peak is already the bar's favorable extreme (set by the
@@ -1424,106 +1597,92 @@ export function processExitOrders(context: any): void {
                     // Phase 2 (favorable extreme → adverse extreme): low for
                     // long / high for short crosses trigger.
                     const hit = isLong ? lowPrice <= trig : highPrice >= trig;
-                    if (hit) {
-                        triggered = true;
-                        triggerPrice = trig;
-                        triggerKind = 'trailing';
-                    }
+                    if (hit) emitTrail(trig);
                 } else {
                     // Phase 3 (favorable extreme → close): close past trigger.
                     const seg3 = isLong ? closePrice < trig : closePrice > trig;
-                    if (seg3) {
-                        triggered = true;
-                        triggerPrice = trig;
-                        triggerKind = 'trailing';
-                    }
+                    if (seg3) emitTrail(trig);
                 }
-                return;
-            }
-
-            // Already armed in a prior bar. Use the full segment model.
-            if (favorableFirst) {
+            } else if (favorableFirst) {
+                // Already armed in a prior bar. Full segment model.
                 updatePeak();
                 const trig = triggerFromPeak();
                 const hit = isLong ? lowPrice <= trig : highPrice >= trig;
-                if (hit) {
-                    triggered = true;
-                    triggerPrice = trig;
-                    triggerKind = 'trailing';
-                }
+                if (hit) emitTrail(trig);
             } else {
                 const oldTrig = triggerFromPeak();
                 const seg1 = isLong ? lowPrice <= oldTrig : highPrice >= oldTrig;
                 if (seg1) {
-                    triggered = true;
-                    triggerPrice = oldTrig;
-                    triggerKind = 'trailing';
-                    return;
-                }
-                updatePeak();
-                const newTrig = triggerFromPeak();
-                const seg3 = isLong ? closePrice < newTrig : closePrice > newTrig;
-                if (seg3) {
-                    triggered = true;
-                    triggerPrice = newTrig;
-                    triggerKind = 'trailing';
+                    emitTrail(oldTrig);
+                } else {
+                    updatePeak();
+                    const newTrig = triggerFromPeak();
+                    const seg3 = isLong ? closePrice < newTrig : closePrice > newTrig;
+                    if (seg3) emitTrail(newTrig);
                 }
             }
-        };
-        const checkTp = () => {
-            if (triggered || tpPrice === undefined) return;
-            const tpHit = isLong ? highPrice >= tpPrice : lowPrice <= tpPrice;
-            if (tpHit) {
-                triggered = true;
-                // Favorable-side gap: long TP with open above limit, or short TP with open below limit.
-                const openPastTp = isLong ? openPrice >= tpPrice : openPrice <= tpPrice;
-                triggerPrice = openPastTp ? openPrice : tpPrice;
-                triggerKind = 'profit';
-            }
-        };
-
-        if (favorableFirst) {
-            // First extreme is the favorable one → TP fires before SL/trail.
-            checkTp();
-            checkSl();
-            checkTrail();
-        } else {
-            // First extreme is the adverse one → SL/trail fire before TP.
-            checkSl();
-            checkTrail();
-            checkTp();
         }
 
-        if (triggered) {
-            // Apply slippage to the trigger price (closing side direction).
-            const fillPrice = applySlippage(context, -matchingDir, triggerPrice);
+        // Path-ordered event list (mirrors the old checkTp/checkSl/
+        // checkTrail priority: TP leg first on favorable-first bars;
+        // SL then trail then TP on adverse-first bars).
+        const events: FillEvent[] = favorableFirst
+            ? [...tpEvents, ...slEvents, ...(trailEvent ? [trailEvent] : [])]
+            : [...slEvents, ...(trailEvent ? [trailEvent] : []), ...tpEvents];
 
-            let qtyToClose = matchingQty;
-            if (order.qty && order.qty > 0) qtyToClose = Math.min(order.qty, matchingQty);
+        if (events.length > 0) {
+            // qty / qty_percent caps apply to the TOTAL closed by this order.
+            let capRemaining = matchingQty;
+            if (order.qty && order.qty > 0) capRemaining = Math.min(order.qty, matchingQty);
             else if (order.qty_percent && order.qty_percent > 0) {
-                qtyToClose = matchingQty * (order.qty_percent / 100);
+                capRemaining = matchingQty * (order.qty_percent / 100);
             }
 
-            // Resolve which per-leg comment to stamp on the closed trade.
-            // strategy.exit() exposes comment_profit / comment_loss /
-            // comment_trailing — each fires only when its leg triggers.
-            // Fall back to the order's generic `comment` if the per-leg
-            // string isn't set.
-            const legComment =
-                triggerKind === 'profit'   ? (order.comment_profit   ?? order.comment) :
-                triggerKind === 'loss'     ? (order.comment_loss     ?? order.comment) :
-                triggerKind === 'trailing' ? (order.comment_trailing ?? order.comment) :
-                                              order.comment;
+            const remainingMatchingQty = () => strategy.opentrades
+                .filter((t) => !order.from_entry || t.entry_id === order.from_entry)
+                .reduce((sum, t) => sum + Math.abs(t.size), 0);
 
-            closeMatching(context, order.from_entry, qtyToClose, fillPrice, currentTime, {
-                triggerKind,
-                exitId:      order.id,
-                exitComment: legComment,
-            });
-            order.status = 'filled';
-            order.fill_price = fillPrice;
-            order.fill_bar = context.idx;
-            order.fill_time = currentTime;
+            let lastFill = NaN;
+            let closedAny = false;
+            for (const ev of events) {
+                if (capRemaining <= 1e-9) break;
+                const remaining = remainingMatchingQty();
+                if (remaining <= 1e-9) break;
+                const qtyThis = Math.min(ev.qty === Infinity ? remaining : ev.qty, capRemaining, remaining);
+                // Apply slippage to the trigger price (closing side direction).
+                const fillPrice = applySlippage(context, -matchingDir, ev.price);
+
+                // Resolve which per-leg comment to stamp on the closed
+                // trade. strategy.exit() exposes comment_profit /
+                // comment_loss / comment_trailing — each fires only when
+                // its leg triggers. Fall back to the generic `comment`.
+                const legComment =
+                    ev.kind === 'profit' ? (order.comment_profit ?? order.comment) :
+                    ev.kind === 'loss'   ? (order.comment_loss   ?? order.comment) :
+                                           (order.comment_trailing ?? order.comment);
+
+                // Bracket fills close their SOURCE lot (per-lot binding);
+                // the trail event has no source lot and closes FIFO.
+                closeMatching(context, order.from_entry, qtyThis, fillPrice, currentTime, {
+                    triggerKind: ev.kind,
+                    exitId:      order.id,
+                    exitComment: legComment,
+                }, ev.tradeId);
+                capRemaining -= qtyThis;
+                lastFill = fillPrice;
+                closedAny = true;
+            }
+
+            // The order is consumed when nothing matching remains open or
+            // its qty cap is exhausted; otherwise it stays pending so the
+            // surviving trades' brackets remain active on later bars (TV
+            // brackets persist until filled or replaced).
+            if (closedAny && (remainingMatchingQty() <= 1e-9 || capRemaining <= 1e-9)) {
+                order.status = 'filled';
+                order.fill_price = lastFill;
+                order.fill_bar = context.idx;
+                order.fill_time = currentTime;
+            }
         }
     }
 
@@ -1536,16 +1695,89 @@ export function processExitOrders(context: any): void {
 }
 
 /**
- * Margin-call check (TV broker emulator). After all entries and user-defined
- * exits have processed for the bar, check whether the bar's INTRA-BAR
- * adverse movement (low for longs, high for shorts) would have pushed
- * account equity below required maintenance margin. If yes, FORCE LIQUIDATE
- * all open positions at the bar's adverse extreme with exit_id="Margin call".
+ * Apply a SECOND margin call scheduled by the phantom re-check (see
+ * processMarginCall). TV books that fill at the PREVIOUS bar's close,
+ * AFTER the script's on-close evaluation — so the script and any order
+ * it queued saw the pre-MC#2 position. PineTS mirrors this by booking
+ * the fill at the very start of the NEXT bar, before entries process:
+ * a reversal queued at the MC bar's close (qty frozen at queue time)
+ * then naturally overshoots by exactly q2, reproducing TV's phantom
+ * opposite-side position (xlsx-confirmed: 2021-10-02 reversal long
+ * 5.263108 = 5 + 0.263108).
  *
- * The exit price is the bar's adverse extreme itself, NOT the theoretical
- * threshold where equity would exactly equal required margin. This is the
- * pessimistic broker model — the trader is assumed to be liquidated at
- * the worst intra-bar price, since intra-bar tick order is unknown.
+ * Same-direction (non-reversal) entries queued on the MC bar are
+ * CANCELED — TV's transient post-MC state rejects them (2022-04-19: the
+ * add queued at the 04-18 close never filled; the next add was accepted
+ * a bar later). Opposite-direction reversals are unaffected (E1), and a
+ * close-MC that flattens the position leaves nothing to gate (IC=900k
+ * experiment: next-open entry from flat was admitted).
+ */
+export function applyPendingCloseMarginCall(context: any): void {
+    const strategy: StrategyState = context.strategy;
+    if (!strategy) return;
+    const pending = (strategy as any)._pending_close_mc;
+    if (!pending) return;
+    (strategy as any)._pending_close_mc = null;
+
+    if (strategy.opentrades.length === 0 || Math.sign(strategy.position_size) !== pending.dir) return;
+
+    closePartialPosition(context, Math.min(pending.qty, Math.abs(strategy.position_size)), pending.price, pending.time, {
+        exitId:      'Margin call',
+        exitComment: 'Margin call',
+    });
+
+    if (Math.abs(strategy.position_size) > 1e-9) {
+        for (const o of strategy.pending_orders) {
+            if (o.status === 'pending' && (o.category ?? 'entry') === 'entry' &&
+                !o._isReversalEntry && parseDirection(o.direction) === pending.dir) {
+                o.status = 'cancelled';
+            }
+        }
+        strategy.pending_orders = strategy.pending_orders.filter((o) => o.status === 'pending');
+    }
+}
+
+/**
+ * True when the bar's first intra-bar move is ADVERSE for the current
+ * position (TV broker-emulator path assumption: open closer to high →
+ * open→high→low→close; open closer to low → open→low→high→close).
+ * Used to path-order the margin-call checkpoint against exit fills.
+ */
+export function isAdverseFirstBar(context: any): boolean {
+    const strategy: StrategyState = context.strategy;
+    const dir = Math.sign(strategy?.position_size ?? 0);
+    if (dir === 0) return false;
+    const openPrice = Series.from(context.data.open).get(0);
+    const highPrice = Series.from(context.data.high).get(0);
+    const lowPrice  = Series.from(context.data.low).get(0);
+    const openCloserToHigh = Math.abs(highPrice - openPrice) <= Math.abs(openPrice - lowPrice);
+    return dir === 1 ? !openCloserToHigh : openCloserToHigh;
+}
+
+/**
+ * Margin-call check (TV broker emulator) at one of two intra-bar
+ * CHECKPOINTS along the assumed price path:
+ *
+ *   'open'    — right after entries fill at the bar's open: equity and
+ *               required margin evaluated AT THE OPEN, liquidation fills
+ *               at the open price.
+ *   'extreme' — at the bar's adverse extreme (low for longs, high for
+ *               shorts), liquidation fills at the extreme itself — the
+ *               pessimistic broker model (intra-bar tick order unknown).
+ *   'close'   — at the bar's close, after all exits: if the (possibly
+ *               already-trimmed) position still breaches at the closing
+ *               price, another partial liquidation fills at the close.
+ *               Evidence: 2021-10-01 (profit QA) shows TWO same-bar MC
+ *               prices — 4×cover at the high, then a further 0.263108
+ *               at 48,147.38 (the close).
+ *
+ * TV checks margin along the path, interleaved with exit fills — proven
+ * by the MC-ordering probe (BTCUSDT 1D, 2026-02-05): a 5-lot short
+ * entered at the open was split within one bar into MC 0.00228 at the
+ * OPEN price, MC 0.0888 at the high, then a TP fill of 4.90892 at the
+ * lows. The caller orders the 'extreme' checkpoint BEFORE exit
+ * processing on adverse-first bars and AFTER it on favorable-first bars
+ * (favorable exits free margin before the adverse extreme is reached).
  *
  * Runs for ALL margin percentages including 100%. At 100% margin the
  * trader still needs full notional collateral; adverse price movement
@@ -1554,7 +1786,7 @@ export function processExitOrders(context: any): void {
  * (the "Margin calls" stat in the Strategy Tester is non-zero on 100%
  * margin runs whenever a position's mark-to-market loss exceeds equity).
  */
-export function processMarginCall(context: any): void {
+export function processMarginCall(context: any, checkpoint: 'open' | 'extreme' | 'close' = 'extreme'): void {
     const strategy: StrategyState = context.strategy;
     if (!strategy || strategy.opentrades.length === 0) return;
 
@@ -1565,12 +1797,17 @@ export function processMarginCall(context: any): void {
         ? (strategy.config.margin_long  ?? 100)
         : (strategy.config.margin_short ?? 100);
 
+    const openPrice   = Series.from(context.data.open).get(0);
     const highPrice   = Series.from(context.data.high).get(0);
     const lowPrice    = Series.from(context.data.low).get(0);
+    const closePrice  = Series.from(context.data.close).get(0);
     const currentTime = Series.from(context.data.openTime).get(0);
     const pointValue  = context.pine?.syminfo?.pointvalue ?? 1;
 
-    const adversePrice = positionDir === 1 ? lowPrice : highPrice;
+    const adversePrice =
+        checkpoint === 'open'  ? openPrice :
+        checkpoint === 'close' ? closePrice :
+        (positionDir === 1 ? lowPrice : highPrice);
     const totalQty = Math.abs(strategy.position_size);
     const equityAtAdverse = computeEquityAtPrice(context, adversePrice);
     const requiredMarginAtAdverse = computeRequiredMargin(totalQty, adversePrice, marginPct, pointValue);
@@ -1588,16 +1825,95 @@ export function processMarginCall(context: any): void {
         // at price 110,797.38 → 4 × 0.30328) and 0.48244 of another
         // (deficit $10,924.98 at 90,574.00 → 4 × 0.12061).
         const deficit = requiredMarginAtAdverse - equityAtAdverse;
-        // TV floors the cover quantity to 5 decimal places BEFORE the 4×
-        // multiplier — both xlsx liquidation quantities reproduce exactly
-        // under this rule (4 × 0.30328 = 1.21312, 4 × 0.12061 = 0.48244)
-        // and under no other truncation placement.
-        const coverQty = Math.floor((deficit / (adversePrice * pointValue)) * 1e5) / 1e5;
+        // Full-precision cover — no truncation. Verified against the
+        // commission-0 margin oracle (BTCUSDC weekly) where TV's
+        // liquidation qty matches PT's untruncated 4× cover exactly, and
+        // against the BTCUSDC avg_price QA xlsx (TV qty 3.602232 ≈ 7
+        // significant digits). An earlier 5-decimal floor was overfit to
+        // the BTCUSDT margin_calls xlsx where TV's exported quantities
+        // (1.21312, 0.48244) are 7-significant-digit values with trailing
+        // zeros trimmed; the residual there (~$1 equity-basis opacity
+        // inside TV) is sub-dollar on a $530k net and accepted.
+        //
+        // The marginPct/100 divisor matters below 100%: TV liquidates
+        // 4×deficit/(price·m) — verified exactly on fresh TV captures at
+        // margin_long/short = 50 (close-MC investigation, 2026-06-12).
+        const marginFrac = marginPct / 100;
+        const coverQty = deficit / (adversePrice * pointValue * marginFrac);
         const qtyToLiquidate = Math.min(totalQty, 4 * coverQty);
+
+        // Remember the FIFO order before the close so we can identify the
+        // PARTIALLY-consumed lot afterwards (the liquidation eats whole
+        // lots from the front; the first lot still open afterwards is the
+        // one it bit into).
+        const fifoBefore = [...strategy.opentrades];
+        const frontPiece = fifoBefore[0];
+        const frontQty   = Math.abs(frontPiece.size);
+        const frontEntry = frontPiece.entry_price;
+
         closePartialPosition(context, qtyToLiquidate, adversePrice, currentTime, {
             exitId:      'Margin call',
             exitComment: 'Margin call',
         });
+
+        // ---- Phantom re-check → SECOND margin call at the bar's CLOSE ----
+        // TV broker-emulator behavior (reverse-engineered 2026-06-12,
+        // exact on 6 TV-captured events incl. margin=50% and full-cap
+        // variants; 122+ negative controls): when the margin call closed
+        // the FIRST (oldest) FIFO piece ENTIRELY, TV re-evaluates the
+        // margin condition in a transient state where that piece's margin
+        // is freed and its unrealized PnL removed from equity, but its
+        // realized PnL has NOT yet been booked. The residual deficit is
+        //   D2 = D1 − p1·(p·m·pv) + u1,   u1 = p1·(p − e1)·dir·pv
+        // (p1/e1 = first piece qty/entry, p = the adverse checkpoint
+        // price, dir = +1 long / −1 short). If D2 > 0, a second margin
+        // call q2 = min(remaining, 4·trunc6(D2/(p·m·pv))) fires — FILLED
+        // AT THE BAR'S CLOSE and booked AFTER the script's on-close
+        // evaluation, so the script (and any order it queues this bar)
+        // still sees the pre-MC#2 position. A reversal queued at that
+        // close therefore overshoots by exactly q2 on the next bar (TV
+        // xlsx 2021-10-02: reversal long 5.263108 = 5 + q2). Application
+        // is deferred to the start of the next bar via
+        // `_pending_close_mc` (see applyPendingCloseMarginCall).
+        //
+        // Single-piece margin calls can never fire this (D2 < 0
+        // algebraically) — only calls that consume the whole front piece
+        // and span into deeper lots qualify, and even then rarely.
+        if (checkpoint === 'extreme' &&
+            qtyToLiquidate >= frontQty - 1e-9 &&
+            Math.abs(strategy.position_size) > 1e-9) {
+            const freedMargin = computeRequiredMargin(frontQty, adversePrice, marginPct, pointValue);
+            const u1 = frontQty * (adversePrice - frontEntry) * positionDir * pointValue;
+            const d2 = deficit - freedMargin + u1;
+            if (d2 > 0) {
+                const closeP = Series.from(context.data.close).get(0);
+                const trunc6 = (x: number) => Math.trunc(x * 1e6) / 1e6;
+                const cover2 = trunc6(d2 / (adversePrice * pointValue * marginFrac));
+                const q2 = Math.min(Math.abs(strategy.position_size), 4 * cover2);
+                if (q2 > 1e-9) {
+                    (strategy as any)._pending_close_mc = {
+                        qty: q2,
+                        price: closeP,
+                        time: currentTime,
+                        dir: positionDir,
+                    };
+                }
+            }
+        }
+
+        // TV broker-emulator rule (QA evidence): a margin call CANCELS all
+        // working exit brackets for the rest of the bar EXCEPT the bracket
+        // of the lot it partially consumed. The canceled lots get fresh
+        // brackets from the next strategy.exit call (next bar).
+        // Evidence: 2024-08-03 (avg_price QA) — after MC 0.59552 at the
+        // high, the shared TP at 59,954 filled ONLY the touched lot's
+        // remainder 4.40448; the other covered lot exited next day at the
+        // refreshed level. Same split on 2021-05-16 (profit QA: only the
+        // MC-touched lot's TP filled same-bar, untouched lots filled next
+        // day at their own levels) and on the MC-probe triple bar
+        // 2026-02-05 (the only lot was the touched one → its TP filled).
+        const survivor = fifoBefore.find((t) => t.status === 'open');
+        (strategy as any)._mc_exit_lock = { bar: context.idx, tradeId: survivor?.id ?? null };
     }
 }
 

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -1452,6 +1452,25 @@ export function transformCallExpression(node: any, scopeManager: ScopeManager, n
             });
         }
 
+        // Inject a trailing `{ __varId }` sentinel on input.* calls that
+        // initialize a variable (tagged by transformVariableDeclaration). The
+        // runtime (parseInputOptions) pops it so `.input[varId]` overrides can
+        // target this exact input — the primary override key, robust to empty
+        // or duplicated titles. Added AFTER arg-wrapping so it stays a literal.
+        if (namespace === 'input' && node._varId !== undefined) {
+            node.arguments.push({
+                type: 'ObjectExpression',
+                properties: [{
+                    type: 'Property',
+                    key: { type: 'Identifier', name: '__varId' },
+                    value: { type: 'Literal', value: node._varId },
+                    kind: 'init',
+                    computed: false,
+                    shorthand: false,
+                }],
+            });
+        }
+
         // Inject unique callsite ID for alert calls (per-callsite frequency gating)
         if (namespace === 'alert') {
             const callsiteId = scopeManager.getNextAlertCallId();

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -250,6 +250,19 @@ export function transformVariableDeclaration(varNode: any, scopeManager: ScopeMa
     if (varNode._skipTransformation) return;
 
     varNode.declarations.forEach((decl: any) => {
+        // Tag `name = input.*(…)` / `name = input(…)` with the assigned
+        // variable name, BEFORE any rename, so transformCallExpression can
+        // inject it as a `{ __varId }` sentinel on the input call. This is the
+        // runtime handle that lets `.input[varId]` overrides target a specific
+        // input even when titles are empty or duplicated.
+        if (decl.init?.type === 'CallExpression' && decl.id?.type === 'Identifier') {
+            const c = decl.init.callee;
+            const isInputCall =
+                (c?.type === 'MemberExpression' && c.object?.type === 'Identifier' && c.object.name === 'input') ||
+                (c?.type === 'Identifier' && c.name === 'input');
+            if (isInputCall) decl.init._varId = decl.id.name;
+        }
+
         // Rewrite NAMESPACES_LIKE entries (na, time, etc.) to .__value in variable initializers
         if (decl.init && decl.init.type === 'Identifier' && NAMESPACES_LIKE.includes(decl.init.name) && scopeManager.isContextBound(decl.init.name)) {
             const originalName = decl.init.name;

--- a/tests/Indicator/Indicator.test.ts
+++ b/tests/Indicator/Indicator.test.ts
@@ -50,7 +50,7 @@ plot(close)
             expect(view['Timeframe']).toBe('1D');
             expect(view['Session']).toBe('0930-1600');
             expect(view['Type']).toBe('EMA');
-            expect(view['Color']).toBe('#ff0000');
+            expect(view['Color']).toBe('#FF0000FF'); // color defaults normalize to #RRGGBBAA
             expect(view['Message']).toBe('hi');
         });
 
@@ -118,9 +118,9 @@ plot(close)
             expect(() => { (ind as any).input = { Length: 5 }; }).toThrow(/cannot be replaced/i);
         });
 
-        it('rejects unknown titles', () => {
+        it('rejects unknown keys', () => {
             const ind = new Indicator(code);
-            expect(() => { (ind.input as any)['Nope'] = 1; }).toThrow(/unknown input title/i);
+            expect(() => { (ind.input as any)['Nope'] = 1; }).toThrow(/unknown input key/i);
         });
 
         it('rejects deletion', () => {
@@ -160,29 +160,42 @@ if not barstate.islast
     log.info('{0}', len)
 `;
             const ind = new Indicator(code);
+            // Write via the title alias; it canonicalizes to the varId.
             (ind.input as any)['Length'] = 33;
 
             const pine = new PineTS(makeData(5));
             await pine.run(ind);
 
+            // Overrides are forwarded under the canonical varId ('len').
             const inputs = ind.getRuntimeInputs();
-            expect(inputs['Length']).toBe(33);
+            expect(inputs['len']).toBe(33);
+            // Reading back through either key reflects the override.
+            expect((ind.input as any)['len']).toBe(33);
+            expect((ind.input as any)['Length']).toBe(33);
         });
 
-        it('explicit .input override takes priority over legacy constructor inputs', () => {
+        it('explicit .input override takes priority over legacy constructor inputs', async () => {
             const code = `
 //@version=6
 indicator("Demo")
 len = input.int(14, "Length")
-plot(close)
+plot(len, "out")
 `;
+            // Legacy constructor map is TITLE-keyed; resolveInput falls back to it.
             const ind = new Indicator(code, { 'Length': 7 });
-            // Before any .input write, legacy wins.
             expect(ind.getRuntimeInputs()['Length']).toBe(7);
 
-            // After explicit write, .input wins.
+            // Explicit .input write is VARID-keyed and resolveInput checks varId
+            // BEFORE title, so it wins at runtime even though the legacy title
+            // entry is still present in the map.
             (ind.input as any)['Length'] = 20;
-            expect(ind.getRuntimeInputs()['Length']).toBe(20);
+            const rt = ind.getRuntimeInputs();
+            expect(rt['len']).toBe(20);       // canonical override
+            expect(rt['Length']).toBe(7);     // legacy entry untouched
+
+            const ctx = await new PineTS(makeData(5)).run(ind);
+            const out = ctx.plots['out'].data;
+            expect(out[out.length - 1].value).toBe(20); // varId override wins at runtime
         });
     });
 
@@ -231,8 +244,8 @@ plot(close)
         });
     });
 
-    describe('duplicate-title collision', () => {
-        it('warns and keeps the first declaration', () => {
+    describe('duplicate titles', () => {
+        it('keeps both (distinguished by varId), no warning', () => {
             const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
             try {
                 const code = `
@@ -242,10 +255,17 @@ a = input.int(14, "Length")
 b = input.int(20, "Length")
 plot(close)
 `;
-                const meta = new Indicator(code).getInputsMeta();
-                expect(meta).toHaveLength(1);
-                expect(meta[0].defval).toBe(14);
-                expect(warn).toHaveBeenCalled();
+                const ind = new Indicator(code);
+                const meta = ind.getInputsMeta();
+                // Both surface now — distinct varIds, shared title.
+                expect(meta).toHaveLength(2);
+                expect(meta.map((m) => m.varId)).toEqual(['a', 'b']);
+                expect(meta.map((m) => m.defval)).toEqual([14, 20]);
+                expect(meta.every((m) => m.title === 'Length')).toBe(true);
+                // No duplicate-varId collision → no warning.
+                expect(warn).not.toHaveBeenCalled();
+                // Each is addressable by its varId; title aliases the first.
+                expect(Object.keys(ind.input)).toEqual(['a', 'b']);
             } finally {
                 warn.mockRestore();
             }

--- a/tests/core/indicator_inputs.test.ts
+++ b/tests/core/indicator_inputs.test.ts
@@ -80,3 +80,198 @@ describe('PineTS Indicator Inputs', () => {
         }
     });
 });
+
+describe('Input varId resolution (.input keyed by variable name)', () => {
+    const ind = (code: string) => new Indicator(code);
+
+    it('exposes varId on every scanned input', () => {
+        const metas = ind(`//@version=6
+indicator("T")
+length = input.int(14, "Length")
+src    = input.source(close, "Source")
+plot(close)`).getInputsMeta();
+        expect(metas.map((m) => m.varId)).toEqual(['length', 'src']);
+    });
+
+    it('keys .input by varId (primary) and forwards overrides under the varId', () => {
+        const i = ind(`//@version=6
+indicator("T")
+length = input.int(14, "Length")
+plot(close)`);
+        i.input['length'] = 99;
+        expect(i.input['length']).toBe(99);
+        expect(i.getRuntimeInputs()['length']).toBe(99); // canonical varId key
+    });
+
+    it('still resolves by title as a fallback alias (back-compat)', () => {
+        const i = ind(`//@version=6
+indicator("T")
+length = input.int(14, "Length")
+plot(close)`);
+        i.input['Length'] = 77;             // title alias
+        expect(i.input['Length']).toBe(77);
+        expect(i.input['length']).toBe(77); // same slot as the varId
+        expect(i.getRuntimeInputs()['length']).toBe(77); // stored under the canonical varId
+    });
+
+    it('Object.keys lists varIds; title alias is accessible but not enumerated', () => {
+        const i = ind(`//@version=6
+indicator("T")
+length = input.int(14, "Length")
+plot(close)`);
+        expect(Object.keys(i.input)).toEqual(['length']);
+        expect('Length' in i.input).toBe(true);  // alias resolves
+        expect('length' in i.input).toBe(true);
+    });
+
+    it('isolates duplicate titles by varId', () => {
+        const i = ind(`//@version=6
+indicator("T")
+a = input.int(10, "Length")
+b = input.int(20, "Length")
+plot(close)`);
+        i.input['b'] = 555;
+        const rt = i.getRuntimeInputs();
+        expect(rt['b']).toBe(555);
+        expect(rt['a']).toBeUndefined();    // 'a' untouched
+        // title aliases the FIRST input only
+        i.input['Length'] = 1;
+        expect(i.input['a']).toBe(1);
+    });
+
+    it('makes empty/untitled inputs overridable by varId', () => {
+        const i = ind(`//@version=6
+indicator("T")
+x = input.int(5, "")
+y = input.int(6)
+plot(close)`);
+        i.input['x'] = 42;
+        i.input['y'] = 43;
+        const rt = i.getRuntimeInputs();
+        expect(rt['x']).toBe(42);
+        expect(rt['y']).toBe(43);
+        expect(Object.keys(i.input)).toEqual(['x', 'y']);
+    });
+
+    it('rejects an unknown key (neither varId nor title)', () => {
+        const i = ind(`//@version=6
+indicator("T")
+length = input.int(14, "Length")
+plot(close)`);
+        expect(() => { (i.input as any)['nope'] = 1; }).toThrow(/unknown input key/i);
+    });
+});
+
+import { normalizeColorToRgbaHex } from '../../src/namespaces/color/PineColor';
+
+describe('Color input defval normalization (getInputsMeta)', () => {
+    const metaFor = (code: string, title: string) =>
+        new Indicator(code).getInputsMeta().find((m) => m.title === title);
+
+    it('normalizes a #RRGGBB hex literal to #RRGGBBAA (opaque alpha)', () => {
+        const m = metaFor(`//@version=6
+indicator("C")
+c = input.color(#ff0000, "Line")
+plot(close)`, 'Line');
+        expect(m?.type).toBe('color');
+        expect(m?.defval).toBe('#FF0000FF');
+    });
+
+    it('resolves a named color constant to its RGBA hex', () => {
+        const m = metaFor(`//@version=6
+indicator("C")
+c = input.color(color.red, "Line")
+plot(close)`, 'Line');
+        expect(m?.defval).toBe('#F23645FF'); // color.red = #F23645
+    });
+
+    it('preserves an explicit alpha byte and uppercases the result', () => {
+        const m = metaFor(`//@version=6
+indicator("C")
+c = input.color(#00bcd480, "Line")
+plot(close)`, 'Line');
+        expect(m?.defval).toBe('#00BCD480');
+    });
+
+    it('normalizes the bare input() auto-detected color form', () => {
+        const m = metaFor(`//@version=6
+indicator("C")
+c = input(#336699, "Line")
+plot(close)`, 'Line');
+        expect(m?.type).toBe('color');
+        expect(m?.defval).toBe('#336699FF');
+    });
+
+    it('keeps .input reads consistent with the normalized meta', () => {
+        const ind = new Indicator(`//@version=6
+indicator("C")
+c = input.color(color.blue, "Line")
+plot(close)`);
+        ind.getInputsMeta(); // trigger scan
+        expect(ind.input['Line']).toBe('#2196F3FF'); // color.blue = #2196F3
+    });
+
+    it('statically evaluates color.new(col, transp) defaults', () => {
+        // transp 50 → alpha 0.5 → 0x80
+        const m = metaFor(`//@version=6
+indicator("C")
+c = input.color(color.new(#26a69a, 50), "Line")
+plot(close)`, 'Line');
+        expect(m?.defval).toBe('#26A69A80');
+    });
+
+    it('evaluates color.new with a named-constant base', () => {
+        const m = metaFor(`//@version=6
+indicator("C")
+c = input.color(color.new(color.teal, 0), "Line")
+plot(close)`, 'Line');
+        expect(m?.defval).toBe('#089981FF'); // color.teal = #089981, transp 0 = opaque
+    });
+
+    it('statically evaluates color.rgb(r,g,b) and color.rgb(r,g,b,transp)', () => {
+        const opaque = metaFor(`//@version=6
+indicator("C")
+c = input.color(color.rgb(6, 162, 47), "Line")
+plot(close)`, 'Line');
+        expect(opaque?.defval).toBe('#06A22FFF');
+
+        const withTransp = metaFor(`//@version=6
+indicator("C")
+c = input.color(color.rgb(207, 23, 23, 50), "Line")
+plot(close)`, 'Line');
+        expect(withTransp?.defval).toBe('#CF171780');
+    });
+
+    it('leaves non-color input defaults untouched', () => {
+        const ind = new Indicator(`//@version=6
+indicator("C")
+len = input.int(14, "Length")
+src = input.string("EMA", "Type")
+plot(close)`);
+        const metas = ind.getInputsMeta();
+        expect(metas.find((m) => m.title === 'Length')?.defval).toBe(14);
+        expect(metas.find((m) => m.title === 'Type')?.defval).toBe('EMA');
+    });
+});
+
+describe('normalizeColorToRgbaHex (unit)', () => {
+    it('expands 6-digit hex to opaque RGBA', () => {
+        expect(normalizeColorToRgbaHex('#ff0000')).toBe('#FF0000FF');
+    });
+    it('passes 8-digit hex through (uppercased)', () => {
+        expect(normalizeColorToRgbaHex('#aabbccdd')).toBe('#AABBCCDD');
+    });
+    it('resolves named constants with and without the namespace', () => {
+        expect(normalizeColorToRgbaHex('color.green')).toBe('#4CAF50FF');
+        expect(normalizeColorToRgbaHex('teal')).toBe('#089981FF');
+    });
+    it('converts rgb()/rgba() to RGBA hex (a in 0..1 → alpha byte)', () => {
+        expect(normalizeColorToRgbaHex('rgb(255, 0, 0)')).toBe('#FF0000FF');
+        expect(normalizeColorToRgbaHex('rgba(255, 0, 0, 0.5)')).toBe('#FF000080');
+    });
+    it('returns non-color / unparseable values unchanged', () => {
+        expect(normalizeColorToRgbaHex('not a color')).toBe('not a color');
+        expect(normalizeColorToRgbaHex(42)).toBe(42);
+        expect(normalizeColorToRgbaHex(undefined)).toBe(undefined);
+    });
+});

--- a/tests/core/indicator_inputs.test.ts
+++ b/tests/core/indicator_inputs.test.ts
@@ -81,6 +81,66 @@ describe('PineTS Indicator Inputs', () => {
     });
 });
 
+describe('Const/variable resolution in input arguments', () => {
+    const metaFor = (code: string, title: string) =>
+        new Indicator(code).getInputsMeta().find((m) => m.title === title);
+
+    it('resolves const references in defval and string args', () => {
+        const code = `//@version=6
+indicator("C")
+const string GRP = "Indicator Settings"
+const string INL = "Moving Average"
+const string TT  = "Lookback period."
+const int    DEF = 14
+len = input.int(DEF, "Length", group = GRP, inline = INL, tooltip = TT)
+plot(close)`;
+        const m = metaFor(code, 'Length');
+        expect(m?.defval).toBe(14);
+        expect(m?.group).toBe('Indicator Settings');
+        expect(m?.inline).toBe('Moving Average');
+        expect(m?.tooltip).toBe('Lookback period.');
+    });
+
+    it('resolves a non-const (simple) literal assignment too', () => {
+        const code = `//@version=6
+indicator("C")
+MY_STRING = "STRING"
+s = input.string(MY_STRING, "Str")
+plot(close)`;
+        expect(metaFor(code, 'Str')?.defval).toBe('STRING');
+    });
+
+    it('resolves chained const references', () => {
+        const code = `//@version=6
+indicator("C")
+const int BASE = 5
+const int LEN  = BASE
+n = input.int(LEN, "N")
+plot(close)`;
+        expect(metaFor(code, 'N')?.defval).toBe(5);
+    });
+
+    it('resolves a const color (incl. color.new) to #RRGGBBAA', () => {
+        const code = `//@version=6
+indicator("C")
+const color LINE = color.new(#26a69a, 50)
+c = input.color(LINE, "Line")
+plot(close)`;
+        expect(metaFor(code, 'Line')?.defval).toBe('#26A69A80');
+    });
+
+    it('falls back to the bare name for unresolvable (computed) references', () => {
+        const code = `//@version=6
+indicator("C")
+ma = ta.sma(close, 5)
+n = input.int(20, "N", tooltip = ma)
+plot(close)`;
+        // ma is a computed series, not a literal const → tooltip stays the name.
+        expect(metaFor(code, 'N')?.tooltip).toBe('ma');
+        expect(metaFor(code, 'N')?.defval).toBe(20);
+    });
+});
+
 describe('Input varId resolution (.input keyed by variable name)', () => {
     const ind = (code: string) => new Indicator(code);
 

--- a/tests/namespaces/strategy/close-snapshot.test.ts
+++ b/tests/namespaces/strategy/close-snapshot.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { Context } from '../../../src/Context.class';
+import { processExitOrders, initializeStrategy } from '../../../src/namespaces/strategy/utils';
+import { close_all } from '../../../src/namespaces/strategy/methods/close_all';
+import { Series } from '../../../src/Series';
+
+/**
+ * Regression for strategy.close_all() snapshot binding.
+ *
+ * TV binds close_all/close(id) to the position at CALL time. Two variants:
+ *  1. Queue-when-flat → no-op (guard in close_all.ts, covered by the
+ *     close_all_flat_book.pine oracle).
+ *  2. Queue-with-position + a reversal entry queued the same bar: the
+ *     reversal fills first on the next bar's open, implicitly closing the
+ *     snapshotted trades. The close_all must then be CANCELLED instead of
+ *     catching the freshly-opened reversal trade at its entry price for
+ *     $0 PnL. Implemented via `_intended_trade_ids` captured at queue time
+ *     and re-checked in processExitOrders.
+ *
+ * Ground truth: QA close_all xlsx (BTCUSDT 1D) — trade #13's $5,512.65
+ * divergence came from exactly this pattern; with the snapshot fix every
+ * metric matches TV to the cent.
+ */
+
+function makeContext() {
+    const context: any = new Context({
+        marketData: [],
+        source: [],
+        tickerId: 'BTCUSDC',
+        timeframe: 'D',
+    } as any);
+    context.pine = { syminfo: { mintick: 0.01, pointvalue: 1 } } as any;
+    initializeStrategy(context, {});
+    return context;
+}
+
+function setBar(context: any, idx: number, price: number) {
+    context.idx = idx;
+    context.data.open = new Series([price]);
+    context.data.high = new Series([price * 1.01]);
+    context.data.low = new Series([price * 0.99]);
+    context.data.close = new Series([price]);
+    context.data.openTime = new Series([idx * 1000]);
+}
+
+function makeTrade(id: string, entryId: string, size: number, entryPrice: number, barIdx: number) {
+    return {
+        id,
+        entry_id: entryId,
+        entry_comment: entryId,
+        entry_price: entryPrice,
+        entry_bar_index: barIdx,
+        entry_time: barIdx * 1000,
+        size,
+        commission: 0,
+        max_drawdown: 0,
+        max_runup: 0,
+        status: 'open',
+    };
+}
+
+describe('strategy.close_all — snapshot binding to call-time position', () => {
+    it('cancels when a reversal already closed the snapshotted trades (no $0 phantom close)', () => {
+        const context = makeContext();
+        const s = context.strategy;
+
+        // Bar 0: long open; close_all queued (snapshots trade_1).
+        setBar(context, 0, 50000);
+        s.opentrades = [makeTrade('trade_1', 'MacdLE', 5, 50000, 0)];
+        s.position_size = 5;
+        s.position_avg_price = 50000;
+        close_all(context)();
+
+        expect(s.pending_orders.length).toBe(1);
+        expect(s.pending_orders[0]._intended_trade_ids).toEqual(['trade_1']);
+
+        // Bar 1: simulate the reversal having filled at the open BEFORE the
+        // close_all is processed — trade_1 closed, trade_2 (short) opened.
+        s.closedtrades = [{ ...s.opentrades[0], status: 'closed', exit_price: 60000, exit_time: 1000, profit: 50000 }];
+        s.opentrades = [makeTrade('trade_2', 'MacdSE', -5, 60000, 1)];
+        s.position_size = -5;
+        s.position_avg_price = 60000;
+        setBar(context, 1, 60000);
+
+        processExitOrders(context);
+
+        // The close_all found none of its snapshotted trades → cancelled.
+        expect(s.pending_orders.length).toBe(0);
+        expect(s.opentrades.length).toBe(1);          // trade_2 untouched
+        expect(s.opentrades[0].id).toBe('trade_2');
+        expect(s.closedtrades.length).toBe(1);         // no extra $0 close
+        expect(s.position_size).toBe(-5);
+    });
+
+    it('fills normally when the snapshotted trades are still open', () => {
+        const context = makeContext();
+        const s = context.strategy;
+
+        setBar(context, 0, 50000);
+        s.opentrades = [makeTrade('trade_1', 'MacdLE', 5, 50000, 0)];
+        s.position_size = 5;
+        s.position_avg_price = 50000;
+        close_all(context)();
+
+        setBar(context, 1, 55000);
+        processExitOrders(context);
+
+        expect(s.closedtrades.length).toBe(1);
+        expect(s.closedtrades[0].exit_price).toBe(55000); // next bar's open
+        expect(s.opentrades.length).toBe(0);
+        expect(s.position_size).toBe(0);
+        expect(s.pending_orders.length).toBe(0);
+    });
+
+    it('is a no-op when called on a flat book', () => {
+        const context = makeContext();
+        const s = context.strategy;
+        setBar(context, 0, 50000);
+        // No open trades.
+        close_all(context)();
+        expect(s.pending_orders.length).toBe(0);
+    });
+});

--- a/tests/namespaces/strategy/equity-peak-basis.test.ts
+++ b/tests/namespaces/strategy/equity-peak-basis.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { Context } from '../../../src/Context.class';
+import { finalizeStrategyBar, initializeStrategy } from '../../../src/namespaces/strategy/utils';
+import { Series } from '../../../src/Series';
+
+/**
+ * Regression for the equity-peak basis used by max_drawdown.
+ *
+ * TV latches the equity high-water on the funds state right after a close
+ * settles — BEFORE the entry commission of a trade opened on the same bar
+ * (reversal) is charged. PineTS nets the reversal close+open atomically, so
+ * `updateEquityPeaks` adds the open trades' entry commissions back into the
+ * PEAK basis. The TROUGH basis keeps the commission deducted, and the
+ * drawdown formula has NO separate commission term.
+ *
+ * The two-latch scenario below is the minimal case that DISAMBIGUATES the
+ * correct model (peak excludes open entry comm) from the historical wrong
+ * one (+openCommission added to the drawdown at the trough side). With a
+ * single latch the two models coincide whenever the open commission at the
+ * peak equals the one at the trough — exactly the constant-commission
+ * degeneracy that hid this bug on cash_per_contract QA data. Here the two
+ * open trades carry DIFFERENT commissions (2,000 vs 500):
+ *
+ *   correct model:  dd = (1,100,000 − 1,049,500) + 20,000        = 70,500
+ *   wrong model:    dd = (1,098,000 − 1,049,500) + 20,000 + 500  = 69,000
+ *
+ * Ground truth: QA margin_calls xlsx (BTCUSDT 1D, 1% percent commission)
+ * where TV's peak was exactly the closed-trades cumulative (+148,279.33)
+ * while the reversal trade opened on the peak bar had already cost
+ * 2,483.81 in entry commission. Max drawdown matches TV to the cent only
+ * under the peak-basis model.
+ */
+
+function makeContext(config: any = {}) {
+    const context: any = new Context({
+        marketData: [],
+        source: [],
+        tickerId: 'BTCUSDC',
+        timeframe: 'D',
+    } as any);
+    context.pine = { syminfo: { mintick: 0.01, pointvalue: 1 } } as any;
+    initializeStrategy(context, config);
+    return context;
+}
+
+function setBar(context: any, idx: number, bar: { open: number; high: number; low: number; close: number }) {
+    context.idx = idx;
+    context.data.open = new Series([bar.open]);
+    context.data.high = new Series([bar.high]);
+    context.data.low = new Series([bar.low]);
+    context.data.close = new Series([bar.close]);
+    context.data.openTime = new Series([idx * 1000]);
+}
+
+function setOpenLong(context: any, entryPrice: number, commission: number) {
+    context.strategy.opentrades = [{
+        id: `trade_${context.idx}`,
+        entry_id: 'L',
+        entry_price: entryPrice,
+        entry_bar_index: context.idx,
+        entry_time: context.idx * 1000,
+        size: 1,
+        commission,
+        max_drawdown: 0,
+        max_runup: 0,
+        status: 'open',
+    }];
+    context.strategy.position_size = 1;
+    context.strategy.position_avg_price = entryPrice;
+}
+
+describe('equity peak basis — open entry commissions excluded from the peak', () => {
+    it('latches the peak on realized + openCommission, not on netprofit alone', () => {
+        const context = makeContext({ initial_capital: 1000000 });
+        const s = context.strategy;
+
+        // Bar 1: a prior trade closed +100,000; a reversal long opened the
+        // same bar with 2,000 entry commission (already deducted at fill).
+        s.netprofit = 98000;
+        setOpenLong(context, 100000, 2000);
+        setBar(context, 1, { open: 100000, high: 100000, low: 100000, close: 100000 });
+        finalizeStrategyBar(context);
+
+        // TV's peak: funds after the close settled, before the new entry's
+        // commission → 1,000,000 + 100,000 = 1,100,000.
+        expect(s.equity_peak).toBe(1100000);
+    });
+
+    it('two-latch scenario: drawdown measured from the commission-free peak (disambiguates the wrong model)', () => {
+        const context = makeContext({ initial_capital: 1000000 });
+        const s = context.strategy;
+
+        // Bar 1 — peak latch: closed +100,000 cumulative, open trade carries
+        // 2,000 entry commission. Flat bar, no excursion.
+        s.netprofit = 98000;
+        setOpenLong(context, 100000, 2000);
+        setBar(context, 1, { open: 100000, high: 100000, low: 100000, close: 100000 });
+        finalizeStrategyBar(context);
+        expect(s.equity_peak).toBe(1100000);
+
+        // Bar 2 — trough: that trade closed at a loss (cum +50,000), a NEW
+        // long opened with a DIFFERENT entry commission (500). The bar dips
+        // to 80,000 → 20,000 adverse excursion on the open trade.
+        s.netprofit = 49500;
+        setOpenLong(context, 100000, 500);
+        setBar(context, 2, { open: 100000, high: 100000, low: 80000, close: 90000 });
+        finalizeStrategyBar(context);
+
+        // dd = (peak 1,100,000 − realized 1,049,500) + excursion 20,000.
+        // The wrong (+openCommission-at-trough) model would yield 69,000.
+        expect(s.max_drawdown).toBe(70500);
+    });
+
+    it('run-up keeps the commission-deducted trough basis (matches TV exactly on all QA datasets)', () => {
+        const context = makeContext({ initial_capital: 1000000 });
+        const s = context.strategy;
+
+        // Bar 1 — trough latch: cumulative −50,000 with an open trade
+        // carrying 1,000 entry commission. Flat bar.
+        s.netprofit = -51000;
+        setOpenLong(context, 100000, 1000);
+        setBar(context, 1, { open: 100000, high: 100000, low: 100000, close: 100000 });
+        finalizeStrategyBar(context);
+        // Trough INCLUDES the open commission deduction.
+        expect(s.equity_trough).toBe(949000);
+
+        // Bar 2 — favorable excursion: netprofit recovers to +20,000 with a
+        // fresh open trade (commission 1,000), bar rallies to 120,000.
+        s.netprofit = 19000;
+        setOpenLong(context, 100000, 1000);
+        setBar(context, 2, { open: 100000, high: 120000, low: 100000, close: 115000 });
+        finalizeStrategyBar(context);
+
+        // runup = (realized 1,019,000 − trough 949,000) + excursion 20,000.
+        expect(s.max_runup).toBe(90000);
+    });
+});

--- a/tests/namespaces/strategy/margin-call.test.ts
+++ b/tests/namespaces/strategy/margin-call.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+import { Context } from '../../../src/Context.class';
+import { processMarginCall, processStrategyOrders, initializeStrategy } from '../../../src/namespaces/strategy/utils';
+import { Order } from '../../../src/namespaces/strategy/types';
+import { Series } from '../../../src/Series';
+
+/**
+ * Engine-level regression tests for the TV broker-emulator margin model.
+ *
+ * Ground truth: QA xlsx exports (BTCUSDT 1D 1% commission "margin_calls",
+ * BTCUSDC 1D 0.3% "position_avg_price") where PineTS matches TV to the cent.
+ *
+ * Two behaviors under test:
+ *  1. PARTIAL margin-call liquidation — TV liquidates 4× the contracts
+ *     needed to cover the deficit (floored), NOT the whole position.
+ *     The remainder stays open.
+ *  2. Reversal close-leg margin semantics — when a reversal entry's OPEN
+ *     leg fails the pre-trade margin check, the CLOSE leg still executes.
+ */
+
+function makeContext(bar: { open: number; high: number; low: number; close: number }, config: any = {}) {
+    const context: any = new Context({
+        marketData: [],
+        source: [],
+        tickerId: 'BTCUSDC',
+        timeframe: 'D',
+    } as any);
+    context.idx = 1;
+    context.data.open = new Series([bar.open, bar.open]);
+    context.data.high = new Series([bar.high, bar.high]);
+    context.data.low = new Series([bar.low, bar.low]);
+    context.data.close = new Series([bar.close, bar.close]);
+    context.data.openTime = new Series([0, 1000]);
+    context.pine = { syminfo: { mintick: 0.01, pointvalue: 1 } } as any;
+    initializeStrategy(context, config);
+    return context;
+}
+
+function openShort(context: any, qty: number, entryPrice: number) {
+    context.strategy.opentrades.push({
+        id: 'trade_0',
+        entry_id: 'MacdSE',
+        entry_comment: 'MacdSE',
+        entry_price: entryPrice,
+        entry_bar_index: 0,
+        entry_time: 0,
+        size: -qty,
+        commission: 0,
+        max_drawdown: 0,
+        max_runup: 0,
+        status: 'open',
+    });
+    context.strategy.position_size = -qty;
+    context.strategy.position_avg_price = entryPrice;
+    context.strategy.position_entry_name = 'MacdSE';
+}
+
+describe('processMarginCall — partial liquidation (TV 4× rule)', () => {
+    // Short 5 @ 100,000, capital 540,000, bar high 110,000 (adverse extreme).
+    //   equity@110k  = 540,000 + 5×(100,000−110,000) = 490,000
+    //   margin@110k  = 5 × 110,000 × 100%             = 550,000
+    //   deficit      = 60,000
+    //   cover        = 60,000 / 110,000 = 0.54545454… (full precision)
+    //   liquidate    = 4 × cover = 2.181818…  (remainder 2.818181… stays open)
+    it('liquidates 4× the cover qty at the adverse extreme, remainder stays open', () => {
+        const context = makeContext({ open: 101000, high: 110000, low: 99000, close: 105000 }, { initial_capital: 540000 });
+        openShort(context, 5, 100000);
+
+        processMarginCall(context);
+
+        const s = context.strategy;
+        expect(s.closedtrades.length).toBe(1);
+        const closed = s.closedtrades[0];
+        expect(Math.abs(closed.size)).toBeCloseTo(4 * (60000 / 110000), 9);
+        expect(closed.exit_price).toBe(110000);
+        expect(closed.exit_id).toBe('Margin call');
+
+        expect(s.opentrades.length).toBe(1);
+        expect(Math.abs(s.opentrades[0].size)).toBeCloseTo(5 - 4 * (60000 / 110000), 9);
+        expect(s.position_size).toBeCloseTo(-(5 - 4 * (60000 / 110000)), 9);
+
+        // Realized loss: 2.181818… contracts × $10,000 adverse move.
+        expect(s.netprofit).toBeCloseTo(-4 * (60000 / 110000) * 10000, 6);
+    });
+
+    it('caps the liquidation at the full position for catastrophic deficits', () => {
+        // capital 100,000: deficit = 550,000 − 50,000 = 500,000 → 4×cover ≫ 5.
+        const context = makeContext({ open: 101000, high: 110000, low: 99000, close: 105000 }, { initial_capital: 100000 });
+        openShort(context, 5, 100000);
+
+        processMarginCall(context);
+
+        const s = context.strategy;
+        expect(s.closedtrades.length).toBe(1);
+        expect(Math.abs(s.closedtrades[0].size)).toBe(5);
+        expect(s.closedtrades[0].exit_id).toBe('Margin call');
+        expect(s.opentrades.length).toBe(0);
+        expect(s.position_size).toBe(0);
+    });
+
+    it('does nothing when equity at the adverse extreme covers required margin', () => {
+        const context = makeContext({ open: 101000, high: 110000, low: 99000, close: 105000 }, { initial_capital: 2000000 });
+        openShort(context, 5, 100000);
+
+        processMarginCall(context);
+
+        const s = context.strategy;
+        expect(s.closedtrades.length).toBe(0);
+        expect(s.opentrades.length).toBe(1);
+        expect(s.position_size).toBe(-5);
+    });
+
+    it('runs at 100% margin (no leverage) — full notional collateral is still required', () => {
+        // Same as the partial case but asserts the check is NOT skipped at
+        // margin_long/margin_short = 100 (a prior bug guarded `>= 100`).
+        const context = makeContext({ open: 101000, high: 110000, low: 99000, close: 105000 }, {
+            initial_capital: 540000,
+            margin_long: 100,
+            margin_short: 100,
+        });
+        openShort(context, 5, 100000);
+
+        processMarginCall(context);
+        expect(context.strategy.closedtrades.length).toBe(1);
+    });
+});
+
+describe('processStrategyOrders — reversal close leg survives margin rejection', () => {
+    function makeReversalSetup(initialCapital: number) {
+        // Long 5 @ 50,000. Reversal short order qty 10 (close 5 + open 5).
+        // Bar open 60,000 → equity = capital + 5×10,000 unrealized.
+        // Open leg requires 5 × 60,000 = 300,000.
+        const context = makeContext({ open: 60000, high: 61000, low: 59000, close: 60500 }, { initial_capital: initialCapital });
+        context.strategy.opentrades.push({
+            id: 'trade_0',
+            entry_id: 'MacdLE',
+            entry_comment: 'MacdLE',
+            entry_price: 50000,
+            entry_bar_index: 0,
+            entry_time: 0,
+            size: 5,
+            commission: 0,
+            max_drawdown: 0,
+            max_runup: 0,
+            status: 'open',
+        });
+        context.strategy.position_size = 5;
+        context.strategy.position_avg_price = 50000;
+        context.strategy.position_entry_name = 'MacdLE';
+
+        const order: Order = {
+            id: 'MacdSE',
+            direction: -1,
+            qty: 10,
+            type: 'market',
+            bar: 0,
+            time: 0,
+            status: 'pending',
+            category: 'entry',
+            comment: 'MacdSE',
+            _isReversalEntry: true,
+        } as any;
+        context.strategy.pending_orders.push(order);
+        return context;
+    }
+
+    it('margin-rejected open leg: close leg still executes, no new position', () => {
+        // equity = 200,000 + 50,000 = 250,000 < 300,000 → open leg rejected.
+        const context = makeReversalSetup(200000);
+        processStrategyOrders(context);
+
+        const s = context.strategy;
+        expect(s.closedtrades.length).toBe(1);
+        expect(s.closedtrades[0].exit_price).toBe(60000);
+        expect(s.closedtrades[0].exit_id).toBe('MacdSE'); // reversal order id stamps the exit
+        expect(s.closedtrades[0].profit).toBeCloseTo(50000, 6);
+
+        expect(s.opentrades.length).toBe(0);   // open leg dropped
+        expect(s.position_size).toBe(0);
+        expect(s.pending_orders.length).toBe(0); // order consumed, not left pending
+    });
+
+    it('sufficient margin: reversal closes old position AND opens the new one', () => {
+        // equity = 400,000 + 50,000 = 450,000 ≥ 300,000 → full reversal.
+        const context = makeReversalSetup(400000);
+        processStrategyOrders(context);
+
+        const s = context.strategy;
+        expect(s.closedtrades.length).toBe(1);
+        expect(s.opentrades.length).toBe(1);
+        expect(s.opentrades[0].size).toBe(-5);
+        expect(s.opentrades[0].entry_price).toBe(60000);
+        expect(s.position_size).toBe(-5);
+    });
+
+    it('non-reversal entry with insufficient margin is dropped entirely', () => {
+        // Fresh entry from flat: no close leg exists, the order is cancelled.
+        const context = makeContext({ open: 60000, high: 61000, low: 59000, close: 60500 }, { initial_capital: 200000 });
+        const order: Order = {
+            id: 'MacdSE',
+            direction: -1,
+            qty: 10, // requires 600,000 > 200,000 equity
+            type: 'market',
+            bar: 0,
+            time: 0,
+            status: 'pending',
+            category: 'entry',
+        } as any;
+        context.strategy.pending_orders.push(order);
+
+        processStrategyOrders(context);
+
+        const s = context.strategy;
+        expect(s.closedtrades.length).toBe(0);
+        expect(s.opentrades.length).toBe(0);
+        expect(s.pending_orders.length).toBe(0); // cancelled
+    });
+});

--- a/tests/namespaces/strategy/risk-adjusted.test.ts
+++ b/tests/namespaces/strategy/risk-adjusted.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { finalizeStrategyRun } from '../../../src/namespaces/strategy/utils';
+
+/**
+ * Risk-adjusted performance ratios (Sharpe / Sortino).
+ *
+ * TV broker-emulator formula (confirmed against TV's Help Center docs and
+ * reverse-engineered to ~3 decimals across 7 QA datasets, 2026-06-15):
+ *   - monthly simple returns rᵢ = Eᵢ/Eᵢ₋₁ − 1, anchored at initial capital
+ *   - RFR = risk_free_rate / 100 / 12   (annual % → monthly)
+ *   - Sharpe  = (mean(r) − RFR) / SD,  SD = √(Σ(rᵢ − mean)² / N)   (population)
+ *   - Sortino = (mean(r) − RFR) / DD,  DD = √(Σ min(0, rᵢ − RFR)² / N)
+ *   - no annualization
+ *
+ * finalizeStrategyRun reads strategy.{config.risk_free_rate, initial_capital,
+ * _monthly_equity} and writes strategy.{sharpe_ratio, sortino_ratio}. These
+ * tests drive it directly with crafted monthly-equity series and assert
+ * against independently hand-computed values.
+ */
+function run(initial_capital: number, monthly: number[], risk_free_rate = 2) {
+    const context: any = { strategy: { config: { risk_free_rate }, initial_capital, _monthly_equity: monthly } };
+    finalizeStrategyRun(context);
+    return context.strategy;
+}
+
+describe('finalizeStrategyRun — Sharpe / Sortino', () => {
+    // equities [1000, 1100, 1045, 1149.5] → returns [+0.10, −0.05, +0.10]
+    //   mean 0.05, RFR 2/1200, SD (pop) 0.0707107, DD (target RFR) 0.0298298
+    it('computes Sharpe and Sortino with the documented formula (rfr = 2%)', () => {
+        const s = run(1000, [1100, 1045, 1149.5], 2);
+        expect(s.sharpe_ratio).toBeCloseTo(0.6835366, 6);
+        expect(s.sortino_ratio).toBeCloseTo(1.6203056, 6);
+    });
+
+    it('applies the risk-free rate as annual/1200 (rfr = 0 ⇒ no drag)', () => {
+        const s = run(1000, [1100, 1045, 1149.5], 0);
+        // mean/SD and mean/DD with no risk-free subtraction
+        expect(s.sharpe_ratio).toBeCloseTo(0.7071068, 6);
+        expect(s.sortino_ratio).toBeCloseTo(1.7320508, 6);
+        // sanity: removing the +rfr drag raises both ratios vs the rfr=2 case
+        const s2 = run(1000, [1100, 1045, 1149.5], 2);
+        expect(s.sharpe_ratio).toBeGreaterThan(s2.sharpe_ratio);
+        expect(s.sortino_ratio).toBeGreaterThan(s2.sortino_ratio);
+    });
+
+    it('anchors the first return at initial capital', () => {
+        // First return is 1100/1000−1 = +0.10, not skipped. Drop the anchor
+        // and the series would have only 2 returns from a different base.
+        const s = run(1000, [1100, 1045, 1149.5], 2);
+        // Independent recompute WITH the anchor must match.
+        const eq = [1000, 1100, 1045, 1149.5];
+        const r = eq.slice(1).map((e, i) => e / eq[i] - 1);
+        const rfr = 2 / 1200, mean = r.reduce((a, b) => a + b, 0) / r.length;
+        const sd = Math.sqrt(r.reduce((a, b) => a + (b - mean) ** 2, 0) / r.length);
+        expect(s.sharpe_ratio).toBeCloseTo((mean - rfr) / sd, 10);
+    });
+
+    it('returns Sortino 0 when there is no downside (all returns above RFR)', () => {
+        // equities [1000,1050,1160,1300] → returns all > 0 ⇒ DD = 0 ⇒ Sortino 0
+        const s = run(1000, [1050, 1160, 1300], 2);
+        expect(s.sortino_ratio).toBe(0);
+        expect(s.sharpe_ratio).toBeCloseTo(2.9776482, 6);
+    });
+
+    it('returns Sharpe 0 on a flat equity curve (zero variance)', () => {
+        const s = run(1000, [1000, 1000, 1000], 2);
+        expect(s.sharpe_ratio).toBe(0);
+        // every return (0) sits below RFR ⇒ downside exists ⇒ Sortino = −1
+        expect(s.sortino_ratio).toBeCloseTo(-1, 10);
+    });
+
+    it('leaves both ratios at 0 with fewer than two monthly returns', () => {
+        expect(run(1000, [1100], 2).sharpe_ratio).toBe(0);
+        expect(run(1000, [1100], 2).sortino_ratio).toBe(0);
+        expect(run(1000, [], 2).sharpe_ratio).toBe(0);
+        expect(run(1000, [], 2).sortino_ratio).toBe(0);
+    });
+
+    it('defaults the risk-free rate to 2% when config omits it', () => {
+        const context: any = { strategy: { config: {}, initial_capital: 1000, _monthly_equity: [1100, 1045, 1149.5] } };
+        finalizeStrategyRun(context);
+        expect(context.strategy.sharpe_ratio).toBeCloseTo(0.6835366, 6);
+    });
+
+    it('handles a negative-performance curve (negative ratios)', () => {
+        // equities [1000, 950, 1000, 900] → returns [−0.05, +0.0526, −0.10]
+        const s = run(1000, [950, 1000, 900], 2);
+        const eq = [1000, 950, 1000, 900];
+        const r = eq.slice(1).map((e, i) => e / eq[i] - 1);
+        const rfr = 2 / 1200, mean = r.reduce((a, b) => a + b, 0) / r.length;
+        const sd = Math.sqrt(r.reduce((a, b) => a + (b - mean) ** 2, 0) / r.length);
+        const dd = Math.sqrt(r.reduce((a, b) => a + Math.min(0, b - rfr) ** 2, 0) / r.length);
+        expect(s.sharpe_ratio).toBeCloseTo((mean - rfr) / sd, 10);
+        expect(s.sortino_ratio).toBeCloseTo((mean - rfr) / dd, 10);
+        expect(s.sharpe_ratio).toBeLessThan(0);
+    });
+});

--- a/tests/namespaces/strategy/trailing-parity.test.ts
+++ b/tests/namespaces/strategy/trailing-parity.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { Context } from '../../../src/Context.class';
+import { Series } from '../../../src/Series';
+import { StrategyState } from '../../../src/namespaces/strategy/types';
+import { processExitOrders } from '../../../src/namespaces/strategy/utils';
+
+function createTrailingContext({
+    open,
+    high,
+    low,
+    close,
+}: {
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+}) {
+    const context = new Context({
+        marketData: [],
+        source: [],
+        tickerId: 'BTCUSDC',
+        timeframe: 'D',
+    });
+    context.idx = 1;
+
+    context.data.open = new Series([100, open]);
+    context.data.high = new Series([110, high]);
+    context.data.low = new Series([99, low]);
+    context.data.close = new Series([110, close]);
+    context.data.openTime = new Series([0, 1000]);
+
+    const strategy: StrategyState = {
+        config: {
+            title: 'Test Strategy',
+            overlay: true,
+        },
+        opentrades: [
+            {
+                id: 'trade_1',
+                entry_id: 'buy',
+                entry_price: 100,
+                entry_bar_index: 0,
+                entry_time: 0,
+                size: 1,
+                status: 'open',
+            },
+        ],
+        closedtrades: [],
+        pending_orders: [
+            {
+                id: 'exit_1',
+                direction: -1,
+                qty: 1,
+                type: 'stop',
+                category: 'exit',
+                from_entry: 'buy',
+                trail_points: 10,
+                trail_offset: 5,
+                trail_peak: 110,
+                trail_armed: true,
+                status: 'pending',
+                bar: 0,
+                time: 0,
+            },
+        ],
+        position_size: 1,
+        position_avg_price: 100,
+        position_entry_name: 'buy',
+        initial_capital: 10000,
+        account_currency: 'USD',
+        equity: 10000,
+        netprofit: 0,
+        grossprofit: 0,
+        grossloss: 0,
+        openprofit: 0,
+        max_drawdown: 0,
+        max_runup: 0,
+        equity_peak: 10000,
+        equity_trough: 10000,
+        equity_at_runup_peak: 10000,
+        equity_at_drawdown_peak: 10000,
+        max_drawdown_percent_value: 0,
+        max_runup_percent_value: 0,
+        wintrades: 0,
+        losstrades: 0,
+        eventrades: 0,
+        wintrades_total_profit: 0,
+        losstrades_total_loss: 0,
+        max_contracts_held_all: 1,
+        max_contracts_held_long: 1,
+        max_contracts_held_short: 0,
+        risk_rules: {},
+        risk_halted: false,
+    };
+
+    context.strategy = strategy;
+    context.pine = {
+        syminfo: {
+            mintick: 1,
+        },
+    } as any;
+
+    return {
+        context,
+        order: strategy.pending_orders[0],
+        strategy,
+    };
+}
+
+describe('Strategy - Trailing Stop Price Path Parity', () => {
+    it('keeps an adverse-first long trail pending when segment 1 misses the old trigger and segment 3 misses the new trigger', () => {
+        const { context, order, strategy } = createTrailingContext({
+            open: 108,
+            high: 120,
+            low: 106,
+            close: 118,
+        });
+
+        processExitOrders(context);
+
+        expect(order.status).toBe('pending');
+        expect(order.trail_peak).toBe(120);
+        expect(strategy.closedtrades).toHaveLength(0);
+    });
+
+    it('fills an adverse-first long trail at the updated trigger when segment 3 crosses it', () => {
+        const { context, order, strategy } = createTrailingContext({
+            open: 108,
+            high: 120,
+            low: 106,
+            close: 110,
+        });
+
+        processExitOrders(context);
+
+        expect(order.status).toBe('filled');
+        expect(order.fill_price).toBe(115);
+        expect(order.trail_peak).toBe(120);
+        expect(strategy.closedtrades).toHaveLength(1);
+        expect(strategy.closedtrades[0].exit_price).toBe(115);
+    });
+
+    it('keeps the favorable-first long trail behavior by updating the peak before the trigger check', () => {
+        const { context, order, strategy } = createTrailingContext({
+            open: 118,
+            high: 120,
+            low: 106,
+            close: 110,
+        });
+
+        processExitOrders(context);
+
+        expect(order.status).toBe('filled');
+        expect(order.fill_price).toBe(115);
+        expect(order.trail_peak).toBe(120);
+        expect(strategy.closedtrades).toHaveLength(1);
+        expect(strategy.closedtrades[0].exit_price).toBe(115);
+    });
+});

--- a/tests/transpiler/pinets-source-to-js.test.ts
+++ b/tests/transpiler/pinets-source-to-js.test.ts
@@ -241,13 +241,17 @@ let src_open = input.any({ title: 'Open Source', defval: open });
     title: 'Fast Length',
     defval: 12
   }, undefined, 'p0');
-  const temp_1 = input.int(p0);
+  const temp_1 = input.int(p0, {
+    __varId: "_int"
+  });
   $.let.glb1__int = $.init($.let.glb1__int, temp_1);
   const p1 = input.param({
     title: 'String Input',
     defval: "Hello"
   }, undefined, 'p1');
-  const temp_2 = input.string(p1);
+  const temp_2 = input.string(p1, {
+    __varId: "_string"
+  });
   $.let.glb1__string = $.init($.let.glb1__string, temp_2);
   const p2 = input.param(10.0, undefined, 'p2');
   const p3 = input.param("float input", undefined, 'p3');
@@ -256,19 +260,25 @@ let src_open = input.any({ title: 'Open Source', defval: open });
     maxval: 100.0,
     step: 0.1
   }, undefined, 'p4');
-  const temp_3 = input.float(p2, p3, p4);
+  const temp_3 = input.float(p2, p3, p4, {
+    __varId: "_float"
+  });
   $.let.glb1__float = $.init($.let.glb1__float, temp_3);
   const p5 = input.param({
     title: 'Close Source',
     defval: close
   }, undefined, 'p5');
-  const temp_4 = input.any(p5);
+  const temp_4 = input.any(p5, {
+    __varId: "src_close"
+  });
   $.let.glb1_src_close = $.init($.let.glb1_src_close, temp_4);
   const p6 = input.param({
     title: 'Open Source',
     defval: open
   }, undefined, 'p6');
-  const temp_5 = input.any(p6);
+  const temp_5 = input.any(p6, {
+    __varId: "src_open"
+  });
   $.let.glb1_src_open = $.init($.let.glb1_src_open, temp_5);
 }`;
 


### PR DESCRIPTION
## [0.9.23] - 2026-06-16 - Strategy Pyramiding Parity, Indicator Input varId & Sharpe/Sortino

### Added

- **`context.strategy.sharpe_ratio` / `sortino_ratio`**: Report-only risk-adjusted performance ratios computed once at end-of-run in `finalizeStrategyRun`, from the monthly equity curve accumulated across the bar loop. Matching TradingView's documented formula — simple monthly returns anchored at `initial_capital`, population SD / downside deviation, no annualization. Not Pine built-ins — available on `context.strategy` after the run only, not inside the run callback.
- **`risk_free_rate` strategy declaration option** (default `2`, annual %): Converted to a monthly figure (`rate / 100 / 12`) as the denominator input for Sharpe / Sortino.
- **`.input` keyed by `varId`**: The primary override key is now the variable each input is assigned to (`length = input.int(…)` → `"length"`). The input's **`title`** still resolves as a secondary alias. Recommended for scripts with empty or duplicated titles — `ind.input['slow']` targets the second `"Length"` input precisely while `ind.input['Length']` aliases the first.
- **`varId` in `getInputsMeta()` / `IPineInput`**: Every scanned input carries its assigned variable name; `Object.keys(ind.input)` enumerates varIds.
- **Transpiler `{ __varId }` injection**: `input.*(...)` calls in Pine source get a trailing varId sentinel so the runtime resolves overrides by varId before title.
- **Color default normalization in input scanner**: `color`-typed inputs report `defval` as a canonical **8-digit RGBA hex `#RRGGBBAA`** (uppercase) regardless of source form — hex literals, named constants (`color.red` → `#F23645FF`), or statically evaluable `color.new()` / `color.rgb()` calls. Gives UI color pickers a single parseable format.
- **Constant resolution in `scanInputs`**: When an input argument references a top-level constant or simple variable (`const DEF = 14; len = input.int(DEF, …)`), the scanner resolves `defval`, `group`, `inline`, `tooltip`, `options`, etc. to the declared value rather than the bare identifier.
- **Tests**: `indicator_inputs.test.ts` (varId keying, color normalization, constant resolution), `close-snapshot.test.ts`, `equity-peak-basis.test.ts`, `margin-call.test.ts`, `risk-adjusted.test.ts`, `trailing-parity.test.ts`.
- **Docs**: `docs/indicator.md` rewritten for varId-first `.input` API; `docs/strategy.md` gains Sharpe / Sortino section and `risk_free_rate` in the options table.

### Fixed

- **`strategy.close_all()` snapshot binding**: TV binds `close_all` / `close(id)` to the position at **call time**. When a reversal entry queued the same bar fills first on the next bar's open — implicitly closing the snapshotted trades — the pending `close_all` is now **cancelled** instead of catching the freshly-opened reversal trade at its entry price for **$0 PnL**. Implemented via `_intended_trade_ids` captured at queue time and re-checked in `processExitOrders`. (QA close_all xlsx, BTCUSDT 1D — trade #13's $5,512.65 divergence.)
- **`strategy.position_avg_price` ghost position after partial liquidation**: Fractional qty residuals from margin-call partial liquidations left `position_avg_price` alive on a near-zero position. Epsilon-snap to flat (`|newSize| < 1e-9 → 0`) now sets `position_avg_price = NaN` and clears `position_entry_name`, preventing phantom TP/SL exits at the next entry's own price. (QA pyramiding xlsx, 2021-11-09 BTCUSDC.)
- **Pyramiding tick-based exit brackets per trade**: When `strategy.exit()` matches multiple open trades, TP/SL levels in ticks are now computed from **each trade's own entry price**, not `strategy.position_avg_price`. Verified against QA pyramiding xlsx (BTCUSDC 1D).
- **Equity peak basis for `max_drawdown`**: Peak latch now uses realized equity **plus open entry commissions** (excludes the commission deduction from the peak side). Trough basis keeps commission deducted. Fixes a degeneracy that hid the bug on constant-commission QA data but diverged on reversal bars with different entry commissions. (QA margin_calls xlsx — matches TV to the cent.)
- **Margin-call partial liquidation (TV 4× rule)**: Intra-bar adverse movement now liquidates **4× the contracts needed to cover the deficit** (floored), not the entire position — remainder stays open.
- **Reversal close-leg margin semantics**: When a reversal entry's **open** leg fails the pre-trade margin check, the **close** leg of the reversal still executes.
- **Deferred close margin call (`applyPendingCloseMarginCall`)**: Phantom re-check scheduled on the previous bar fills at that bar's close, before entries — so a reversal queued at that close overshoots by exactly the deferred quantity, as TV does.
- **Intra-bar margin checkpoint ordering**: Margin checks now run at the bar **open** (after entries fill) and at the **adverse extreme** — before exit fills on adverse-first bars, after them on favorable-first bars (`isAdverseFirstBar`). Exit processing moved to an explicit `'intrabar'` phase in `processExitOrders`.
- **Trailing stop adverse-first segment model** (PR #213): On bars where the adverse extreme precedes the favorable move, an already-armed trail now checks segment 1 against the **old** peak's trigger, updates the peak, then checks segment 3 against the **new** trigger — keeping the order pending when both segments miss. Fill price remains the literal trigger level.

### Changed

- **`.input` override precedence**: Runtime resolves **varId before title**. A varId-keyed `.input['len'] = 3` write wins over a constructor-map `{ Length: 21 }` title override. Both keys coexist in `ctx.inputs`; the script picks up the varId one.
- **Bar-loop strategy processing order**: Entries → deferred close margin call → open checkpoint → (adverse-first extreme checkpoint) → intrabar exits → (favorable-first extreme checkpoint) → `finalizeStrategyBar` peak latch → end-of-run `finalizeStrategyRun` for Sharpe / Sortino.