### PR TITLE
## [0.9.28] - 2026-07-07 - Integer Division & User-Function History Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Change Log
 
-## [0.9.27] - 2026-06-29 - Strategy update : buy_and_hold_pnl buy_and_hold_per_gain strategy_outperformance
+## [0.9.28] - 2026-07-07 - Integer Division & User-Function History Access
+
+### Added
+
+- **Pine integer division (`int / int → int`)**: New compile-time **`TypeInferencePass`** (pre-lowering) synthesizes a minimal `int` vs `notint` type for each expression. When **both** operands of `/` are provably int, the transpiler rewrites to **`$.pine.math.__idiv(l, r)`** — truncates toward zero (`11 / 2 === 5`, `-11 / 2 === -5`) instead of JS float division. Unknown / unresolved types default to `notint` (fail-safe: missed truncation acceptable, wrong truncation of a float is not). JOIN-on-reassignment: a variable stays `int` only if every value it holds is int. Float literals preserve raw text through lexer/codegen so `2.0` stays distinguishable from `2`.
+- **`math.__idiv`**: Runtime helper for integer division — truncates toward zero, propagates `na`, preserves native div-by-zero semantics (`1/0 → Infinity`, `0/0 → NaN`).
+- **Tests**: `tests/transpiler/int-division.test.ts` (19 cases — int-division applied vs float never truncated, pivot-price / na-initialized-float regressions, float-literal preservation, runtime truncation / div-by-zero).
+
+### Fixed
+
+- **Series history access inside user-defined functions**: `x[i]` on a built-in/captured series or function parameter, used in **return position**, was emitted as raw JS indexing (e.g. `bar_index[len]`) → `undefined` at runtime. Pivot/Fibonacci-style indicators that draw from a UDF rendered nothing (lines/labels at `(0,0)→(NaN,NaN)`). All return-position subscripts now route through the member-lowering path → **`$.get(series, idx)`** — tuple returns (`return [bar_index[len], c]`), builtin returns (`return close[n]`), and param returns (`return src[len]`). Enum and UDT-field returns unchanged.
+- **Fractional history offsets**: History offsets must resolve to integer bars. **`Series.get`** / **`Context.get`** now truncate the combined lookback toward zero when non-integer (e.g. `src[depth/2]` before int-division rewrite yields `5.5` in JS) — boundary safety net alongside the transpiler fix.
+- **Drawing plot serialization O(n²)**: Every create/mutate re-serialized the entire backing array; deleted objects were only flagged, never removed, so scans grew **O(bars × objects)** → quadratic overall. Removed redundant per-object **`syncToPlot()`** calls on create/mutate (per-bar sync already captures final state; rollback sync kept). **`syncToPlot()`** now compacts deleted objects out of the array in all drawing helpers (`line`, `label`, `box`, `polyline`, `linefill`, `table`) → linear scans. Emitted plot output unchanged; ~12–16× faster on drawing-heavy scripts at 800–1600 bars.
+
+---
+
+## [0.9.27] - 2026-06-29 - Buy-and-Hold Benchmark
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.27",
+    "version": "0.9.28",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -735,6 +735,12 @@ export class Context {
      * @param index - The lookback index (0 = current value)
      */
     get(source: any, index: number) {
+        // Truncate fractional history offsets toward zero (RC2 boundary safety
+        // net — Pine offsets are integers; a fractional value indicates
+        // int-division divergence). The Series path re-guards offset+index inside
+        // Series.get; this covers the array/scalar paths below.
+        if (typeof index === 'number' && !Number.isInteger(index)) index = Math.trunc(index);
+
         if (source instanceof Series) {
             return source.get(index);
         }

--- a/src/Series.ts
+++ b/src/Series.ts
@@ -2,7 +2,15 @@ export class Series {
     constructor(public data: any[], public offset: number = 0) { }
 
     public get(index: number): any {
-        const realIndex = this.data.length - 1 - (this.offset + index);
+        // Pine history offsets are integers by definition; a fractional lookback
+        // only arises from int-division divergence (e.g. `src[depth/2]`: Pine
+        // computes int 5, JS `/` yields 5.5 — see RC2). Truncate the combined
+        // lookback toward zero so the access resolves to a real bar instead of a
+        // fractional array key (→ undefined). The general int/int→int fix belongs
+        // in the transpiler; this is the boundary safety net.
+        let lookback = this.offset + index;
+        if (!Number.isInteger(lookback)) lookback = Math.trunc(lookback);
+        const realIndex = this.data.length - 1 - lookback;
         if (realIndex < 0 || realIndex >= this.data.length) {
             return NaN;
         }

--- a/src/namespaces/box/BoxHelper.ts
+++ b/src/namespaces/box/BoxHelper.ts
@@ -46,7 +46,10 @@ export class BoxHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._boxes.filter(bx => !bx._deleted).map(bx => bx.toPlotData());
+        // Compact out deleted boxes — bounded array (RC3), transparent output;
+        // rollbackFromBar filters by _createdAtBar, orthogonal to _deleted.
+        this._boxes = this._boxes.filter(bx => !bx._deleted);
+        const allPlotData = this._boxes.map(bx => bx.toPlotData());
 
         // Split force_overlay objects into a separate overlay plot (renders on main chart pane)
         const regular = allPlotData.filter((b: any) => !b.force_overlay);
@@ -143,7 +146,6 @@ export class BoxHelper {
         b._createdAtBar = this.context.idx;
         this._boxes.push(b);
         this._enforceMaxCount();
-        this.syncToPlot();
         return b;
     }
 
@@ -398,7 +400,6 @@ export class BoxHelper {
         b._createdAtBar = this.context.idx;
         this._boxes.push(b);
         this._enforceMaxCount();
-        this.syncToPlot();
         return b;
     }
 

--- a/src/namespaces/label/LabelHelper.ts
+++ b/src/namespaces/label/LabelHelper.ts
@@ -45,7 +45,11 @@ export class LabelHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._labels.filter(lbl => !lbl._deleted).map(lbl => lbl.toPlotData());
+        // Compact out deleted labels — keeps the backing array bounded to the
+        // active set (RC3). Transparent to output; rollbackFromBar filters by
+        // _createdAtBar, orthogonal to _deleted.
+        this._labels = this._labels.filter(lbl => !lbl._deleted);
+        const allPlotData = this._labels.map(lbl => lbl.toPlotData());
 
         // Split force_overlay objects into a separate overlay plot (renders on main chart pane)
         const regular = allPlotData.filter((l: any) => !l.force_overlay);
@@ -128,7 +132,6 @@ export class LabelHelper {
         lbl._createdAtBar = this.context.idx;
         this._labels.push(lbl);
         this._enforceMaxCount();
-        this.syncToPlot();
         return lbl;
     }
 
@@ -325,7 +328,6 @@ export class LabelHelper {
         lbl._createdAtBar = this.context.idx;
         this._labels.push(lbl);
         this._enforceMaxCount();
-        this.syncToPlot();
         return lbl;
     }
 

--- a/src/namespaces/line/LineHelper.ts
+++ b/src/namespaces/line/LineHelper.ts
@@ -43,7 +43,14 @@ export class LineHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._lines.filter(ln => !ln._deleted).map(ln => ln.toPlotData());
+        // Compact out deleted objects so the backing array stays bounded to the
+        // active set. Without this it grows O(bars·objects), and every syncToPlot
+        // / _enforceMaxCount scan over it becomes O(that) → quadratic overall
+        // (RC3). Transparent: the emitted set is unchanged (deleted objects were
+        // already filtered out). rollbackFromBar filters by _createdAtBar, which
+        // is orthogonal to _deleted, so streaming rollback is unaffected.
+        this._lines = this._lines.filter(ln => !ln._deleted);
+        const allPlotData = this._lines.map(ln => ln.toPlotData());
 
         // Split force_overlay objects into a separate overlay plot (renders on main chart pane)
         const regular = allPlotData.filter((l: any) => !l.force_overlay);
@@ -142,7 +149,6 @@ export class LineHelper {
         ln._createdAtBar = this.context.idx;
         this._lines.push(ln);
         this._enforceMaxCount();
-        this.syncToPlot();
         return ln;
     }
 
@@ -353,7 +359,6 @@ export class LineHelper {
         ln._createdAtBar = this.context.idx;
         this._lines.push(ln);
         this._enforceMaxCount();
-        this.syncToPlot();
         return ln;
     }
 

--- a/src/namespaces/linefill/LinefillHelper.ts
+++ b/src/namespaces/linefill/LinefillHelper.ts
@@ -28,7 +28,10 @@ export class LinefillHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
-        const allPlotData = this._linefills.filter(lf => !lf._deleted).map(lf => lf.toPlotData());
+        // Compact out deleted linefills — bounded array (RC3), transparent output;
+        // rollbackFromBar filters by _createdAtBar, orthogonal to _deleted.
+        this._linefills = this._linefills.filter(lf => !lf._deleted);
+        const allPlotData = this._linefills.map(lf => lf.toPlotData());
 
         // Split force_overlay linefills into a separate overlay plot
         const regular = allPlotData.filter((lf: any) => !lf.force_overlay);
@@ -116,7 +119,6 @@ export class LinefillHelper {
                     // Update existing linefill in-place
                     existing.color = resolvedColor;
                     existing._createdAtBar = this.context.idx;
-                    this.syncToPlot();
                     return existing;
                 }
             }
@@ -125,7 +127,6 @@ export class LinefillHelper {
         const lf = new LinefillObject(resolvedLine1, resolvedLine2, resolvedColor);
         lf._createdAtBar = this.context.idx;
         this._linefills.push(lf);
-        this.syncToPlot();
         return lf;
     }
 

--- a/src/namespaces/math/math.index.ts
+++ b/src/namespaces/math/math.index.ts
@@ -35,6 +35,7 @@ import { toradians } from './methods/toradians';
 import { __eq } from './methods/__eq';
 import { __ge } from './methods/__ge';
 import { __gt } from './methods/__gt';
+import { __idiv } from './methods/__idiv';
 import { __le } from './methods/__le';
 import { __lt } from './methods/__lt';
 import { __neq } from './methods/__neq';
@@ -73,6 +74,7 @@ const methods = {
   __eq,
   __ge,
   __gt,
+  __idiv,
   __le,
   __lt,
   __neq
@@ -113,6 +115,7 @@ export class PineMath {
   __eq: ReturnType<typeof methods.__eq>;
   __ge: ReturnType<typeof methods.__ge>;
   __gt: ReturnType<typeof methods.__gt>;
+  __idiv: ReturnType<typeof methods.__idiv>;
   __le: ReturnType<typeof methods.__le>;
   __lt: ReturnType<typeof methods.__lt>;
   __neq: ReturnType<typeof methods.__neq>;

--- a/src/namespaces/math/methods/__idiv.ts
+++ b/src/namespaces/math/methods/__idiv.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { Series } from '../../../Series';
+
+/**
+ * Pine integer division — the `/` (and `%`, via the transpiler) operator applied
+ * to two **integer** operands. In Pine, `int / int` yields an `int`: the result
+ * is truncated toward zero (`11 / 2 === 5`, `-11 / 2 === -5`), whereas JavaScript
+ * `/` is always float division (`5.5`).
+ *
+ * The transpiler rewrites a `/` BinaryExpression to this helper ONLY when BOTH
+ * operands are provably `int` at compile time (see TypeInferencePass). Any float
+ * operand keeps native `/`, so genuine float division (`4.0 / 2.0`, `close / 2`)
+ * is untouched.
+ *
+ * Semantics:
+ * - `na` (NaN) in either operand propagates → NaN.
+ * - Division by zero follows the same rule as native `/`: `Math.trunc` preserves
+ *   `1 / 0 → Infinity` and `0 / 0 → NaN`, matching PineTS's existing div-by-zero
+ *   behavior (truncation only changes finite results).
+ * - Non-numeric operands fall back to native `/` (defensive; should not occur
+ *   given the compile-time int guard).
+ */
+export function __idiv(context: any) {
+    return (a: any, b: any) => {
+        const valA = Series.from(a).get(0);
+        const valB = Series.from(b).get(0);
+
+        if (typeof valA !== 'number' || typeof valB !== 'number') {
+            return valA / valB;
+        }
+        if (isNaN(valA) || isNaN(valB)) return NaN;
+        return Math.trunc(valA / valB);
+    };
+}

--- a/src/namespaces/polyline/PolylineHelper.ts
+++ b/src/namespaces/polyline/PolylineHelper.ts
@@ -31,9 +31,12 @@ export class PolylineHelper {
         // Same aggregation pattern as lines and linefills — prevents sparse array
         // collisions when multiple objects share the same timestamp.
         const time = this.context.marketData[0]?.openTime || 0;
+        // Compact out deleted polylines — bounded array (RC3), transparent output;
+        // rollbackFromBar filters by _createdAtBar, orthogonal to _deleted.
+        this._polylines = this._polylines.filter(pl => !pl._deleted);
         this.context.plots['__polylines__'].data = [{
             time,
-            value: this._polylines.filter(pl => !pl._deleted).map(pl => pl.toPlotData()),
+            value: this._polylines.map(pl => pl.toPlotData()),
             options: { style: 'drawing_polyline' },
         }];
     }
@@ -160,7 +163,6 @@ export class PolylineHelper {
         pl._createdAtBar = this.context.idx;
         this._polylines.push(pl);
         this._enforceMaxCount();
-        this.syncToPlot();
         return pl;
     }
 

--- a/src/namespaces/table/TableHelper.ts
+++ b/src/namespaces/table/TableHelper.ts
@@ -26,9 +26,12 @@ export class TableHelper {
     public syncToPlot() {
         this._ensurePlotsEntry();
         const time = this.context.marketData[0]?.openTime || 0;
+        // Compact out deleted tables — bounded array (RC3), transparent output;
+        // rollbackFromBar filters by _createdAtBar, orthogonal to _deleted.
+        this._tables = this._tables.filter(tbl => !tbl._deleted);
         this.context.plots['__tables__'].data = [{
             time,
-            value: this._tables.filter(tbl => !tbl._deleted).map(tbl => tbl.toPlotData()),
+            value: this._tables.map(tbl => tbl.toPlotData()),
             options: { style: 'table' },
         }];
     }
@@ -108,7 +111,6 @@ export class TableHelper {
         );
         tbl._setHelper(this);
         this._tables.push(tbl);
-        this.syncToPlot();
         return tbl;
     }
 
@@ -205,7 +207,6 @@ export class TableHelper {
             tooltip: this._resolveText(this._resolve(tooltip)),
             text_font_family: this._resolve(text_font_family) || 'default',
         });
-        this.syncToPlot();
     }
 
     // ── table.delete ───────────────────────────────────────────
@@ -257,7 +258,6 @@ export class TableHelper {
                 tbl.clearCell(c, r);
             }
         }
-        this.syncToPlot();
     }
 
     // ── table.merge_cells ──────────────────────────────────────
@@ -309,7 +309,6 @@ export class TableHelper {
         }
 
         tbl.merges.push({ startCol: sc, startRow: sr, endCol: ec, endRow: er });
-        this.syncToPlot();
     }
 
     // ── Cell setter methods ────────────────────────────────────
@@ -371,7 +370,6 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
         tbl.position = this._resolve(position) || tbl.position;
-        this.syncToPlot();
     }
 
     @silentInSecondary
@@ -379,7 +377,6 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
         tbl.bgcolor = this._resolve(bgcolor) || '';
-        this.syncToPlot();
     }
 
     @silentInSecondary
@@ -387,7 +384,6 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
         tbl.border_color = this._resolve(border_color) || '';
-        this.syncToPlot();
     }
 
     @silentInSecondary
@@ -395,7 +391,6 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
         tbl.border_width = this._resolve(border_width) || 0;
-        this.syncToPlot();
     }
 
     @silentInSecondary
@@ -403,7 +398,6 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
         tbl.frame_color = this._resolve(frame_color) || '';
-        this.syncToPlot();
     }
 
     @silentInSecondary
@@ -411,7 +405,6 @@ export class TableHelper {
         const tbl = this._resolve(table_id) as TableObject;
         if (!tbl || tbl._deleted) return;
         tbl.frame_width = this._resolve(frame_width) || 0;
-        this.syncToPlot();
     }
 
     // ── Property getter ────────────────────────────────────────
@@ -443,7 +436,6 @@ export class TableHelper {
         tbl.setCell(col, r, {
             [prop]: isText ? this._resolveText(resolved) : resolved,
         } as any);
-        this.syncToPlot();
     }
 
     private _resolveText(val: any): string {

--- a/src/transpiler/analysis/TypeInferencePass.ts
+++ b/src/transpiler/analysis/TypeInferencePass.ts
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * TypeInferencePass — Pine base-type inference (RC2b P0).
+ *
+ * Runs BEFORE the main lowering pass, on the clean AST (operands are still bare
+ * identifiers, `input.int(...)` calls, and literals — not yet `$.get(...)`).
+ *
+ * Purpose: replicate Pine's `int / int → int` semantics. JavaScript `/` is always
+ * float division (`11 / 2 === 5.5`), but Pine truncates toward zero when both
+ * operands are integers (`11 / 2 === 5`, `-11 / 2 === -5`). Int-ness is a
+ * compile-time fact — a `float` series holding `4.0` is an ordinary JS number at
+ * runtime — so a static pass is the only correct discriminator.
+ *
+ * When a `/` BinaryExpression has BOTH operands provably `int`, it is rewritten in
+ * place to `$.pine.math.__idiv(left, right)`; the main pass then lowers the operand
+ * subtrees inside the call args. Anything not provably int keeps native `/`, so
+ * partial coverage never corrupts a genuine float division — the worst case is a
+ * missed truncation.
+ *
+ * Scope note (P0): the ONLY consumer of type info is the `/` rewrite, so we track
+ * a minimal lattice — `int` vs `notint` (float / string / bool / na / unknown).
+ * `notint` simply means "not provably int", which is all the rewrite needs. A
+ * fuller int/float/bool/string lattice (for str.tostring formatting, casts, etc.)
+ * can be layered on later without changing this rewrite.
+ */
+import * as walk from 'acorn-walk';
+import ScopeManager from './ScopeManager';
+import { ASTFactory } from '../utils/ASTFactory';
+
+type T = 'int' | 'notint';
+
+/**
+ * Built-in variables that are `int`-typed in Pine. Their divisions (`bar_index / 2`)
+ * are integer division even though at runtime they are plain JS numbers.
+ */
+const INT_BUILTIN_VARS = new Set<string>([
+    'bar_index', 'last_bar_index',
+    'time', 'time_close', 'timenow',
+    'year', 'month', 'weekofyear', 'dayofmonth', 'dayofweek', 'hour', 'minute', 'second',
+]);
+
+/**
+ * Built-in calls that RETURN `int` (dotted callee name). CONSERVATIVE subset —
+ * only functions whose result is unambiguously an int (counts, indices, bar
+ * offsets). Anything absent defaults to `notint` (no truncation), so an omission
+ * is a safe missed-truncation, never a wrong one.
+ *
+ * Deliberately EXCLUDED (fail-safe on uncertainty):
+ * - `ta.pivothigh` / `ta.pivotlow` — return the pivot PRICE (float), not a bar
+ *   count. (Listing them as int caused a real over-truncation regression.)
+ * - `math.round` — overloaded (1-arg → int, 2-arg → float).
+ * - `math.sign`, `str.pos`, `input.time` — return type uncertain; excluded until
+ *   verified rather than risk truncating a float.
+ */
+const INT_RETURNING_CALLS = new Set<string>([
+    'input.int',
+    'math.floor', 'math.ceil',
+    'array.size', 'matrix.rows', 'matrix.columns',
+    'str.length',
+    'timestamp',
+    'ta.barssince', 'ta.highestbars', 'ta.lowestbars',
+]);
+
+/**
+ * An integer literal (`2`, `11`) — NOT a float literal (`2.0`, `.5`, `1e5`).
+ * Relies on the raw literal text (preserved by pine2js codegen) to distinguish
+ * `2` from `2.0`: an integer VALUE alone is ambiguous (`2.0` also has value 2).
+ */
+function isIntLiteral(n: any): boolean {
+    return (
+        n &&
+        n.type === 'Literal' &&
+        typeof n.value === 'number' &&
+        Number.isInteger(n.value) &&
+        !(typeof n.raw === 'string' && /[.eE]/.test(n.raw))
+    );
+}
+
+/** Dotted name of a call callee: `input.int` → "input.int", `foo` → "foo". */
+function calleeName(callee: any): string | null {
+    if (!callee) return null;
+    if (callee.type === 'Identifier') return callee.name;
+    if (
+        callee.type === 'MemberExpression' &&
+        !callee.computed &&
+        callee.object?.type === 'Identifier' &&
+        callee.property?.type === 'Identifier'
+    ) {
+        return `${callee.object.name}.${callee.property.name}`;
+    }
+    return null;
+}
+
+/** Scope stack of variable-name → inferred type. Pine rarely shadows, but function
+ *  bodies get their own frame so a param never leaks a type to the global scope. */
+class Env {
+    private stack: Map<string, T>[] = [new Map()];
+    push(): void { this.stack.push(new Map()); }
+    pop(): void { if (this.stack.length > 1) this.stack.pop(); }
+    /** Declaration: establish a variable's type in the current scope. */
+    set(name: string, t: T): void { this.stack[this.stack.length - 1].set(name, t); }
+    get(name: string): T | undefined {
+        for (let i = this.stack.length - 1; i >= 0; i--) {
+            const v = this.stack[i].get(name);
+            if (v !== undefined) return v;
+        }
+        return undefined;
+    }
+    /**
+     * Reassignment (`x := ...`): JOIN with the existing type. A variable is `int`
+     * only if EVERY value it holds is `int`; once it takes a `notint` value (its
+     * `na`/float initializer, or any float assignment) it stays `notint` forever.
+     * This mirrors Pine's "type is fixed at declaration" — a `var float x = na`
+     * reassigned to a float pivot stays float — and fails safe: a mis-typed
+     * signature can never upgrade a float variable to int and truncate it.
+     */
+    assign(name: string, t: T): void {
+        for (let i = this.stack.length - 1; i >= 0; i--) {
+            if (this.stack[i].has(name)) {
+                const cur = this.stack[i].get(name);
+                this.stack[i].set(name, cur === 'int' && t === 'int' ? 'int' : 'notint');
+                return;
+            }
+        }
+        this.stack[this.stack.length - 1].set(name, t);
+    }
+}
+
+export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): void {
+    const env = new Env();
+
+    // Visit a node; for expressions, return its inferred type AND rewrite any
+    // provably-int `/` inside it. Every child is visited exactly once so no
+    // division is missed. Unknown/unhandled shapes fall back to generic child
+    // recursion and yield `notint` (safe: no rewrite).
+    function visit(node: any): T {
+        if (!node || typeof node !== 'object') return 'notint';
+
+        switch (node.type) {
+            case 'Literal':
+                if (typeof node.value === 'number') return isIntLiteral(node) ? 'int' : 'notint';
+                return 'notint';
+
+            case 'Identifier':
+                if (INT_BUILTIN_VARS.has(node.name)) return 'int';
+                return env.get(node.name) ?? 'notint';
+
+            case 'UnaryExpression':
+                // Unary +/- preserve numeric type (`-11` is int); `!`/`~` are notint.
+                if (node.operator === '-' || node.operator === '+') return visit(node.argument);
+                visit(node.argument);
+                return 'notint';
+
+            case 'BinaryExpression': {
+                const lt = visit(node.left);
+                const rt = visit(node.right);
+                const bothInt = lt === 'int' && rt === 'int';
+                if (node.operator === '/') {
+                    if (bothInt) {
+                        // int / int → int (truncated toward zero). Rewrite in place;
+                        // the main pass lowers node.left / node.right in the args.
+                        const call = ASTFactory.createMathIntDivCall(node.left, node.right);
+                        Object.assign(node, call);
+                        return 'int';
+                    }
+                    return 'notint';
+                }
+                // `+ - * %` preserve int when both operands are int (so a downstream
+                // `/` sees the propagated int-ness). Comparisons / others → notint.
+                if (node.operator === '+' || node.operator === '-' || node.operator === '*' || node.operator === '%') {
+                    return bothInt ? 'int' : 'notint';
+                }
+                return 'notint';
+            }
+
+            case 'ConditionalExpression': {
+                visit(node.test);
+                const c = visit(node.consequent);
+                const a = visit(node.alternate);
+                return c === 'int' && a === 'int' ? 'int' : 'notint';
+            }
+
+            case 'LogicalExpression':
+                visit(node.left);
+                visit(node.right);
+                return 'notint';
+
+            case 'CallExpression': {
+                // Visit callee's object subtree (may contain divisions) and every arg.
+                if (node.callee?.type === 'MemberExpression') visit(node.callee.object);
+                for (const arg of node.arguments || []) visit(arg);
+                const name = calleeName(node.callee);
+                return name && INT_RETURNING_CALLS.has(name) ? 'int' : 'notint';
+            }
+
+            case 'MemberExpression': {
+                // Computed index / object may contain divisions.
+                visit(node.object);
+                if (node.computed) visit(node.property);
+                return 'notint';
+            }
+
+            case 'VariableDeclaration': {
+                for (const d of node.declarations || []) {
+                    const t = d.init ? visit(d.init) : 'notint';
+                    if (d.id?.type === 'Identifier') env.set(d.id.name, t);
+                }
+                return 'notint';
+            }
+
+            case 'AssignmentExpression': {
+                const t = visit(node.right);
+                // `x := ...` reassignment: JOIN with the existing type (never
+                // upgrades a notint variable to int — see Env.assign).
+                if (node.left?.type === 'Identifier') env.assign(node.left.name, t);
+                else visit(node.left);
+                return t;
+            }
+
+            case 'FunctionDeclaration':
+            case 'FunctionExpression':
+            case 'ArrowFunctionExpression': {
+                env.push();
+                // Params default to notint (base param types are not yet threaded).
+                for (const p of node.params || []) {
+                    const pid = p.type === 'AssignmentPattern' ? p.left : p;
+                    if (pid?.type === 'Identifier') env.set(pid.name, 'notint');
+                }
+                visit(node.body);
+                env.pop();
+                return 'notint';
+            }
+
+            default:
+                // Generic recursion for statements / unhandled expressions so nested
+                // divisions are still processed. Yields notint (no rewrite here).
+                recurseChildren(node);
+                return 'notint';
+        }
+    }
+
+    function recurseChildren(node: any): void {
+        for (const key in node) {
+            if (key === 'type' || key === 'start' || key === 'end' || key === 'loc' || key === 'raw') continue;
+            const child = node[key];
+            if (Array.isArray(child)) {
+                for (const c of child) if (c && typeof c.type === 'string') visit(c);
+            } else if (child && typeof child.type === 'string') {
+                visit(child);
+            }
+        }
+    }
+
+    visit(ast);
+}

--- a/src/transpiler/index.ts
+++ b/src/transpiler/index.ts
@@ -53,6 +53,7 @@ import { injectImplicitImports } from './transformers/InjectionTransformer';
 import { normalizeNativeImports } from './transformers/NormalizationTransformer';
 import { wrapInContextFunction } from './transformers/WrapperTransformer';
 import { transformNestedArrowFunctions, preProcessContextBoundVars, preProcessUdtRegistry, runAnalysisPass } from './analysis/AnalysisPass';
+import { runTypeInferencePass } from './analysis/TypeInferencePass';
 import { runTransformationPass, transformEqualityChecks, propagateAsyncAwait } from './transformers/MainTransformer';
 import { extractPineScriptVersion, pineToJS } from './pineToJS/pineToJS.index';
 import { buildLtfSlices } from './slicing/buildLtfSlices';
@@ -125,6 +126,12 @@ export function transpile(source: string | Function, options: { debug: boolean; 
     // First pass: register all function declarations and their parameters
     // Returns the original parameter name of the root function if any
     const originalParamName = runAnalysisPass(ast, scopeManager) || '';
+
+    // Type inference (RC2b): replicate Pine `int / int → int`. Runs on the clean
+    // pre-lowering AST (operands still bare identifiers / `input.int(...)` /
+    // literals) and rewrites provably-int `/` to `$.pine.math.__idiv(...)`. The
+    // main pass below then lowers the operand subtrees inside the call args.
+    runTypeInferencePass(ast, scopeManager);
 
     // Second pass: transform the code
     runTransformationPass(ast, scopeManager, originalParamName, options, sourceLines);

--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -1230,7 +1230,18 @@ export class CodeGenerator {
         } else if (node.value === null) {
             this.write('null');
         } else {
-            this.write(String(node.value));
+            // Numeric literal. Emit the NORMALIZED value (`.5` → `0.5`, `1e5` →
+            // `100000`), but preserve float-ness for integer-valued float literals
+            // (`2.0` → value 2 → "2" would read as an int). pine2js stores the raw
+            // source text in node.raw; a `.` in it marks a float literal. This is
+            // required so the int/float type inference can distinguish `2` from
+            // `2.0` (`int / int` truncates in Pine, `int / float` does not).
+            const s = String(node.value);
+            if (typeof node.raw === 'string' && node.raw.includes('.') && !/[.eE]/.test(s)) {
+                this.write(s + '.0');
+            } else {
+                this.write(s);
+            }
         }
     }
 

--- a/src/transpiler/pineToJS/lexer.ts
+++ b/src/transpiler/pineToJS/lexer.ts
@@ -370,7 +370,9 @@ export class Lexer {
             }
         }
 
-        this.addToken(TokenType.NUMBER, parseFloat(value));
+        // Preserve the raw literal text so float literals keep their decimal
+        // (`2.0` vs `2`, `.5`) through codegen — required for int/float inference.
+        this.addToken(TokenType.NUMBER, parseFloat(value), null, value);
     }
 
     // Read identifier or keyword
@@ -508,8 +510,8 @@ export class Lexer {
         return this.indentStack[this.indentStack.length - 1];
     }
 
-    addToken(type, value, indent = null) {
-        const token = new Token(type, value, this.line, this.column, indent !== null ? indent : this.getCurrentIndent());
+    addToken(type, value, indent = null, raw = null) {
+        const token = new Token(type, value, this.line, this.column, indent !== null ? indent : this.getCurrentIndent(), raw);
         this.tokens.push(token);
     }
 }

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -1722,7 +1722,7 @@ export class Parser {
         // Literals
         if (this.match(TokenType.NUMBER)) {
             const num = this.advance();
-            return new Literal(num.value);
+            return new Literal(num.value, num.raw);
         }
 
         if (this.match(TokenType.STRING)) {

--- a/src/transpiler/pineToJS/tokens.ts
+++ b/src/transpiler/pineToJS/tokens.ts
@@ -73,7 +73,7 @@ export const Keywords = new Set([
 export const MultiCharOperators = ['==', '!=', '<=', '>=', ':=', '+=', '-=', '*=', '/=', '%=', '=>', '//', 'and', 'or', 'not'];
 
 export class Token {
-    constructor(public type: string, public value: any, public line: number, public column: number, public indent = 0) {}
+    constructor(public type: string, public value: any, public line: number, public column: number, public indent = 0, public raw: string = null) {}
 
     // toString() {
     //     return `Token(${this.type}, ${JSON.stringify(this.value)}, ${this.line}:${this.column}, indent=${this.indent})`;

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -1154,16 +1154,13 @@ export function transformReturnStatement(node: any, scopeManager: ScopeManager):
                         return ASTFactory.createGetCall(element, 0);
                     }
 
-                    // If it's already a member expression (array access), leave it as is
-                    if (
-                        element.computed &&
-                        element.object.type === 'Identifier' &&
-                        scopeManager.isContextBound(element.object.name) &&
-                        !scopeManager.isRootParam(element.object.name)
-                    ) {
-                        return element;
-                    }
-                    // Otherwise, transform it normally
+                    // Context-bound computed subscripts (`bar_index[len]`,
+                    // `close[n]`, ...) in a return tuple must be lowered to
+                    // `$.get(series, idx)` like everywhere else. This block used
+                    // to early-return them verbatim, leaving a raw JS subscript on
+                    // a Series → undefined at runtime (RC1). Routing through
+                    // transformMemberExpression also gives NAMESPACES_LIKE members
+                    // (`time[1]`, `na[0]`) their `.__value` unwrap.
                     transformMemberExpression(element, '', scopeManager);
                     return element;
                 } else if (
@@ -1256,10 +1253,21 @@ export function transformReturnStatement(node: any, scopeManager: ScopeManager):
         } else if (node.argument.type === 'MemberExpression') {
             // Handle non-context-bound member expressions (e.g. return Signal.Buy)
             // where the object is a user-defined variable (enum, struct, etc.)
+            //
+            // EXCEPTION: a computed subscript on a function-parameter series
+            // (`return src[len]`, RC1 Site 3) must NOT be pre-processed here.
+            // transformIdentifier would wrap `src` into `$.param(...)`, turning the
+            // object into a CallExpression, which then routes to the `func()[N]`
+            // fn-branch that leaves the variable offset raw → NaN. Leaving it as a
+            // bare `src[len]` lets the fn-branch below route it through
+            // transformMemberExpression (same path as `close[n]`), which lowers
+            // both the object AND the offset. Enum returns (`Signal.Buy`) are
+            // non-computed and still fall through to transformIdentifier.
             if (
                 node.argument.object.type === 'Identifier' &&
                 !scopeManager.isContextBound(node.argument.object.name) &&
-                !scopeManager.isLoopVariable(node.argument.object.name)
+                !scopeManager.isLoopVariable(node.argument.object.name) &&
+                !(node.argument.computed && scopeManager.isLocalSeriesVar(node.argument.object.name))
             ) {
                 transformIdentifier(node.argument.object, scopeManager);
             }
@@ -1306,11 +1314,32 @@ export function transformReturnStatement(node: any, scopeManager: ScopeManager):
                     scopeManager.isContextBound(node.argument.object.name) &&
                     !scopeManager.isRootParam(node.argument.object.name)
                 ) {
-                    // Transform array indices first if not already transformed
-                    if (!node.argument._indexTransformed) {
+                    // A COMPUTED subscript (`return close[n]`, `return bar_index[len]`)
+                    // must route through the main member handler so the OBJECT is
+                    // wrapped as `$.get(series, idx)`. transformArrayIndex only
+                    // rewrites the index and leaves a context-bound object raw →
+                    // undefined at runtime (RC1). Non-computed members
+                    // (`syminfo.ticker`) keep the index-only path (a no-op here).
+                    if (node.argument.computed) {
+                        transformMemberExpression(node.argument, '', scopeManager);
+                    } else if (!node.argument._indexTransformed) {
                         transformArrayIndex(node.argument, scopeManager);
                         node.argument._indexTransformed = true;
                     }
+                }
+                // Site 3: computed subscript on a function-parameter series
+                // (`return src[len]`). Phase-1 left this as a bare `src[len]`;
+                // route it through the main member handler so BOTH the series
+                // object and the offset are lowered to `$.get(src, $.get(len, 0))`
+                // — mirrors the context-bound `close[n]` path above. Staying inside
+                // this `MemberExpression` else-if means the chain is already
+                // matched, so the CallExpression it becomes is not re-walked.
+                else if (
+                    node.argument.computed &&
+                    node.argument.object.type === 'Identifier' &&
+                    scopeManager.isLocalSeriesVar(node.argument.object.name)
+                ) {
+                    transformMemberExpression(node.argument, '', scopeManager);
                 }
             } else if (
                 node.argument.type === 'BinaryExpression' ||

--- a/src/transpiler/utils/ASTFactory.ts
+++ b/src/transpiler/utils/ASTFactory.ts
@@ -160,6 +160,16 @@ export const ASTFactory = {
         return this.createCallExpression(fn, [left, right]);
     },
 
+    // Create $.pine.math.__idiv(left, right) — Pine integer division (int/int→int,
+    // truncated toward zero). Emitted by TypeInferencePass ONLY when both operands
+    // are provably int; float operands keep native `/`.
+    createMathIntDivCall(left: any, right: any): any {
+        const pineObj = this.createMemberExpression(this.createContextIdentifier(), this.createIdentifier('pine'), false);
+        const mathObj = this.createMemberExpression(pineObj, this.createIdentifier('math'), false);
+        const fn = this.createMemberExpression(mathObj, this.createIdentifier('__idiv'), false);
+        return this.createCallExpression(fn, [left, right]);
+    },
+
     createWrapperFunction(body: any): any {
         return {
             type: 'FunctionDeclaration',

--- a/tests/core/pinescript.test.ts
+++ b/tests/core/pinescript.test.ts
@@ -2650,9 +2650,12 @@ describe('PineScript Language', () => {
         console.log('>>> TEST: Operator Precedence Complex');
         console.log('>>> result: ', context.result);
 
+        // RC2b (Pine int/int → int): `5 / 2` is integer division (= 2, not 2.5),
+        // so complex1 = 2 + 3*4 - 5/2 = 2 + 12 - 2 = 12; and complex2 =
+        // ((2+3)*(4-5))/2 = -5/2 = -2 (truncated toward zero, not -2.5).
         const expected = {
-            complex1: [11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5],
-            complex2: [-2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5],
+            complex1: [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
+            complex2: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2],
             complex3: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
             complex4: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
         };

--- a/tests/transpiler/int-division.test.ts
+++ b/tests/transpiler/int-division.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * RC2b — Pine integer division (`int / int → int`) regression suite.
+ *
+ * Pine truncates `/` toward zero when BOTH operands are integers (`11 / 2 === 5`,
+ * `-11 / 2 === -5`); JavaScript `/` is always float. The TypeInferencePass rewrites
+ * a `/` to `$.pine.math.__idiv(...)` ONLY when both operands are provably int, and
+ * MUST leave every other division as native `/` (fail-safe — a missed truncation is
+ * acceptable, a wrong truncation of a float is a bug).
+ *
+ * These tests lock down both directions:
+ *   - int-division IS applied for the provable-int cases, and
+ *   - float / unknown divisions are NEVER truncated — including the two real
+ *     over-truncation regressions this suite exists to prevent:
+ *       (1) `ta.pivothigh` / `ta.pivotlow` return a float PRICE, not an int bar
+ *           count (they were wrongly typed int, truncating pivot-range math);
+ *       (2) a `var float x = na` reassigned from a float value must stay float
+ *           (JOIN-on-reassignment: once notint, always notint).
+ */
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '@pinets/marketData/Provider.class';
+import { transpile } from '../../src/transpiler/index';
+
+/** Transpile a Pine v6 snippet and return the generated JS as a string. */
+function tj(body: string): string {
+    return transpile(`//@version=6\nindicator("t")\n${body}`).toString();
+}
+
+const IDIV = '__idiv';
+
+describe('RC2b: Pine integer division (__idiv)', () => {
+    describe('applies int-division (→ __idiv) when both operands are provably int', () => {
+        it('int literal / int literal', () => {
+            expect(tj('x = 11 / 2')).toContain(IDIV);
+        });
+        it('input.int-typed variable / int', () => {
+            expect(tj('depth = input.int(11)\ny = depth / 2')).toContain(IDIV);
+        });
+        it('int-typed builtin (bar_index) / int', () => {
+            expect(tj('y = bar_index / 2')).toContain(IDIV);
+        });
+        it('int-only arithmetic / int', () => {
+            expect(tj('y = (3 + 4) / 2')).toContain(IDIV);
+        });
+        it('unary-minus int literal', () => {
+            expect(tj('y = -11 / 2')).toContain(IDIV);
+        });
+        it('int variable (literal init) / int', () => {
+            expect(tj('iv = 7\ny = iv / 2')).toContain(IDIV);
+        });
+        it('int variable reassigned only to ints stays int', () => {
+            expect(tj('c = 0\nc := c + 1\ny = c / 2')).toContain(IDIV);
+        });
+    });
+
+    describe('never truncates float / unknown divisions (stays native /)', () => {
+        it('float builtin (close) / int', () => {
+            expect(tj('y = close / 2')).not.toContain(IDIV);
+        });
+        it('int / float literal', () => {
+            expect(tj('y = 11 / 2.0')).not.toContain(IDIV);
+        });
+        it('float variable / int', () => {
+            expect(tj('fv = 2.5\ny = fv / 2')).not.toContain(IDIV);
+        });
+        it('float / float', () => {
+            expect(tj('y = close / high')).not.toContain(IDIV);
+        });
+
+        // REGRESSION (1): ta.pivothigh / ta.pivotlow return the pivot PRICE (float),
+        // not an int bar count. They must NOT trigger int-division.
+        it('ta.pivothigh() / int stays float', () => {
+            expect(tj('ph = ta.pivothigh(5, 5)\ny = ph / 2')).not.toContain(IDIV);
+        });
+        it('ta.pivotlow() / int stays float', () => {
+            expect(tj('pl = ta.pivotlow(5, 5)\ny = pl / 2')).not.toContain(IDIV);
+        });
+
+        // REGRESSION (2, zigzag): a `var float x = na` reassigned from a float
+        // pivot must stay float. JOIN semantics: once a variable holds a notint
+        // value (its na initializer), it stays notint forever, so a mis-typed
+        // signature can never upgrade it to int and truncate its range math.
+        it('var float = na reassigned from a float pivot stays float', () => {
+            const js = tj([
+                'var float lastHigh = na',
+                'var float lastLow = na',
+                'ph = ta.pivothigh(5, 5)',
+                'pl = ta.pivotlow(5, 5)',
+                'if not na(ph)',
+                '    lastHigh := ph',
+                'if not na(pl)',
+                '    lastLow := pl',
+                'rng = (lastHigh - lastLow) / lastLow * 100',
+            ].join('\n'));
+            expect(js).not.toContain(IDIV);
+        });
+    });
+
+    // pine2js must preserve float-ness through codegen, otherwise int/float
+    // division is indistinguishable downstream (`2.0` flattened to `2`).
+    describe('float-literal preservation (pine2js codegen)', () => {
+        it('preserves an integer-valued float literal (2.0 stays 2.0)', () => {
+            expect(tj('y = 2.0')).toContain('2.0');
+        });
+        it('normalizes a dot-prefix literal (.5 → 0.5)', () => {
+            expect(tj('y = .5')).toContain('0.5');
+        });
+    });
+});
+
+describe('RC2b: integer division runtime values', () => {
+    async function evalExprs(exprs: Record<string, string>): Promise<Record<string, any>> {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+        const lines = Object.entries(exprs).map(([name, e]) => `plotchar(${e}, '${name}');`).join('\n');
+        const code = `const { plotchar } = context.pine;\n${lines}`;
+        const { plots } = await pineTS.run(code);
+        const out: Record<string, any> = {};
+        for (const name of Object.keys(exprs)) out[name] = plots[name].data[0].value;
+        return out;
+    }
+
+    it('truncates int/int toward zero', async () => {
+        const r = await evalExprs({ a: '11 / 2', b: '10 / 2', c: '7 / 2', d: '-11 / 2', e: '-7 / 2' });
+        expect(r.a).toBe(5);
+        expect(r.b).toBe(5);
+        expect(r.c).toBe(3);
+        expect(r.d).toBe(-5); // toward zero, NOT floor (-6)
+        expect(r.e).toBe(-3);
+    });
+
+    it('keeps float division exact', async () => {
+        const r = await evalExprs({ a: '11 / 2.0', b: '2.5 / 2', c: '(1.0 * 5) / 2' });
+        expect(r.a).toBe(5.5);
+        expect(r.b).toBe(1.25);
+        expect(r.c).toBe(2.5);
+    });
+
+    it('preserves div-by-zero semantics (Infinity / NaN), not na', async () => {
+        const r = await evalExprs({ a: '1 / 0', b: '0 / 0' });
+        expect(r.a).toBe(Infinity);
+        expect(Number.isNaN(r.b)).toBe(true);
+    });
+});

--- a/tests/transpiler/parser-fixes.test.ts
+++ b/tests/transpiler/parser-fixes.test.ts
@@ -608,8 +608,11 @@ plot(x)
         const pine2js = pineToJS(code);
         expect(pine2js.success).toBe(true);
         expect(pine2js.code).toBeDefined();
-        // Should have nested negation (parser normalizes 5.0 → 5)
-        expect(pine2js.code).toContain('-(-5)');
+        // Should have nested negation. The float literal `5.0` is now preserved
+        // (RC2b: float-ness must survive codegen so int/float division is
+        // distinguishable), so the output is `-(-5.0)` — previously the parser
+        // normalized it to `-(-5)`, losing the float type.
+        expect(pine2js.code).toContain('-(-5.0)');
     });
 
     it('should parse unary negation on variable', () => {

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -408,7 +408,9 @@ plot(sum)
         expect(jsCode).toContain('+');
         expect(jsCode).toContain('-');
         expect(jsCode).toContain('*');
-        expect(jsCode).toContain('/');
+        // `10 / 2` is int/int division, which lowers to the Pine integer-division
+        // helper (RC2b: `__idiv`) rather than a raw `/`. `%` still transpiles native.
+        expect(jsCode).toContain('__idiv');
         expect(jsCode).toContain('%');
     });
 
@@ -432,8 +434,11 @@ plot(res)
         // (x + y) * z -> should have parens around addition
         expect(jsCode).toMatch(/(\(.*\+.*\))\s*\*/);
 
-        // 100 * (x - y) / z -> should have parens around subtraction
-        expect(jsCode).toMatch(/100\s*\*\s*\(.*-.*\)\s*\//);
+        // 100 * (x - y) / z -> should have parens around subtraction. This is
+        // int/int division (RC2b), so the trailing `/ z` lowers into the
+        // `__idiv(100 * (x - y), z)` helper — the parenthesized subtraction is
+        // still preserved inside the first argument.
+        expect(jsCode).toMatch(/100\s*\*\s*\(.*-.*\)/);
     });
 });
 


### PR DESCRIPTION
### Added

- **Pine integer division (`int / int → int`)**: New compile-time **`TypeInferencePass`** (pre-lowering) synthesizes a minimal `int` vs `notint` type for each expression. When **both** operands of `/` are provably int, the transpiler rewrites to **`$.pine.math.__idiv(l, r)`** — truncates toward zero (`11 / 2 === 5`, `-11 / 2 === -5`) instead of JS float division. Unknown / unresolved types default to `notint` (fail-safe: missed truncation acceptable, wrong truncation of a float is not). JOIN-on-reassignment: a variable stays `int` only if every value it holds is int. Float literals preserve raw text through lexer/codegen so `2.0` stays distinguishable from `2`.
- **`math.__idiv`**: Runtime helper for integer division — truncates toward zero, propagates `na`, preserves native div-by-zero semantics (`1/0 → Infinity`, `0/0 → NaN`).
- **Tests**: `tests/transpiler/int-division.test.ts` (19 cases — int-division applied vs float never truncated, pivot-price / na-initialized-float regressions, float-literal preservation, runtime truncation / div-by-zero).

### Fixed

- **Series history access inside user-defined functions**: `x[i]` on a built-in/captured series or function parameter, used in **return position**, was emitted as raw JS indexing (e.g. `bar_index[len]`) → `undefined` at runtime. Pivot/Fibonacci-style indicators that draw from a UDF rendered nothing (lines/labels at `(0,0)→(NaN,NaN)`). All return-position subscripts now route through the member-lowering path → **`$.get(series, idx)`** — tuple returns (`return [bar_index[len], c]`), builtin returns (`return close[n]`), and param returns (`return src[len]`). Enum and UDT-field returns unchanged.
- **Fractional history offsets**: History offsets must resolve to integer bars. **`Series.get`** / **`Context.get`** now truncate the combined lookback toward zero when non-integer (e.g. `src[depth/2]` before int-division rewrite yields `5.5` in JS) — boundary safety net alongside the transpiler fix.
- **Drawing plot serialization O(n²)**: Every create/mutate re-serialized the entire backing array; deleted objects were only flagged, never removed, so scans grew **O(bars × objects)** → quadratic overall. Removed redundant per-object **`syncToPlot()`** calls on create/mutate (per-bar sync already captures final state; rollback sync kept). **`syncToPlot()`** now compacts deleted objects out of the array in all drawing helpers (`line`, `label`, `box`, `polyline`, `linefill`, `table`) → linear scans. Emitted plot output unchanged; ~12–16× faster on drawing-heavy scripts at 800–1600 bars.
