### PR TITLE
[0.9.27] - 2026-06-29 - Strategy update : buy_and_hold_pnl buy_and_hold_per_gain strategy_outperformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,21 @@
 # Change Log
 
+## [0.9.27] - 2026-06-29 - Strategy update : buy_and_hold_pnl buy_and_hold_per_gain strategy_outperformance
+
+### Added
+
+- **`context.strategy.buy_and_hold_pnl` / `buy_and_hold_per_gain` / `strategy_outperformance`**: Report-only buy-and-hold benchmark (TV's "Buy & Hold Return"), computed once at end-of-run in `finalizeStrategyRun`. Models a single long position bought with the entire `initial_capital` at the first trade's (slippage-adjusted) entry price and held open through the last bar — affected by `initial_capital` and `slippage`, never by commissions (no exit leg). `strategy_outperformance = netprofit − buy_and_hold_pnl`. `NaN` until the first trade opens. Not Pine built-ins — available on `context.strategy` after the run only.
+- **Docs**: `docs/strategy.md` Buy-and-hold return sections.
+
+---
+
 ## [0.9.26] - 2026-06-24 - Strategy update, add context.strategy.cagr
 
 ### Added
 
 - **`context.strategy.cagr`**: Report-only Compound Annual Growth Rate (%) of strategy equity over the backtest window, computed once at end-of-run in `finalizeStrategyRun`. Not a Pine built-in — available on `context.strategy` after the run only.
-- **`context.strategy.buy_and_hold_pnl` / `buy_and_hold_per_gain` / `strategy_outperformance`**: Report-only buy-and-hold benchmark (TV's "Buy & Hold Return"), computed once at end-of-run in `finalizeStrategyRun`. Models a single long position bought with the entire `initial_capital` at the first trade's (slippage-adjusted) entry price and held open through the last bar — affected by `initial_capital` and `slippage`, never by commissions (no exit leg). `strategy_outperformance = netprofit − buy_and_hold_pnl`. `NaN` until the first trade opens. Not Pine built-ins — available on `context.strategy` after the run only.
 - **Tests**: `tests/namespaces/strategy/cagr.test.ts` — unit coverage of the CAGR formula and `NaN` edge cases, plus an integration run of the MACD strategy on BINANCE:BTCUSDT 1D (3235 bars) asserting a strategy CAGR of ≈ 2.12%.
-- **Docs**: `docs/strategy.md` gains Compound Annual Growth Rate (CAGR) and Buy-and-hold return sections.
+- **Docs**: `docs/strategy.md` gains Compound Annual Growth Rate (CAGR).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 
 - **`context.strategy.cagr`**: Report-only Compound Annual Growth Rate (%) of strategy equity over the backtest window, computed once at end-of-run in `finalizeStrategyRun`. Not a Pine built-in — available on `context.strategy` after the run only.
+- **`context.strategy.buy_and_hold_pnl` / `buy_and_hold_per_gain` / `strategy_outperformance`**: Report-only buy-and-hold benchmark (TV's "Buy & Hold Return"), computed once at end-of-run in `finalizeStrategyRun`. Models a single long position bought with the entire `initial_capital` at the first trade's (slippage-adjusted) entry price and held open through the last bar — affected by `initial_capital` and `slippage`, never by commissions (no exit leg). `strategy_outperformance = netprofit − buy_and_hold_pnl`. `NaN` until the first trade opens. Not Pine built-ins — available on `context.strategy` after the run only.
 - **Tests**: `tests/namespaces/strategy/cagr.test.ts` — unit coverage of the CAGR formula and `NaN` edge cases, plus an integration run of the MACD strategy on BINANCE:BTCUSDT 1D (3235 bars) asserting a strategy CAGR of ≈ 2.12%.
-- **Docs**: `docs/strategy.md` gains a Compound Annual Growth Rate (CAGR) section.
+- **Docs**: `docs/strategy.md` gains Compound Annual Growth Rate (CAGR) and Buy-and-hold return sections.
 
 ---
 

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -28,6 +28,7 @@ Every example below is exercised by a verification harness at `PineTS/.scratchpa
 - [Read-only getters](#read-only-getters)
 - [Risk-adjusted performance (Sharpe / Sortino)](#risk-adjusted-performance-sharpe--sortino)
 - [Compound annual growth rate (CAGR)](#compound-annual-growth-rate-cagr)
+- [Benchmark - Buy-and-hold return](#benchmark---buy-and-hold-return)
 - [Constants](#constants)
 - [Risk management](#risk-management)
 - [Conversion helpers](#conversion-helpers)
@@ -286,6 +287,13 @@ interface StrategyState {
     // Capital efficiency
     cagr:             number;           // annualized return %, report-only (NaN if window < 1 day)
 
+    // Buy-and-hold benchmark — report-only, computed ONCE at end-of-run.
+    // Models a long position bought with the entire initial capital at the
+    // first trade's (slippage-adjusted) entry price and held to the last bar.
+    buy_and_hold_pnl:        number;    // initial_capital × per_gain / 100
+    buy_and_hold_per_gain:   number;    // (last_close − first_entry) / first_entry × 100
+    strategy_outperformance: number;    // netprofit − buy_and_hold_pnl
+
     // Trade-stat counters
     wintrades:                number;
     losstrades:               number;
@@ -509,6 +517,39 @@ CAGR%       = 100 × ( (initial_capital + netprofit) / initial_capital ) ^ ((1 /
 `firstBarTime` / `lastBarTime` are the open times of the first and last loaded bars (matching Pine's `var int firstTime = time` and `last_bar_time`).
 
 Edge cases: the result is `NaN` when the window is shorter than one day, when there is no loaded data, or when the capital figures are non-finite.
+
+---
+
+## Benchmark - Buy-and-hold return
+
+PineTS reports how the strategy fared against simply **buying and holding** the instrument over the same window:
+
+```javascript
+const ctx = await pine.run(/* ... */);
+const s = ctx.strategy;
+
+console.log('Buy & hold P&L:',     s.buy_and_hold_pnl);        // currency
+console.log('Buy & hold % gain:',  s.buy_and_hold_per_gain);   // percent
+console.log('Outperformance:',     s.strategy_outperformance); // netprofit − buy&hold
+```
+
+Like CAGR / Sharpe / Sortino these are **report-only fields, not Pine built-ins** — computed once in `finalizeStrategyRun` and read off `context.strategy` after the run.
+
+### How it's calculated
+
+The benchmark models a single **long** position bought with the **entire initial capital** at the **first trade's entry price** and held open through the last bar — it is never sold:
+
+```
+price_start   = first trade's entry price   // slippage already applied at fill
+price_end     = last bar's close
+qty           = initial_capital / price_start
+buy_and_hold_pnl        = qty × (price_end − price_start)
+                        = initial_capital × (price_end − price_start) / price_start
+buy_and_hold_per_gain   = (price_end − price_start) / price_start × 100
+strategy_outperformance = netprofit − buy_and_hold_pnl
+```
+
+Because the anchor is the first trade's actual fill price, the benchmark **is affected by the `slippage` property** (slippage shifts that fill). Since the position is never closed, there is **no exit leg**: commissions never apply and `price_end` carries no slippage. The figures are `NaN` until the first trade opens.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.26",
+    "version": "0.9.27",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/namespaces/strategy/types.ts
+++ b/src/namespaces/strategy/types.ts
@@ -259,6 +259,31 @@ export interface StrategyState {
     // live on the state object and are read via ctx.strategy.*.
     sharpe_ratio: number;
     sortino_ratio: number;
+
+    // Buy-and-hold benchmark (TV's "Buy & Hold Return" report figures).
+    // Computed ONCE at end-of-run by finalizeStrategyRun. Not Pine built-in
+    // variables (TV exposes them only in the Strategy Tester report), so they
+    // live on the state object and are read via ctx.strategy.* after the run.
+    //
+    // Model: a single long position bought with the ENTIRE initial capital at
+    // the FIRST trade's entry price (slippage already baked into that fill
+    // price) and held open through the last bar — never sold, so commissions
+    // never apply and the exit leg carries no slippage.
+    //   qty                  = initial_capital / first_entry_price
+    //   buy_and_hold_pnl      = qty × (last_close − first_entry_price)
+    //                         = initial_capital × per_gain / 100
+    //   buy_and_hold_per_gain = (last_close − first_entry_price)
+    //                            / first_entry_price × 100
+    //   strategy_outperformance = netprofit − buy_and_hold_pnl
+    // All NaN until the first trade opens (no entry price to anchor on).
+    buy_and_hold_pnl: number;
+    buy_and_hold_per_gain: number;
+    strategy_outperformance: number;
+    // Internal: entry price (slippage-adjusted) of the FIRST trade ever
+    // opened in the run — the anchor for the buy-and-hold benchmark. Latched
+    // once in openTrade and never overwritten.
+    _first_entry_price?: number;
+
     // Internal: mark-to-market equity at each calendar month's last bar,
     // and the month key of the most recent bar (rollover detector). Feed
     // the Sharpe / Sortino computation.

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -594,6 +594,12 @@ export function openTrade(
 
     strategy.opentrades.push(trade);
 
+    // Latch the slippage-adjusted entry price of the FIRST trade ever opened —
+    // the anchor for the buy-and-hold benchmark (see finalizeStrategyRun).
+    if (strategy._first_entry_price === undefined) {
+        strategy._first_entry_price = price;
+    }
+
     // FIFO ledger-entry record for TV-style exit pairing (see
     // consumeLedger / closePartialPosition): TV's xlsx pairs exit fills
     // with entry records oldest-first, splitting at record boundaries.
@@ -1970,6 +1976,9 @@ export function finalizeStrategyRun(context: any): void {
     // Sharpe / Sortino short-circuit below.
     strategy.cagr = computeCagr(context);
 
+    // Buy-and-hold benchmark (independent of the monthly equity curve too).
+    computeBuyAndHold(context);
+
     const series = strategy._monthly_equity ?? [];
     const equities = [strategy.initial_capital, ...series];
     const returns: number[] = [];
@@ -2038,6 +2047,49 @@ function computeCagr(context: any): number {
 
     const years = daysBetween / 365;
     return 100 * (Math.pow(exitPrice / entryPrice, 1 / years) - 1);
+}
+
+/**
+ * Buy-and-hold benchmark statistics (TV's "Buy & Hold Return" report).
+ *
+ * Models a single long position bought with the ENTIRE initial capital at the
+ * FIRST trade's entry price and held open through the last bar:
+ *   - The anchor (price_start) is strategy._first_entry_price — the first
+ *     trade's fill price, with slippage ALREADY applied by the engine. This
+ *     is why the benchmark is affected by the slippage property.
+ *   - The position is never sold (always open), so there is no exit leg:
+ *     commissions never apply and price_end carries no slippage.
+ *   - price_end is the last bar's close.
+ *
+ *   qty                     = initial_capital / price_start
+ *   buy_and_hold_pnl        = qty × (price_end − price_start)
+ *                           = initial_capital × (price_end − price_start) / price_start
+ *   buy_and_hold_per_gain   = (price_end − price_start) / price_start × 100
+ *   strategy_outperformance = netprofit − buy_and_hold_pnl
+ *
+ * Left at NaN when no trade ever opened (no entry price to anchor on) or the
+ * figures are non-finite.
+ */
+function computeBuyAndHold(context: any): void {
+    const strategy: StrategyState = context?.strategy;
+    if (!strategy) return;
+
+    const priceStart = strategy._first_entry_price;
+    const candles = context?.marketData;
+    const priceEnd = Array.isArray(candles) && candles.length > 0 ? candles[candles.length - 1]?.close : NaN;
+
+    if (!Number.isFinite(priceStart) || !Number.isFinite(priceEnd) || (priceStart as number) === 0) {
+        strategy.buy_and_hold_pnl = NaN;
+        strategy.buy_and_hold_per_gain = NaN;
+        strategy.strategy_outperformance = NaN;
+        return;
+    }
+
+    const start = priceStart as number;
+    const ratio = (priceEnd - start) / start;
+    strategy.buy_and_hold_per_gain = ratio * 100;
+    strategy.buy_and_hold_pnl = (strategy.initial_capital ?? 0) * ratio;
+    strategy.strategy_outperformance = (strategy.netprofit ?? 0) - strategy.buy_and_hold_pnl;
 }
 
 /**
@@ -2130,6 +2182,13 @@ export function initializeStrategy(context: any, config: any): void {
         sharpe_ratio: 0,
         sortino_ratio: 0,
         cagr: NaN,
+
+        // Buy-and-hold benchmark (computed at end-of-run; NaN until then).
+        buy_and_hold_pnl: NaN,
+        buy_and_hold_per_gain: NaN,
+        strategy_outperformance: NaN,
+        _first_entry_price: undefined,
+
         _monthly_equity: [],
         _last_month_key: -1,
 


### PR DESCRIPTION
### Added

- **`context.strategy.buy_and_hold_pnl` / `buy_and_hold_per_gain` / `strategy_outperformance`**: Report-only buy-and-hold benchmark (TV's "Buy & Hold Return"), computed once at end-of-run in `finalizeStrategyRun`. Models a single long position bought with the entire `initial_capital` at the first trade's (slippage-adjusted) entry price and held open through the last bar — affected by `initial_capital` and `slippage`, never by commissions (no exit leg). `strategy_outperformance = netprofit − buy_and_hold_pnl`. `NaN` until the first trade opens. Not Pine built-ins — available on `context.strategy` after the run only.
- **Docs**: `docs/strategy.md` Buy-and-hold return sections.