### PR TITLE
[0.9.29] - 2026-07-11 - Heikin Ashi Chart Type & Extended Tickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [0.9.29] - 2026-07-11 - Heikin Ashi Chart Type & Extended Tickers
+
+### Added
+
+- **Extended tickers — THE CHART TYPE IS THE TICKER**: a host runs a Heikin Ashi chart by constructing PineTS with an extended ticker — `new PineTS(source, 'BTCUSDT;heikinashi', 'D', …)`. The chart type is a `";modifier"` suffix on the ticker id (the single source of truth; there is no separate setting), from which everything derives: `chart.is_heikinashi` / `chart.is_standard`, the `syminfo.tickerid` suffix (`"BINANCE:BTCUSDT;heikinashi"`; `syminfo.ticker` stays clean), and `request.security` routing. **PineTS never transforms bars** — the modifier is a routing marker: a data source that owns the transform (an embedding host) serves derived bars for the extended ticker and raw bars for the plain one; bundled providers (Binance/Alpaca/FMP/Mock) strip the modifier at their boundary (`BaseProvider.getMarketData` + each `getSymbolInfo`) and always serve standard candles.
+- **`src/tickerModifier.ts`** (exported): `splitTickerModifier` / `stripTickerModifier` / `withTickerModifier` — the extended-ticker parser (recognized modifiers: `heikinashi`, `standard`; unknown suffixes stay part of the symbol).
+- **`ticker.heikinashi()`** now returns the extended ticker (`"sym;heikinashi"`, idempotent) instead of the plain symbol; **`ticker.standard()`** strips the chart-type modifier (the standard-data opt-out); **`ticker.inherit()`** propagates the chart-type modifier from `from_tickerid` onto the new symbol.
+- **`request.security` / `request.security_lower_tf` chart-type routing**: extended tickers pass through to the data source untouched; the empty-string symbol resolves to the chart's own ticker *modifier included*; the same-timeframe shortcut is chart-type aware — on a Heikin Ashi chart `security(syminfo.tickerid, <chart tf>, …)` shortcuts to the chart's series while `security(ticker.standard(…), <chart tf>, …)` builds a secondary that fetches standard data (previously indistinguishable).
+- **Tests**: `tests/namespaces/heikinashi-chart-style.test.ts` — ticker-modifier helpers, `ticker.*` behavior, predicate derivation from the constructor ticker, provider-boundary stripping, chart-type-aware same-TF shortcut, and a real-Pine-source run locking the transpiler contract for bare `chart.is_*` access.
+
+### Changed
+
+- **`chart.is_standard` / `is_heikinashi` / `is_kagi` / `is_linebreak` / `is_pnf` / `is_range` / `is_renko` are now getters** on `pine.chart` (they are Pine *variables* — bare member access), matching the `left/right_visible_bar_time` pattern; `is_standard`/`is_heikinashi` now answer truthfully from the chart ticker (the rest remain always-`false` stubs). ⚠️ Breaking only for JS-style consumers that called them as functions (`chart.is_standard()`); transpiled Pine source is unaffected. Documented as Case #4b in `src/namespaces/README.md`.
+
+---
+
 ## [0.9.28] - 2026-07-07 - Integer Division & User-Function History Access
 
 ### Added

--- a/docs/api-coverage/chart.md
+++ b/docs/api-coverage/chart.md
@@ -15,15 +15,15 @@ parent: API Coverage
 
 ### Chart Type Detection
 
-| Function              | Status | Description                   |
-| --------------------- | ------ | ----------------------------- |
-| `chart.is_heikinashi` | ✅     | Check if Heikin Ashi chart    |
-| `chart.is_kagi`       | ✅     | Check if Kagi chart           |
-| `chart.is_linebreak`  | ✅     | Check if Line Break chart     |
-| `chart.is_pnf`        | ✅     | Check if Point & Figure chart |
-| `chart.is_range`      | ✅     | Check if Range chart          |
-| `chart.is_renko`      | ✅     | Check if Renko chart          |
-| `chart.is_standard`   | ✅     | Check if standard chart       |
+| Function              | Status | Description                                        |
+| --------------------- | ------ | -------------------------------------------------- |
+| `chart.is_heikinashi` | ✅     | True on a Heikin Ashi chart (see note below)       |
+| `chart.is_kagi`       | ⚠️     | Always `false` — chart type not representable      |
+| `chart.is_linebreak`  | ⚠️     | Always `false` — chart type not representable      |
+| `chart.is_pnf`        | ⚠️     | Always `false` — chart type not representable      |
+| `chart.is_range`      | ⚠️     | Always `false` — chart type not representable      |
+| `chart.is_renko`      | ⚠️     | Always `false` — chart type not representable      |
+| `chart.is_standard`   | ✅     | True unless the chart is a non-standard type       |
 
 ### Visible Range
 
@@ -52,4 +52,7 @@ parent: API Coverage
 
 ### Notes
 
+- **`is_heikinashi` / `is_standard` — THE CHART TYPE IS THE TICKER.** A host declares a Heikin Ashi chart by constructing PineTS with an **extended ticker**: `new PineTS(source, 'BTCUSDT;heikinashi', 'D', …)`. The chart type is derived from that ticker's `;heikinashi` modifier — there is no separate setting. On such a chart, `chart.is_heikinashi` is `true`, `chart.is_standard` is `false`, and `syminfo.tickerid` carries the modifier (so `request.security(syminfo.tickerid, …)` routes chart-typed data requests to the data source — see [Ticker](ticker.html)). **PineTS never transforms bars**: the data source of an extended ticker is expected to serve the chart-type view already (an embedding host that owns the transform, e.g. a charting library); PineTS' bundled providers strip the modifier and serve standard candles.
+- **`is_kagi` / `is_renko` / `is_linebreak` / `is_pnf` / `is_range`** — these chart types have no data source that can construct their bars, so the predicates are hardcoded `false`.
+- These predicates are Pine **variables** (bare member access, `chart.is_heikinashi` — no call), exposed as getters like the visible-range built-ins below.
 - **`left_visible_bar_time` / `right_visible_bar_time`** — In TradingView these reflect the user's UI viewport (what's scrolled into view). PineTS is renderer-agnostic, so by default they fall back to the first/last bar of the loaded `marketData` (i.e. "the full loaded range is the viewport"). Hosts that render PineTS output and want to model a true zoom/pan can override via `PineTS.setVisibleRange(left, right)`. Use `PineTS.usesVisibleRange()` to skip viewport-change re-runs for indicators that don't reference these built-ins; `PineTS.update(code)` is a smart re-run helper that gates on this tag automatically.

--- a/docs/api-coverage/request.md
+++ b/docs/api-coverage/request.md
@@ -20,3 +20,8 @@ parent: API Coverage
 | `request.quandl()`            |        | Request Quandl data          |
 | `request.seed()`              |        | Request seed data            |
 | `request.splits()`            |        | Request splits data          |
+
+### Notes
+
+- **Chart-type routing (extended tickers)** — the symbol argument may carry a chart-type modifier (`"BTCUSDT;heikinashi"`, built by `ticker.heikinashi()` or inherited from `syminfo.tickerid` on a Heikin Ashi chart; see [Ticker](ticker.html)). The modifier rides through to the data source untouched: a host data source that owns the transform serves derived bars; PineTS' bundled providers strip it and serve standard candles. An empty-string symbol (`""`) resolves to the chart's own ticker, **modifier included**.
+- **Same-timeframe shortcut is chart-type aware** — `request.security(sym, tf, expr)` with the chart's own symbol *and* timeframe evaluates the expression against the chart's series directly (no secondary context). "Same symbol" requires the chart-type modifier to match too: on a Heikin Ashi chart, `security(syminfo.tickerid, <chart tf>, close)` shortcuts to the chart's (Heikin Ashi) series, while `security(ticker.standard(syminfo.tickerid), <chart tf>, close)` builds a secondary context that fetches STANDARD data.

--- a/docs/api-coverage/syminfo.md
+++ b/docs/api-coverage/syminfo.md
@@ -19,7 +19,7 @@ Symbol information namespace providing metadata about the current trading symbol
 | `syminfo.prefix`           | ✅     | Exchange identifier (e.g., "BINANCE")                     |
 | `syminfo.root`             | ✅     | Base asset/root symbol (e.g., "BTC")                      |
 | `syminfo.ticker`           | ✅     | Symbol name (e.g., "BTCUSDT", "BTCUSDT.P")                |
-| `syminfo.tickerid`         | ✅     | Exchange:Symbol format (e.g., "BINANCE:BTCUSDT")          |
+| `syminfo.tickerid`         | ✅     | Exchange:Symbol format (e.g., "BINANCE:BTCUSDT"); carries the chart-type modifier on a non-standard chart (e.g., "BINANCE:BTCUSDT;heikinashi" — see note) |
 | `syminfo.type`             | ✅     | Instrument type ("crypto" or "futures")                   |
 | `syminfo.prefix()`         |        | Prefix function                                           |
 | `syminfo.ticker()`         |        | Ticker function                                           |
@@ -86,6 +86,10 @@ Symbol information namespace providing metadata about the current trading symbol
 | `syminfo.target_price_median`    | ✅     | Median price target (N/A for crypto, returns 0)  |
 
 ## Implementation Notes
+
+### Chart-Type Modifier in `tickerid`
+
+On a non-standard chart — declared by constructing PineTS with an extended ticker, e.g. `new PineTS(source, 'BTCUSDT;heikinashi', 'D', …)` — `syminfo.tickerid` carries the chart-type suffix (`"BINANCE:BTCUSDT;heikinashi"`), matching TradingView's behavior of encoding the chart type into the ticker id. `syminfo.ticker` stays clean. `ticker.standard(syminfo.tickerid)` strips the modifier; passing the modified `tickerid` to `request.security` routes a chart-typed data request to the data source (see [Ticker](ticker.html) and [Chart](chart.html)).
 
 ### Binance Provider
 

--- a/docs/api-coverage/ticker.md
+++ b/docs/api-coverage/ticker.md
@@ -22,5 +22,15 @@ parent: API Coverage
 
 ### Notes
 
+#### Extended tickers — the chart-type modifier
+
+Non-standard chart types travel **in the ticker id** as a `";modifier"` suffix (the *extended ticker*): `"BINANCE:BTCUSDT;heikinashi"`. This is PineTS' equivalent of TradingView's encoded chart-type ticker IDs, and it is the **single source of truth** for the chart type (see [Chart](chart.html)):
+
+- **`ticker.heikinashi(sym)`** → `"sym;heikinashi"` (idempotent). Passed to `request.security`, the extended ticker rides through to the data source: a host data source that owns the Heikin Ashi transform serves derived bars; PineTS' **bundled providers strip the modifier** and serve standard candles (standalone no-op — PineTS never synthesises bars).
+- **`ticker.standard(sym?)`** → strips any chart-type modifier. On a Heikin Ashi chart, `ticker.standard(syminfo.tickerid)` turns `"…;heikinashi"` back into the plain ticker, so the request fetches STANDARD candles (the opt-out).
+- **`ticker.inherit(from, sym)`** → propagates the chart-type modifier from `from` onto `sym` (`inherit(syminfo.tickerid, "ETHUSDT")` on an HA chart → `"ETHUSDT;heikinashi"`). Other modifier kinds (session, adjustment) are dropped, as before.
+
+#### Other notes
+
 - **`inherit`, `new`, `modify`, `standard`** — return ticker-ID strings that match TradingView's output exactly for the common "no extra modifiers" case (the dominant real-world usage). When non-default `adjustment` / `backadjustment` / `settlement_as_close` values are passed, TV emits an encoded `={"adjustment":"…","symbol":"…"}` form; PineTS returns the plain `prefix:ticker` since the underlying providers don't honour those modifiers anyway. Documented in [`src/namespaces/Ticker.ts`](../../src/namespaces/Ticker.ts).
-- **`heikinashi`, `renko`, `kagi`, `linebreak`, `pointfigure`** — accepted and chainable into `request.security` / `request.security_lower_tf` without errors, but they return the plain symbol rather than TV's encoded "alternative chart type" ticker ID. PineTS' data providers serve standard OHLCV candles only — non-standard bar-construction algorithms aren't synthesised, so requests resolve to standard data regardless of which `ticker.*` helper constructed the ID. Use `chart.is_*` to detect this and branch in scripts that depend on actual HA/Renko bars.
+- **`renko`, `kagi`, `linebreak`, `pointfigure`** — accepted and chainable into `request.security` / `request.security_lower_tf` without errors, but they return the plain symbol rather than an encoded "alternative chart type" ticker ID. No data source we route to can construct those bars, so requests resolve to standard data. Use `chart.is_*` to detect this and branch in scripts that depend on actual Renko/Kagi bars.

--- a/docs/data-providers.md
+++ b/docs/data-providers.md
@@ -418,6 +418,14 @@ Provider['MyProvider'] = new MyProvider();
 // Now available as Provider.MyProvider
 ```
 
+### Chart-Type Modifiers (Extended Tickers)
+
+A ticker may carry a chart-type modifier suffix — `"BTCUSDT;heikinashi"` (see [Non-Standard Chart Types](initialization-and-usage.html#non-standard-chart-types-heikin-ashi)). The contract at the provider boundary:
+
+-   **Providers extending `BaseProvider`** never see the modifier in `getMarketData()` — the base class strips it, because a venue API serves standard candles only. Strip it likewise at the top of your `getSymbolInfo()` (all bundled providers do): `tickerId = stripTickerModifier(tickerId)` (exported from `pinets`).
+-   **A source that OWNS a chart-type transform** (typically an embedding host implementing `IProvider` directly, not via `BaseProvider`) receives the extended ticker verbatim and must serve the derived bars for `"SYM;heikinashi"` and raw bars for `"SYM"` — the modifier is the only thing distinguishing the two requests.
+-   **PineTS itself never transforms bars** — the modifier is routing metadata, end to end.
+
 ---
 
 ## Timeframe Reference

--- a/docs/initialization-and-usage.md
+++ b/docs/initialization-and-usage.md
@@ -18,6 +18,7 @@ This guide explains how to initialize PineTS and run indicators or strategies wi
 -   [The stream() Method](#the-stream-method)
 -   [The update() Method](#the-update-method)
 -   [Host Environment (Visible Range)](#host-environment-visible-range)
+-   [Non-Standard Chart Types (Heikin Ashi)](#non-standard-chart-types-heikin-ashi)
 -   [Context Object](#context-object)
 -   [Return Values](#return-values)
 -   [Alerts](#alerts)
@@ -487,6 +488,29 @@ case).
 `stream()` already handles continuous data input. Combining `stream()`
 with `setVisibleRange()` is a planned follow-up — for the batch path,
 use `run()` / `update()`.
+
+---
+
+## Non-Standard Chart Types (Heikin Ashi)
+
+**The chart type is the ticker.** To run a script "on a Heikin Ashi chart", construct PineTS with an **extended ticker** — the plain symbol plus a chart-type modifier suffix:
+
+```javascript
+const pineTS = new PineTS(myHaAwareSource, 'BTCUSDT;heikinashi', 'D', 500);
+```
+
+Everything derives from that one setting:
+
+-   `chart.is_heikinashi` is `true` (and `chart.is_standard` is `false`);
+-   `syminfo.tickerid` carries the modifier (`"BINANCE:BTCUSDT;heikinashi"`), while `syminfo.ticker` stays clean;
+-   `request.security(syminfo.tickerid, tf, expr)` requests **chart-typed** data from the data source, and `request.security(ticker.standard(syminfo.tickerid), tf, expr)` explicitly requests **standard** data — including at the chart's own timeframe.
+
+**PineTS never transforms bars.** The extended ticker is a *routing marker*, not a conversion request:
+
+-   A **host data source that owns the transform** (e.g. a charting library embedding PineTS and serving Heikin Ashi views) receives the extended ticker verbatim from `getMarketData()` / `getSymbolInfo()` and must serve the derived bars for it — and raw bars for the plain symbol.
+-   PineTS' **bundled providers** (Binance, Alpaca, FMP, Mock) strip the modifier at their boundary and always serve standard candles — so on a bundled provider the extended ticker is a documented no-op (the chart *reports* Heikin Ashi but runs on standard data).
+
+Consequently, a consistent standalone Heikin Ashi run requires a data source that distinguishes `"SYM;heikinashi"` from `"SYM"`. Renko / Kagi / Line Break / Point & Figure have no such source and remain unsupported (`chart.is_renko` etc. are always `false`; `ticker.renko()` etc. return the plain symbol).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pinets",
-    "version": "0.9.5",
+    "version": "0.9.29",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pinets",
-            "version": "0.9.5",
+            "version": "0.9.29",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "acorn": "^8.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.28",
+    "version": "0.9.29",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -50,6 +50,7 @@ export class Context {
     public strategy?: StrategyState; // State for strategy calculations
     public isSecondaryContext: boolean = false; // Flag to prevent infinite recursion in request.security
     public chartTimezone: string | null = null; // Chart display timezone (affects log timestamps only, not computation)
+    public chartStyle: string = 'standard'; // Chart type DERIVED from the ticker's chart-type modifier ("SYM;heikinashi") at context init; read by chart.is_*
     public dataVersion: number = 0; // Incremented when market data changes (streaming mode)
 
     public __maxLoops: number = 500000;
@@ -307,13 +308,16 @@ export class Context {
             param: chartHelper.param.bind(chartHelper),
             bg_color: chartHelper.bg_color.bind(chartHelper),
             fg_color: chartHelper.fg_color.bind(chartHelper),
-            is_standard: chartHelper.is_standard.bind(chartHelper),
-            is_heikinashi: chartHelper.is_heikinashi.bind(chartHelper),
-            is_kagi: chartHelper.is_kagi.bind(chartHelper),
-            is_linebreak: chartHelper.is_linebreak.bind(chartHelper),
-            is_pnf: chartHelper.is_pnf.bind(chartHelper),
-            is_range: chartHelper.is_range.bind(chartHelper),
-            is_renko: chartHelper.is_renko.bind(chartHelper),
+            // Chart-type predicates are Pine VARIABLES (`chart.is_heikinashi`, no call) —
+            // exposed as getters so bare member access yields the boolean, like the
+            // visible-range built-ins below.
+            get is_standard() { return chartHelper.is_standard(); },
+            get is_heikinashi() { return chartHelper.is_heikinashi(); },
+            get is_kagi() { return chartHelper.is_kagi(); },
+            get is_linebreak() { return chartHelper.is_linebreak(); },
+            get is_pnf() { return chartHelper.is_pnf(); },
+            get is_range() { return chartHelper.is_range(); },
+            get is_renko() { return chartHelper.is_renko(); },
             point: chartHelper.point,
             // Visible-range built-ins. Host (e.g. chart UI) overrides via
             // PineTS.setVisibleRange(); fallback is the loaded data range.

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Alaa-eddine KADDOURI
 import { IProvider, ISymbolInfo } from './marketData/IProvider';
 import { Context } from './Context.class';
+import { splitTickerModifier, withTickerModifier } from './tickerModifier';
 import { Series } from './Series';
 import { Indicator } from './Indicator';
 import { processStrategyOrders, processExitOrders, processMarginCall, finalizeStrategyBar, finalizeStrategyRun, isAdverseFirstBar, applyPendingCloseMarginCall } from './namespaces/strategy/utils';
@@ -1066,6 +1067,22 @@ export class PineTS {
         });
 
         context.pine.syminfo = this._syminfo;
+        // THE CHART TYPE IS THE TICKER (single source of truth): a non-standard chart is
+        // addressed by an extended ticker — `new PineTS(source, "SYM;heikinashi", …)` — so
+        // the data source can distinguish the chart series from standard-data requests.
+        // Everything else derives from that modifier here: `context.chartStyle` (behind
+        // `chart.is_*`) and the `syminfo.tickerid` suffix (a CLONE — the provider's cached
+        // syminfo object, which is always modifier-free since providers strip, must stay
+        // untouched). PineTS never transforms bars: the source of an extended ticker is
+        // expected to serve the chart-type view already.
+        const chartModifier = splitTickerModifier(String(this.tickerId ?? '')).modifier;
+        context.chartStyle = chartModifier === 'heikinashi' ? 'heikinashi' : 'standard';
+        if (this._syminfo && chartModifier === 'heikinashi') {
+            context.pine.syminfo = {
+                ...this._syminfo,
+                tickerid: withTickerModifier(String(this._syminfo.tickerid ?? this.tickerId), 'heikinashi'),
+            };
+        }
         // Chart timezone only affects display formatting (log timestamps).
         // It does NOT override syminfo.timezone, which drives computation
         // (timestamp(), hour, dayofmonth, time_tradingday, etc.).

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export type { Kline, PeriodType } from './marketData/types';
 export { computeNextPeriodStart, localTimeToUTC, computeSessionClose, TIMEFRAME_SECONDS, TIMEFRAME_PERIOD_INFO } from './marketData/types';
 export { aggregateCandles, selectSubTimeframe, getAggregationRatio } from './marketData/aggregation';
 
+export { splitTickerModifier, stripTickerModifier, withTickerModifier } from './tickerModifier';
+
 export { PineTS, Context, Provider, Indicator, PineRuntimeError };
 export type { IPineInput, IPineProp, PineInputType, PineInputDisplay, PinePropType, PreparedScript } from './Indicator';
 export { INDICATOR_PROPS, STRATEGY_PROPS, propsForDeclaration } from './Indicator';

--- a/src/marketData/Alpaca/AlpacaProvider.class.ts
+++ b/src/marketData/Alpaca/AlpacaProvider.class.ts
@@ -2,6 +2,7 @@
 
 import { ISymbolInfo, ApiKeyProviderConfig } from '@pinets/marketData/IProvider';
 import { BaseProvider } from '@pinets/marketData/BaseProvider';
+import { stripTickerModifier } from '../../tickerModifier';
 import { Kline, PeriodType, computeNextPeriodStart, localTimeToUTC } from '@pinets/marketData/types';
 
 // ── Constants ────────────────────────────────────────────────────────────
@@ -341,6 +342,7 @@ export class AlpacaProvider extends BaseProvider<AlpacaProviderConfig> {
 
     async getSymbolInfo(tickerId: string): Promise<ISymbolInfo> {
         this.ensureConfigured();
+        tickerId = stripTickerModifier(tickerId); // chart-type modifiers never reach the venue API
 
         try {
             const asset = await this._fetchAsset(tickerId);

--- a/src/marketData/BaseProvider.ts
+++ b/src/marketData/BaseProvider.ts
@@ -3,6 +3,7 @@
 import { IProvider, ISymbolInfo, BaseProviderConfig } from './IProvider';
 import { Kline, normalizeCloseTime } from './types';
 import { selectSubTimeframe, aggregateCandles, getAggregationRatio } from './aggregation';
+import { stripTickerModifier } from '../tickerModifier';
 
 /**
  * Normalize a user-supplied timeframe key to the canonical form used
@@ -153,6 +154,10 @@ export abstract class BaseProvider<TConfig extends BaseProviderConfig = BaseProv
         sDate?: number,
         eDate?: number,
     ): Promise<Kline[]> {
+        // Extended-ticker chart-type modifiers (";heikinashi") are honored only by data
+        // sources that own the transform; bundled providers serve STANDARD candles, so the
+        // modifier is stripped here — the venue APIs must never see it.
+        tickerId = stripTickerModifier(tickerId);
         const normalizedTf = normalizeTimeframeKey(timeframe);
         const supported = this.getSupportedTimeframes();
 

--- a/src/marketData/Binance/BinanceProvider.class.ts
+++ b/src/marketData/Binance/BinanceProvider.class.ts
@@ -25,6 +25,7 @@ const timeframe_to_binance = {
 
 import { ISymbolInfo } from '@pinets/marketData/IProvider';
 import { BaseProvider } from '@pinets/marketData/BaseProvider';
+import { stripTickerModifier } from '../../tickerModifier';
 import { Kline, INTERVAL_DURATION_MS } from '@pinets/marketData/types';
 
 interface CacheEntry<T> {
@@ -346,6 +347,7 @@ export class BinanceProvider extends BaseProvider<BinanceProviderConfig> {
     }
 
     async getSymbolInfo(tickerId: string): Promise<ISymbolInfo> {
+        tickerId = stripTickerModifier(tickerId); // chart-type modifiers never reach the venue API
         try {
             // tickerId comes in as "BTCUSDT" or "BTCUSDT.P"
             // We keep it EXACTLY as is for ticker field (Pine Script includes .P)

--- a/src/marketData/FMP/FMPProvider.class.ts
+++ b/src/marketData/FMP/FMPProvider.class.ts
@@ -2,6 +2,7 @@
 
 import { ISymbolInfo, ApiKeyProviderConfig } from '@pinets/marketData/IProvider';
 import { BaseProvider } from '@pinets/marketData/BaseProvider';
+import { stripTickerModifier } from '../../tickerModifier';
 import { Kline, PeriodType, computeNextPeriodStart, computeSessionClose } from '@pinets/marketData/types';
 
 // ── Constants ────────────────────────────────────────────────────────────
@@ -402,6 +403,7 @@ export class FMPProvider extends BaseProvider<FMPProviderConfig> {
 
     async getSymbolInfo(tickerId: string): Promise<ISymbolInfo> {
         this.ensureConfigured();
+        tickerId = stripTickerModifier(tickerId); // chart-type modifiers never reach the venue API
 
         // Return cached symbolInfo if available
         if (this._symbolInfoCache.has(tickerId)) {

--- a/src/marketData/Mock/MockProvider.class.ts
+++ b/src/marketData/Mock/MockProvider.class.ts
@@ -2,6 +2,7 @@
 
 import { ISymbolInfo } from '@pinets/marketData/IProvider';
 import { BaseProvider } from '@pinets/marketData/BaseProvider';
+import { stripTickerModifier } from '../../tickerModifier';
 import { Kline } from '@pinets/marketData/types';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -280,6 +281,7 @@ export class MockProvider extends BaseProvider<MockProviderConfig> {
      * @returns Promise<ISymbolInfo> - Symbol information
      */
     async getSymbolInfo(tickerId: string): Promise<ISymbolInfo> {
+        tickerId = stripTickerModifier(tickerId); // chart-type modifiers never reach a provider
         try {
             // tickerId comes in as "BTCUSDT" or "BTCUSDT.P"
             // We keep it EXACTLY as is for ticker field (Pine Script includes .P)

--- a/src/namespaces/README.md
+++ b/src/namespaces/README.md
@@ -297,7 +297,11 @@ This follows the same pattern as Case #2, ensuring consistent behavior across bo
 
 **Problem:** Some namespaces expose both methods and constants. For example, `math` exposes both functions and constants like `math.pi`.
 
-**Solution:** In this case we implement the constants as methods without params, because the transpiler converts namespace constants to function calls internally.
+There are **two implementations of this case**, depending on how the transpiler treats the namespace's member access:
+
+#### Case #4a — Auto-called namespaces (ta, math): constants as no-arg METHODS
+
+For namespaces whose property accesses the transpiler converts into function calls (see Case #1), constants are implemented as methods without params.
 
 For example:
 in order to handle the pine script `math.pi` we implement a method in the math namespace methods folder called pi
@@ -310,6 +314,23 @@ export function pi(context: any) {
     };
 }
 ```
+
+#### Case #4b — Member-access namespaces (chart, barstate, syminfo, timeframe): variables as GETTERS
+
+For the member-access family (the namespaces listed in `settings.ts` whose **non-computed member reads the transpiler leaves as plain property access** — see the note in Case #6), a Pine *variable* must be a **getter** on the wired namespace object, so bare access yields the value:
+
+```typescript
+// Context.class.ts — pine.chart wiring
+this.pine['chart'] = {
+    // Pine VARIABLES (`chart.is_heikinashi`, no call) → getters
+    get is_standard() { return chartHelper.is_standard(); },
+    get is_heikinashi() { return chartHelper.is_heikinashi(); },
+    get left_visible_bar_time() { /* ... */ },
+    // functions stay methods: chart.point.new(...), param(...)
+};
+```
+
+Implementing these as bound functions instead would make bare Pine access (`chart.is_heikinashi ? 1 : 0`) evaluate the function *object* — always truthy. Locked by a real-Pine-source test in `tests/namespaces/heikinashi-chart-style.test.ts`.
 
 ---
 

--- a/src/namespaces/Ticker.ts
+++ b/src/namespaces/Ticker.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Alaa-eddine KADDOURI
 
 import { Series } from '../Series';
+import { splitTickerModifier, stripTickerModifier, withTickerModifier } from '../tickerModifier';
 
 /**
  * Pine Script `ticker.*` namespace.
@@ -9,11 +10,17 @@ import { Series } from '../Series';
  * The methods here construct "ticker ID" strings that are passed to
  * `request.security` / `request.security_lower_tf` to fetch data for a
  * specific symbol — potentially with extra modifiers (session,
- * adjustment, non-standard chart type). PineTS' data providers serve
- * standard candles only; chart-type modifiers (Heikin-Ashi, Renko,
- * Kagi, Line Break, Point & Figure) are silently dropped at the
- * `request.security` boundary, since we can't render alternative
- * bar-construction algorithms from the raw OHLCV feed.
+ * adjustment, non-standard chart type).
+ *
+ * CHART-TYPE modifiers travel as an EXTENDED-TICKER suffix
+ * (`"BINANCE:BTCUSDT;heikinashi"` — see `tickerModifier.ts`):
+ * `ticker.heikinashi()` appends it, `ticker.standard()` strips it, and
+ * `request.security` passes it through to the data source untouched. An
+ * embedding host that owns the transform honors it; PineTS' own bundled
+ * providers serve standard candles only and strip it at their boundary
+ * (documented no-op for standalone use). The other non-standard types
+ * (Renko, Kagi, Line Break, Point & Figure) remain plain-symbol stubs —
+ * no data source we route to can construct those bars.
  *
  * For the plain "no-modifier" cases — which cover virtually every
  * real-world Pine script — the returned tickerid strings match
@@ -36,17 +43,20 @@ export class Ticker {
     }
 
     /**
-     * ticker.inherit(from_tickerid, symbol) → simple string
+     * ticker.inherit(from_tickerid, symbol) → string
      *
-     * Returns a ticker ID that uses `symbol` and inherits modifier
-     * settings (session, currency, adjustment, chart type) from
-     * `from_tickerid`. For data-fetching purposes the result is
-     * effectively `symbol` — modifiers can't be honored without a TV
-     * datafeed, and `symbol` is what `request.security` needs.
+     * Returns a ticker ID that uses `symbol` and inherits modifier settings from
+     * `from_tickerid`. The CHART-TYPE modifier is honored: inheriting from a
+     * `";heikinashi"` ticker (e.g. `syminfo.tickerid` on a Heikin-Ashi chart)
+     * yields `"symbol;heikinashi"`, so the derived request keeps the chart type.
+     * The other modifier kinds (session, currency, adjustment) can't be honored
+     * without a TV datafeed and are dropped, as before.
      */
     inherit(_from_tickerid: any, symbol: any): string {
-        const sym = this._coerce(symbol);
-        return sym;
+        const from = this._coerce(_from_tickerid);
+        const sym = stripTickerModifier(this._coerce(symbol));
+        const { modifier } = splitTickerModifier(from);
+        return modifier && modifier !== 'standard' ? withTickerModifier(sym, modifier) : sym;
     }
 
     /**
@@ -79,31 +89,31 @@ export class Ticker {
     /**
      * ticker.standard(symbol?) → simple string
      *
-     * Returns the symbol stripped of any non-standard chart-type
-     * modifiers. Since PineTS doesn't synthesise non-standard chart
-     * types in the first place, this is effectively a pass-through
-     * (the standard form IS what our providers serve). If `symbol` is
-     * undefined, falls back to `syminfo.tickerid`.
+     * Returns the symbol stripped of any chart-type modifier suffix —
+     * on a Heikin-Ashi chart, `ticker.standard(syminfo.tickerid)` turns
+     * `"BINANCE:BTCUSDT;heikinashi"` back into `"BINANCE:BTCUSDT"`, so a
+     * `request.security` call on the result fetches STANDARD candles.
+     * If `symbol` is undefined, falls back to `syminfo.tickerid`.
      */
     standard(symbol?: any): string {
         if (symbol === undefined || symbol === null) {
-            return this.context?.pine?.syminfo?.tickerid || this.context?.tickerId || '';
+            return stripTickerModifier(this.context?.pine?.syminfo?.tickerid || this.context?.tickerId || '');
         }
-        return this._coerce(symbol);
+        return stripTickerModifier(this._coerce(symbol));
     }
 
     /**
-     * ticker.heikinashi(symbol) → simple string
+     * ticker.heikinashi(symbol) → extended-ticker string
      *
-     * In TV this returns an encoded tickerid that instructs the
-     * datafeed to deliver Heikin-Ashi bars. PineTS' providers don't
-     * synthesise HA candles, so we return the plain symbol — downstream
-     * `request.security` fetches standard candles, NOT HA-transformed
-     * ones. Behavior diverges from TV when the script depends on the
-     * HA values matching TV's HA computation. Documented limitation.
+     * Returns the symbol with the Heikin-Ashi chart-type modifier
+     * appended (`"BINANCE:BTCUSDT;heikinashi"`). `request.security`
+     * passes it through to the data source: an embedding host that owns
+     * the Heikin-Ashi transform serves derived bars; PineTS' own bundled
+     * providers strip the modifier and serve standard candles (documented
+     * standalone limitation). Idempotent on already-modified tickers.
      */
     heikinashi(symbol: any): string {
-        return this._coerce(symbol);
+        return withTickerModifier(this._coerce(symbol), 'heikinashi');
     }
 
     /**

--- a/src/namespaces/chart/ChartHelper.ts
+++ b/src/namespaces/chart/ChartHelper.ts
@@ -58,11 +58,12 @@ export class ChartHelper {
     }
 
     is_standard(): boolean {
-        return true;
+        const style = this.context?.chartStyle;
+        return style == null || style === 'standard';
     }
 
     is_heikinashi(): boolean {
-        return false;
+        return this.context?.chartStyle === 'heikinashi';
     }
 
     is_kagi(): boolean {

--- a/src/namespaces/request/methods/security.ts
+++ b/src/namespaces/request/methods/security.ts
@@ -2,6 +2,7 @@
 
 import { PineTS } from '../../../PineTS.class';
 import { Series } from '../../../Series';
+import { splitTickerModifier, withTickerModifier } from '../../../tickerModifier';
 import { TIMEFRAMES, normalizeTimeframe } from '../utils/TIMEFRAMES';
 import { findSecContextIdx } from '../utils/findSecContextIdx';
 import { findLTFContextIdx } from '../utils/findLTFContextIdx';
@@ -126,9 +127,18 @@ export function security(context: any) {
         const lookaheadSlot = resolveSlotValue(parsed.lookahead);
 
         // Strip exchange prefix (e.g. "BINANCE:BTCUSDC" → "BTCUSDC") so the
-        // provider receives a clean ticker when creating a secondary context.
+        // provider receives a clean ticker when creating a secondary context. A
+        // chart-type modifier suffix (";heikinashi") is NOT stripped here — it rides
+        // through to the data source (an embedding host honors it; PineTS' own
+        // providers strip it at their boundary).
         const rawSymbol = symbolSlot instanceof Series ? symbolSlot.get(0) : symbolSlot;
-        // Empty string "" means "use chart's symbol" (Pine Script spec)
+        // THE CHART TYPE IS THE TICKER: on a non-standard chart the context's own ticker is
+        // extended ("SYM;heikinashi"), so the chart's modifier is parsed straight off it.
+        const ctxNoPrefix = typeof context.tickerId === 'string' && context.tickerId.includes(':') ? context.tickerId.split(':')[1] : context.tickerId;
+        const ctxParts = typeof ctxNoPrefix === 'string' ? splitTickerModifier(ctxNoPrefix) : { symbol: ctxNoPrefix, modifier: null };
+        const chartModifier = ctxParts.modifier === 'standard' ? null : ctxParts.modifier;
+        // Empty string "" means "use chart's symbol" (Pine Script spec) — i.e. the chart's own
+        // ticker, modifier included.
         const resolvedSymbol = rawSymbol === '' ? context.tickerId : rawSymbol;
         const _symbol = typeof resolvedSymbol === 'string' && resolvedSymbol.includes(':') ? resolvedSymbol.split(':')[1] : resolvedSymbol;
         const rawTimeframe = timeframeSlot instanceof Series ? timeframeSlot.get(0) : timeframeSlot;
@@ -174,10 +184,13 @@ export function security(context: any) {
         // expression verbatim (e.g. BTC close) for a request meant to fetch a
         // different ticker (e.g. ETH close). Fall through to the secondary-context
         // path (line ~280+) which builds a fresh PineTS instance for `_symbol`.
-        const ctxRawSymbol = typeof context.tickerId === 'string' && context.tickerId.includes(':')
-            ? context.tickerId.split(':')[1]
-            : context.tickerId;
-        const isSameSymbol = !_symbol || _symbol === '' || _symbol === ctxRawSymbol;
+        // "Same" is also CHART-TYPE aware: the chart's data is its chart-typed view,
+        // so on a Heikin-Ashi chart only "SYM;heikinashi" is the same series — a plain
+        // "SYM" (e.g. via ticker.standard()) must fetch STANDARD data through a
+        // secondary context, and vice versa on a standard chart.
+        const reqParts = typeof _symbol === 'string' ? splitTickerModifier(_symbol) : { symbol: _symbol, modifier: null };
+        const reqModifier = reqParts.modifier === 'standard' ? null : reqParts.modifier; // ";standard" ≡ no modifier
+        const isSameSymbol = !_symbol || _symbol === '' || (reqParts.symbol === ctxParts.symbol && reqModifier === chartModifier);
 
         if (ctxTimeframeIdx === reqTimeframeIdx && isSameSymbol) {
             // Resolve any helper objects (TimeComponentHelper, NAHelper, Series, etc.)

--- a/src/namespaces/request/methods/security_lower_tf.ts
+++ b/src/namespaces/request/methods/security_lower_tf.ts
@@ -287,7 +287,10 @@ export function security_lower_tf(context: any) {
         const expressionSlot = resolveSlotValue(parsed.expression);
 
         const rawSymbol = symbolSlot instanceof Series ? symbolSlot.get(0) : symbolSlot;
-        // Empty string "" means "use chart's symbol" (Pine Script spec)
+        // Empty string "" means "use chart's symbol" (Pine Script spec) — i.e. the chart's own
+        // ticker. THE CHART TYPE IS THE TICKER: on a non-standard chart it already carries the
+        // ";heikinashi" modifier, which rides through to the data source (PineTS' own providers
+        // strip it at their boundary).
         const resolvedSymbol = rawSymbol === '' ? context.tickerId : rawSymbol;
         const _symbol = typeof resolvedSymbol === 'string' && resolvedSymbol.includes(':') ? resolvedSymbol.split(':')[1] : resolvedSymbol;
         const rawTimeframe = timeframeSlot instanceof Series ? timeframeSlot.get(0) : timeframeSlot;

--- a/src/tickerModifier.ts
+++ b/src/tickerModifier.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Alaa-eddine KADDOURI
+
+/**
+ * EXTENDED-TICKER chart-type modifiers.
+ *
+ * A ticker id may carry a chart-type modifier as a `";modifier"` suffix —
+ * `"BINANCE:BTCUSDT;heikinashi"`. THE CHART TYPE IS THE TICKER — the single
+ * source of truth: a host runs a non-standard chart by constructing PineTS
+ * with the extended ticker (`new PineTS(source, "SYM;heikinashi", …)`), and
+ * everything derives from it — `chart.is_heikinashi`, the `syminfo.tickerid`
+ * suffix, and `request.security` routing. In scripts, `ticker.heikinashi()`
+ * appends the modifier and `ticker.standard()` strips it.
+ *
+ * Division of labor: PineTS only ROUTES these strings — a `request.security`
+ * call passes the extended ticker through to the data source untouched, so an
+ * embedding host that owns the transform (e.g. a charting library serving
+ * Heikin-Ashi views) can honor it. PineTS' own bundled providers serve standard
+ * candles only and strip the modifier at their boundary (see BaseProvider /
+ * provider getSymbolInfo) — for them the modifier is a documented no-op.
+ */
+
+/** The modifier suffixes recognized as chart-type markers. */
+const KNOWN_MODIFIERS = new Set(['heikinashi', 'standard']);
+
+/** Split `"SYM;modifier"` into its parts. Plain symbols yield `modifier: null`. */
+export function splitTickerModifier(tickerId: string): { symbol: string; modifier: string | null } {
+    if (typeof tickerId !== 'string') return { symbol: tickerId, modifier: null };
+    const at = tickerId.lastIndexOf(';');
+    if (at <= 0 || at === tickerId.length - 1) return { symbol: tickerId, modifier: null };
+    const modifier = tickerId.slice(at + 1).toLowerCase();
+    if (!KNOWN_MODIFIERS.has(modifier)) return { symbol: tickerId, modifier: null };
+    return { symbol: tickerId.slice(0, at), modifier };
+}
+
+/** The plain symbol with any chart-type modifier removed. */
+export function stripTickerModifier(tickerId: string): string {
+    return splitTickerModifier(tickerId).symbol;
+}
+
+/** Append a chart-type modifier (replacing any existing one; idempotent). */
+export function withTickerModifier(tickerId: string, modifier: string): string {
+    return `${stripTickerModifier(tickerId)};${modifier}`;
+}

--- a/tests/namespaces/chart/chart.test.ts
+++ b/tests/namespaces/chart/chart.test.ts
@@ -119,11 +119,11 @@ describe('CHART Namespace', () => {
             expect(result.fgColor[0].length).toBeGreaterThan(0);
         });
 
-        it('chart.is_standard() returns true', async () => {
+        it('chart.is_standard returns true (Pine variable — bare member access)', async () => {
             const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-11-20').getTime());
 
             const { result } = await pineTS.run((context) => {
-                var isStandard = chart.is_standard();
+                var isStandard = chart.is_standard;
                 return { isStandard };
             });
 

--- a/tests/namespaces/heikinashi-chart-style.test.ts
+++ b/tests/namespaces/heikinashi-chart-style.test.ts
@@ -1,0 +1,118 @@
+import { PineTS } from 'index';
+import { describe, expect, it } from 'vitest';
+
+import { Provider } from '@pinets/marketData/Provider.class';
+import { splitTickerModifier, stripTickerModifier, withTickerModifier } from '../../src/tickerModifier';
+
+const RANGE = [new Date('2025-01-01').getTime(), new Date('2025-03-01').getTime()] as const;
+
+describe('Heikin-Ashi chart style (extended tickers + chartStyle)', () => {
+    it('tickerModifier helpers split/strip/append the chart-type suffix', () => {
+        expect(splitTickerModifier('BINANCE:BTCUSDT;heikinashi')).toEqual({ symbol: 'BINANCE:BTCUSDT', modifier: 'heikinashi' });
+        expect(splitTickerModifier('BINANCE:BTCUSDT')).toEqual({ symbol: 'BINANCE:BTCUSDT', modifier: null });
+        expect(splitTickerModifier('BTCUSDT;unknownthing')).toEqual({ symbol: 'BTCUSDT;unknownthing', modifier: null }); // unknown suffixes stay part of the symbol
+        expect(stripTickerModifier('BTCUSDT;heikinashi')).toBe('BTCUSDT');
+        expect(withTickerModifier('BTCUSDT', 'heikinashi')).toBe('BTCUSDT;heikinashi');
+        expect(withTickerModifier('BTCUSDT;heikinashi', 'heikinashi')).toBe('BTCUSDT;heikinashi'); // idempotent
+    });
+
+    it('ticker.heikinashi() appends the modifier; ticker.standard() strips it; ticker.inherit() propagates it', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, RANGE[0], RANGE[1]);
+        const { result } = await pineTS.run((context) => {
+            const ha = ticker.heikinashi(syminfo.tickerid);
+            const std = ticker.standard(ha);
+            const stdNoArg = ticker.standard();
+            const inheritHa = ticker.inherit(ha, 'BINANCE:ETHUSDT');
+            const inheritStd = ticker.inherit(std, 'BINANCE:ETHUSDT');
+            return { ha, std, stdNoArg, inheritHa, inheritStd };
+        });
+        expect(result.ha[0]).toBe('BINANCE:BTCUSDC;heikinashi');
+        expect(result.std[0]).toBe('BINANCE:BTCUSDC');
+        expect(result.stdNoArg[0]).toBe('BINANCE:BTCUSDC');
+        expect(result.inheritHa[0]).toBe('BINANCE:ETHUSDT;heikinashi'); // chart type inherited
+        expect(result.inheritStd[0]).toBe('BINANCE:ETHUSDT');
+    });
+
+    it('default chart: is_standard true, is_heikinashi false, tickerid clean', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, RANGE[0], RANGE[1]);
+        const { result } = await pineTS.run((context) => {
+            const isStd = chart.is_standard; // Pine variables — bare member access
+            const isHa = chart.is_heikinashi;
+            const tid = syminfo.tickerid;
+            return { isStd, isHa, tid };
+        });
+        expect(result.isStd[0]).toBe(true);
+        expect(result.isHa[0]).toBe(false);
+        expect(result.tid[0]).toBe('BINANCE:BTCUSDC');
+    });
+
+    it('an extended constructor ticker IS the chart type: predicates flip and syminfo.tickerid gains the suffix', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC;heikinashi', 'D', null, RANGE[0], RANGE[1]);
+        const { result } = await pineTS.run((context) => {
+            const isStd = chart.is_standard; // Pine variables — bare member access
+            const isHa = chart.is_heikinashi;
+            const tid = syminfo.tickerid;
+            const std = ticker.standard(); // strips the modifier back off
+            return { isStd, isHa, tid, std };
+        });
+        expect(result.isStd[0]).toBe(false);
+        expect(result.isHa[0]).toBe(true);
+        expect(result.tid[0]).toBe('BINANCE:BTCUSDC;heikinashi');
+        expect(result.std[0]).toBe('BINANCE:BTCUSDC');
+    });
+
+    it('REAL Pine source: bare chart.is_* member access resolves as a VARIABLE through the transpiler', async () => {
+        // Locks the transpiler contract the getters rely on: non-computed `chart.*` member
+        // access is a plain property read (like syminfo.tickerid / barstate.islast), NOT
+        // auto-converted to a call (the ta.tr / math.pi constant treatment).
+        const src = `//@version=5
+indicator("probe")
+v1 = chart.is_heikinashi ? 1 : 0
+v2 = chart.is_standard ? 1 : 0
+plot(v1, "v1")
+plot(v2, "v2")
+`;
+        const onHa = new PineTS(Provider.Mock, 'BTCUSDC;heikinashi', 'D', null, RANGE[0], RANGE[1]);
+        const haCtx: any = await onHa.run(src);
+        const last = (ctx: any, k: string): number => {
+            const d = ctx.plots[k].data;
+            return d[d.length - 1].value;
+        };
+        expect(last(haCtx, 'v1')).toBe(1);
+        expect(last(haCtx, 'v2')).toBe(0);
+
+        const onStd = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, RANGE[0], RANGE[1]);
+        const stdCtx: any = await onStd.run(src);
+        expect(last(stdCtx, 'v1')).toBe(0);
+        expect(last(stdCtx, 'v2')).toBe(1);
+    });
+
+    it('a bundled provider strips the modifier: security on an extended ticker still serves data', async () => {
+        // The Mock provider must never see ";heikinashi" — the strip at the provider
+        // boundary means the request degrades to standard candles instead of failing.
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, RANGE[0], RANGE[1]);
+        const { result } = await pineTS.run((context) => {
+            const haClose = request.security(ticker.heikinashi(syminfo.tickerid), 'W', close);
+            const stdClose = request.security(ticker.standard(syminfo.tickerid), 'W', close);
+            return { haClose, stdClose };
+        });
+        // Standalone: both resolve to the SAME standard weekly closes (documented no-op).
+        expect(result.haClose[0]).toBe(result.stdClose[0]);
+        expect(Number.isFinite(result.haClose[0])).toBe(true);
+    });
+
+    it('same-tf shortcut is chart-type aware: standard request on a heikinashi chart builds a secondary', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC;heikinashi', 'D', null, RANGE[0], RANGE[1]);
+        const { result } = await pineTS.run((context) => {
+            // Same timeframe as the chart, EXPLICITLY standard: must not shortcut to the
+            // chart's own (chart-typed) series. With the Mock provider both end up serving
+            // the same standard data, so equality here just proves the call resolves.
+            const viaStd = request.security(ticker.standard(syminfo.tickerid), 'D', close);
+            // Same timeframe, chart's own tickerid (modifier included): shortcut path.
+            const viaSelf = request.security(syminfo.tickerid, 'D', close);
+            return { viaStd, viaSelf };
+        });
+        expect(Number.isFinite(result.viaStd[0])).toBe(true);
+        expect(Number.isFinite(result.viaSelf[0])).toBe(true);
+    });
+});


### PR DESCRIPTION
### Added

- **Extended tickers — THE CHART TYPE IS THE TICKER**: a host runs a Heikin Ashi chart by constructing PineTS with an extended ticker — `new PineTS(source, 'BTCUSDT;heikinashi', 'D', …)`. The chart type is a `";modifier"` suffix on the ticker id (the single source of truth; there is no separate setting), from which everything derives: `chart.is_heikinashi` / `chart.is_standard`, the `syminfo.tickerid` suffix (`"BINANCE:BTCUSDT;heikinashi"`; `syminfo.ticker` stays clean), and `request.security` routing. **PineTS never transforms bars** — the modifier is a routing marker: a data source that owns the transform (an embedding host) serves derived bars for the extended ticker and raw bars for the plain one; bundled providers (Binance/Alpaca/FMP/Mock) strip the modifier at their boundary (`BaseProvider.getMarketData` + each `getSymbolInfo`) and always serve standard candles.
- **`src/tickerModifier.ts`** (exported): `splitTickerModifier` / `stripTickerModifier` / `withTickerModifier` — the extended-ticker parser (recognized modifiers: `heikinashi`, `standard`; unknown suffixes stay part of the symbol).
- **`ticker.heikinashi()`** now returns the extended ticker (`"sym;heikinashi"`, idempotent) instead of the plain symbol; **`ticker.standard()`** strips the chart-type modifier (the standard-data opt-out); **`ticker.inherit()`** propagates the chart-type modifier from `from_tickerid` onto the new symbol.
- **`request.security` / `request.security_lower_tf` chart-type routing**: extended tickers pass through to the data source untouched; the empty-string symbol resolves to the chart's own ticker *modifier included*; the same-timeframe shortcut is chart-type aware — on a Heikin Ashi chart `security(syminfo.tickerid, <chart tf>, …)` shortcuts to the chart's series while `security(ticker.standard(…), <chart tf>, …)` builds a secondary that fetches standard data (previously indistinguishable).
- **Tests**: `tests/namespaces/heikinashi-chart-style.test.ts` — ticker-modifier helpers, `ticker.*` behavior, predicate derivation from the constructor ticker, provider-boundary stripping, chart-type-aware same-TF shortcut, and a real-Pine-source run locking the transpiler contract for bare `chart.is_*` access.

### Changed

- **`chart.is_standard` / `is_heikinashi` / `is_kagi` / `is_linebreak` / `is_pnf` / `is_range` / `is_renko` are now getters** on `pine.chart` (they are Pine *variables* — bare member access), matching the `left/right_visible_bar_time` pattern; `is_standard`/`is_heikinashi` now answer truthfully from the chart ticker (the rest remain always-`false` stubs). ⚠️ Breaking only for JS-style consumers that called them as functions (`chart.is_standard()`); transpiled Pine source is unaffected. Documented as Case #4b in `src/namespaces/README.md`.