### PR TITLE
Dev to main

### DIFF
--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -25,4 +25,4 @@ For pricing, terms, and inquiries, Please [reach out](mailto:business@luxalgo.co
 
 ---
 
-_Copyright (c) 2025-present LuxAlgo_
+_Copyright (c) 2026-present LuxAlgo_

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ PineTS enables algorithmic traders, quant developers, and platforms to integrate
   <a href="./.github/badges/coverage.svg"><img src="./.github/badges/coverage.svg" alt="Coverage"></a>
   <a href="https://github.com/LuxAlgo/PineTS#api-coverage"><img src="./.github/badges/api-coverage.svg" alt="API Coverage"></a>
   <a href="https://luxalgo.github.io/PineTS/"><img src="https://img.shields.io/badge/docs-github--pages-blue?style=flat-square" alt="Documentation"></a>
+  <a href="https://github.com/wilsonfreitas/awesome-quant"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Quant" /></a>
 </p>
 
 <p align="center">
@@ -403,5 +404,6 @@ PineTS is dual-licensed:
 ---
 
 <p align="center">
-  <sub>Built with passion by <a href="https://www.luxalgo.com">LuxAlgo</a></sub>
+  <sub>Built with passion by <a href="https://www.luxalgo.com">LuxAlgo</a></sub><br>
+  <sub>Copyright (C) 2026-present LuxAlgo</sub>
 </p>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,15 +7,15 @@ description: Pine Script in TypeScript - Write trading indicators with TypeScrip
 show_downloads: true
 google_analytics:
 github:
-    repository_url: https://github.com/alaa-eddine/PineTS
+    repository_url: https://github.com/LuxAlgo/PineTS
 
 # Just the Docs specific settings
 color_scheme: dark
 aux_links:
     'PineTS on GitHub':
-        - 'https://github.com/alaa-eddine/PineTS'
+        - 'https://github.com/LuxAlgo/PineTS'
 heading_anchors: true
 nav_sort: case_sensitive
 back_to_top: true
 back_to_top_text: 'Back to top'
-footer_content: 'Created by <a href="https://github.com/alaa-eddine">Alaa-eddine KADDOURI</a> | Licensed under AGPL-3.0'
+footer_content: 'Copyright (C) 2026-present <a href="https://www.luxalgo.com">LuxAlgo</a> | Licensed under AGPL-3.0'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,4 +259,4 @@ After getting started, try exploring our demo indicators:
 - [WillVixFix Indicator](../indicators/willvixfix/index.html)
 - [Squeeze Momentum Indicator](../indicators/sqzmom/index.html)
 
-Or contribute to the project on [GitHub](https://github.com/alaa-eddine/PineTS)!
+Or contribute to the project on [GitHub](https://github.com/LuxAlgo/PineTS)!

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,4 +50,4 @@ Click [here](api-coverage.md) to check the implementation status of [Pine Script
 
 ---
 
-Created by [Alaa-eddine KADDOURI](https://github.com/alaa-eddine) | Licensed under AGPL-3.0
+Copyright (C) 2026-present [LuxAlgo](https://www.luxalgo.com) | Licensed under AGPL-3.0

--- a/docs/initialization-and-usage.md
+++ b/docs/initialization-and-usage.md
@@ -1018,4 +1018,4 @@ For full documentation including frequency constants, alert modes, and complete 
 -   Check [API Coverage](../api-coverage/) to see all available technical analysis functions
 -   Explore [Language Coverage](../lang-coverage/) to understand Pine Script compatibility
 -   Try our demo indicators: [WillVixFix](../indicators/willvixfix/index.html) and [Squeeze Momentum](../indicators/sqzmom/index.html)
--   Contribute on [GitHub](https://github.com/alaa-eddine/PineTS)
+-   Contribute on [GitHub](https://github.com/LuxAlgo/PineTS)

--- a/docs/strategy.md
+++ b/docs/strategy.md
@@ -121,7 +121,7 @@ await pine.run(($) => {
 
 After the call, `context.strategy.config` holds the merged options (defaults + your overrides) and the rest of `context.strategy` is initialized — see the [object reference below](#the-contextstrategy-object).
 
-**Supported options** (every field is `StrategyConfig` in [`PineTS/src/namespaces/strategy/types.ts`](https://github.com/alaa-eddine/PineTS/blob/main/src/namespaces/strategy/types.ts)):
+**Supported options** (every field is `StrategyConfig` in [`PineTS/src/namespaces/strategy/types.ts`](https://github.com/LuxAlgo/PineTS/blob/main/src/namespaces/strategy/types.ts)):
 
 | Field | Type | Default | Notes |
 |---|---|---|---|
@@ -150,7 +150,7 @@ PineTS implements the same order lifecycle as TradingView:
 2. **On bar N+1's open, the engine processes it** — fills it if market, or checks limit/stop conditions. Slippage and commissions are applied at fill time.
 3. **Position-mutating events** (open / close / reverse) are mirrored on the flat scalars (`position_size`, `position_avg_price`, `position_entry_name`).
 
-Internal lifecycle is handled by `processStrategyOrders()` and `processExitOrders()` in [`strategy/utils.ts`](https://github.com/alaa-eddine/PineTS/blob/main/src/namespaces/strategy/utils.ts), invoked at the start of every bar.
+Internal lifecycle is handled by `processStrategyOrders()` and `processExitOrders()` in [`strategy/utils.ts`](https://github.com/LuxAlgo/PineTS/blob/main/src/namespaces/strategy/utils.ts), invoked at the start of every bar.
 
 ### `strategy.order()`
 
@@ -247,7 +247,7 @@ if ($.idx === 1) {
 
 ## The `context.strategy` object
 
-After `strategy()` is declared, `context.strategy` exposes the live state — the same object every getter reads from. It's documented in [`StrategyState`](https://github.com/alaa-eddine/PineTS/blob/main/src/namespaces/strategy/types.ts):
+After `strategy()` is declared, `context.strategy` exposes the live state — the same object every getter reads from. It's documented in [`StrategyState`](https://github.com/LuxAlgo/PineTS/blob/main/src/namespaces/strategy/types.ts):
 
 ```typescript
 interface StrategyState {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "prepublishOnly": "npm run build:prod:all",
         "knip": "knip"
     },
-    "author": "Alaa-eddine KADDOURI",
+    "author": "LuxAlgo",
     "license": "AGPL-3.0-only",
     "dependencies": {
         "acorn": "^8.14.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 const LicenseHeader = `
 /* 
- * Copyright (C) 2025 Alaa-eddine KADDOURI
+ * Copyright (C) 2026 LuxAlgo
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { IProvider, ISymbolInfo } from './marketData/IProvider';
 import { PineArray } from './namespaces/array/array.index';

--- a/src/Indicator.ts
+++ b/src/Indicator.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 export { Indicator } from './Indicator/Indicator.class';
 export { INDICATOR_PROPS, STRATEGY_PROPS, propsForDeclaration } from './Indicator/propsSchema';

--- a/src/PineTS.class.ts
+++ b/src/PineTS.class.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 import { IProvider, ISymbolInfo } from './marketData/IProvider';
 import { Context } from './Context.class';
 import { splitTickerModifier, withTickerModifier } from './tickerModifier';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import PineTS from './PineTS.class';
 import { Context } from './Context.class';

--- a/src/namespaces/Ticker.ts
+++ b/src/namespaces/Ticker.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Series } from '../Series';
 import { splitTickerModifier, stripTickerModifier, withTickerModifier } from '../tickerModifier';

--- a/src/namespaces/silentInSecondary.ts
+++ b/src/namespaces/silentInSecondary.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * `@silentInSecondary` — method decorator.

--- a/src/namespaces/strategy/methods/account_currency.ts
+++ b/src/namespaces/strategy/methods/account_currency.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Account currency configured in the strategy() declaration's `currency=`.

--- a/src/namespaces/strategy/methods/any.ts
+++ b/src/namespaces/strategy/methods/any.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { parseStrategyOptions, initializeStrategy } from '../utils';
 

--- a/src/namespaces/strategy/methods/avg_losing_trade.ts
+++ b/src/namespaces/strategy/methods/avg_losing_trade.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Average loss across losing closed trades, returned as a POSITIVE number

--- a/src/namespaces/strategy/methods/avg_losing_trade_percent.ts
+++ b/src/namespaces/strategy/methods/avg_losing_trade_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Average per-trade loss (as a SIGNED negative percent) across losing

--- a/src/namespaces/strategy/methods/avg_trade.ts
+++ b/src/namespaces/strategy/methods/avg_trade.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Average profit/loss across all closed trades (post-commission).

--- a/src/namespaces/strategy/methods/avg_trade_percent.ts
+++ b/src/namespaces/strategy/methods/avg_trade_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Average per-trade return as a percent. Computed as the mean of each

--- a/src/namespaces/strategy/methods/avg_winning_trade.ts
+++ b/src/namespaces/strategy/methods/avg_winning_trade.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Average profit across winning closed trades. NaN when no winners yet.

--- a/src/namespaces/strategy/methods/avg_winning_trade_percent.ts
+++ b/src/namespaces/strategy/methods/avg_winning_trade_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Average per-trade return (as a percent) across winning closed trades.

--- a/src/namespaces/strategy/methods/cancel.ts
+++ b/src/namespaces/strategy/methods/cancel.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Order } from '../types';
 import { parseArgsForPineParams } from '../../utils';

--- a/src/namespaces/strategy/methods/cancel_all.ts
+++ b/src/namespaces/strategy/methods/cancel_all.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Order } from '../types';
 

--- a/src/namespaces/strategy/methods/cash.ts
+++ b/src/namespaces/strategy/methods/cash.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Constant for order sizing type: cash

--- a/src/namespaces/strategy/methods/closedtrades.ts
+++ b/src/namespaces/strategy/methods/closedtrades.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Trade } from '../types';
 

--- a/src/namespaces/strategy/methods/convert_to_account.ts
+++ b/src/namespaces/strategy/methods/convert_to_account.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Convert a value from the symbol's currency to the account currency.

--- a/src/namespaces/strategy/methods/convert_to_symbol.ts
+++ b/src/namespaces/strategy/methods/convert_to_symbol.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Inverse of convert_to_account: from account currency → symbol currency.

--- a/src/namespaces/strategy/methods/default_entry_qty.ts
+++ b/src/namespaces/strategy/methods/default_entry_qty.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { calculateOrderQty } from '../utils';
 

--- a/src/namespaces/strategy/methods/entry.ts
+++ b/src/namespaces/strategy/methods/entry.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { calculateOrderQty, parseDirection, wouldExceedPyramiding, roundToMintick } from '../utils';
 import { Order } from '../types';

--- a/src/namespaces/strategy/methods/equity.ts
+++ b/src/namespaces/strategy/methods/equity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Returns the current equity (initial_capital + netprofit + openprofit).

--- a/src/namespaces/strategy/methods/eventrades.ts
+++ b/src/namespaces/strategy/methods/eventrades.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** Count of breakeven (profit === 0) closed trades. Matches Pine's strategy.eventrades. */
 export function eventrades(context: any) {

--- a/src/namespaces/strategy/methods/exit.ts
+++ b/src/namespaces/strategy/methods/exit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Order } from '../types';
 import { Series } from '../../../Series';

--- a/src/namespaces/strategy/methods/fixed.ts
+++ b/src/namespaces/strategy/methods/fixed.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Constant for order sizing type: fixed

--- a/src/namespaces/strategy/methods/grossloss.ts
+++ b/src/namespaces/strategy/methods/grossloss.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Total currency value of all completed losing trades, as a POSITIVE number

--- a/src/namespaces/strategy/methods/grossloss_percent.ts
+++ b/src/namespaces/strategy/methods/grossloss_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * strategy.grossloss as a percent of initial capital.

--- a/src/namespaces/strategy/methods/grossprofit.ts
+++ b/src/namespaces/strategy/methods/grossprofit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Total currency value of all completed winning trades (post-commission).

--- a/src/namespaces/strategy/methods/grossprofit_percent.ts
+++ b/src/namespaces/strategy/methods/grossprofit_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * strategy.grossprofit as a percent of initial capital.

--- a/src/namespaces/strategy/methods/initial_capital.ts
+++ b/src/namespaces/strategy/methods/initial_capital.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** The initial capital configured on the strategy() declaration. Matches Pine's strategy.initial_capital. */
 export function initial_capital(context: any) {

--- a/src/namespaces/strategy/methods/long.ts
+++ b/src/namespaces/strategy/methods/long.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Constant representing long direction

--- a/src/namespaces/strategy/methods/losstrades.ts
+++ b/src/namespaces/strategy/methods/losstrades.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** Count of closed trades with profit < 0. Matches Pine's strategy.losstrades. */
 export function losstrades(context: any) {

--- a/src/namespaces/strategy/methods/margin_liquidation_price.ts
+++ b/src/namespaces/strategy/methods/margin_liquidation_price.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Price at which the current leveraged position would be force-liquidated.

--- a/src/namespaces/strategy/methods/max_contracts_held_all.ts
+++ b/src/namespaces/strategy/methods/max_contracts_held_all.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** Peak |position_size| seen across the run. Matches Pine's strategy.max_contracts_held_all. */
 export function max_contracts_held_all(context: any) {

--- a/src/namespaces/strategy/methods/max_contracts_held_long.ts
+++ b/src/namespaces/strategy/methods/max_contracts_held_long.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** Peak long-side position_size seen. Matches Pine's strategy.max_contracts_held_long. */
 export function max_contracts_held_long(context: any) {

--- a/src/namespaces/strategy/methods/max_contracts_held_short.ts
+++ b/src/namespaces/strategy/methods/max_contracts_held_short.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** Peak |short-side position_size| seen. Matches Pine's strategy.max_contracts_held_short. */
 export function max_contracts_held_short(context: any) {

--- a/src/namespaces/strategy/methods/max_drawdown.ts
+++ b/src/namespaces/strategy/methods/max_drawdown.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Maximum peak-to-trough equity drawdown over the whole run (currency).

--- a/src/namespaces/strategy/methods/max_drawdown_percent.ts
+++ b/src/namespaces/strategy/methods/max_drawdown_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Maximum drawdown percent. Pine's semantic is the RUNNING MAX of

--- a/src/namespaces/strategy/methods/max_runup.ts
+++ b/src/namespaces/strategy/methods/max_runup.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Maximum equity run-up over the whole run (currency).

--- a/src/namespaces/strategy/methods/max_runup_percent.ts
+++ b/src/namespaces/strategy/methods/max_runup_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Maximum equity run-up percent. Mirrors the `max_drawdown_percent`

--- a/src/namespaces/strategy/methods/netprofit.ts
+++ b/src/namespaces/strategy/methods/netprofit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Realized P&L summed across all closed trades.

--- a/src/namespaces/strategy/methods/netprofit_percent.ts
+++ b/src/namespaces/strategy/methods/netprofit_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Realized net profit expressed as a percent of initial capital.

--- a/src/namespaces/strategy/methods/openprofit.ts
+++ b/src/namespaces/strategy/methods/openprofit.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Unrealized P&L across all currently-open trades.

--- a/src/namespaces/strategy/methods/openprofit_percent.ts
+++ b/src/namespaces/strategy/methods/openprofit_percent.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Unrealized P&L expressed as a percent of initial capital.

--- a/src/namespaces/strategy/methods/opentrades.ts
+++ b/src/namespaces/strategy/methods/opentrades.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Trade } from '../types';
 

--- a/src/namespaces/strategy/methods/order.ts
+++ b/src/namespaces/strategy/methods/order.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { calculateOrderQty, parseDirection } from '../utils';
 import { Order } from '../types';

--- a/src/namespaces/strategy/methods/param.ts
+++ b/src/namespaces/strategy/methods/param.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Series } from '../../../Series';
 

--- a/src/namespaces/strategy/methods/percent_of_equity.ts
+++ b/src/namespaces/strategy/methods/percent_of_equity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Constant for order sizing type: percent_of_equity

--- a/src/namespaces/strategy/methods/position_avg_price.ts
+++ b/src/namespaces/strategy/methods/position_avg_price.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Weighted-average entry price of the current open position.

--- a/src/namespaces/strategy/methods/position_entry_name.ts
+++ b/src/namespaces/strategy/methods/position_entry_name.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Id string of the entry that initially opened the current position.

--- a/src/namespaces/strategy/methods/position_size.ts
+++ b/src/namespaces/strategy/methods/position_size.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Signed position size — positive for long, negative for short, 0 for flat.

--- a/src/namespaces/strategy/methods/risk.ts
+++ b/src/namespaces/strategy/methods/risk.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * `strategy.risk` is a nested namespace with 6 setter functions that

--- a/src/namespaces/strategy/methods/short.ts
+++ b/src/namespaces/strategy/methods/short.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Constant representing short direction

--- a/src/namespaces/strategy/methods/wintrades.ts
+++ b/src/namespaces/strategy/methods/wintrades.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /** Count of closed trades with profit > 0. Matches Pine's strategy.wintrades. */
 export function wintrades(context: any) {

--- a/src/namespaces/strategy/utils.ts
+++ b/src/namespaces/strategy/utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { Order, StrategyState, Trade } from './types';
 import { Series } from '../../Series';

--- a/src/tickerModifier.ts
+++ b/src/tickerModifier.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * EXTENDED-TICKER chart-type modifiers.

--- a/src/transpiler/analysis/AnalysisPass.ts
+++ b/src/transpiler/analysis/AnalysisPass.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
 import ScopeManager from './ScopeManager';

--- a/src/transpiler/analysis/ScopeManager.ts
+++ b/src/transpiler/analysis/ScopeManager.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * JavaScript global literals and objects that should never be treated as user variables

--- a/src/transpiler/index.ts
+++ b/src/transpiler/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * PineTS Transpiler

--- a/src/transpiler/pineToJS/ast.ts
+++ b/src/transpiler/pineToJS/ast.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 // AST Node Definitions for PineScript
 // These will be transformed to ESTree format

--- a/src/transpiler/pineToJS/codegen.ts
+++ b/src/transpiler/pineToJS/codegen.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 // JavaScript Code Generator for PineScript AST
 // Transforms ESTree-compatible AST into JavaScript code

--- a/src/transpiler/pineToJS/lexer.ts
+++ b/src/transpiler/pineToJS/lexer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 // PineScript Lexer with Indentation Tracking
 // Generates INDENT/DEDENT tokens like Python

--- a/src/transpiler/pineToJS/parser.ts
+++ b/src/transpiler/pineToJS/parser.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 // PineScript Parser with Proper Indentation Support
 // Uses INDENT/DEDENT tokens from lexer

--- a/src/transpiler/pineToJS/pineToJS.index.ts
+++ b/src/transpiler/pineToJS/pineToJS.index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 // PineScript to JavaScript Converter
 // Converts PineScript files to JavaScript using the parser and code generator

--- a/src/transpiler/pineToJS/tokens.ts
+++ b/src/transpiler/pineToJS/tokens.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 // Token types for PineScript lexer
 

--- a/src/transpiler/slicing/buildLtfSlices.ts
+++ b/src/transpiler/slicing/buildLtfSlices.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * LTF / HTF request slicing — Phases 1 + 2 + 3.

--- a/src/transpiler/transformers/ExpressionTransformer.ts
+++ b/src/transpiler/transformers/ExpressionTransformer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
 import ScopeManager from '../analysis/ScopeManager';

--- a/src/transpiler/transformers/InjectionTransformer.ts
+++ b/src/transpiler/transformers/InjectionTransformer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
 import { ASTFactory, CONTEXT_NAME } from '../utils/ASTFactory';

--- a/src/transpiler/transformers/MainTransformer.ts
+++ b/src/transpiler/transformers/MainTransformer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
 import ScopeManager from '../analysis/ScopeManager';

--- a/src/transpiler/transformers/NormalizationTransformer.ts
+++ b/src/transpiler/transformers/NormalizationTransformer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
 import { CONTEXT_NAME } from '../utils/ASTFactory';

--- a/src/transpiler/transformers/StatementTransformer.ts
+++ b/src/transpiler/transformers/StatementTransformer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as walk from 'acorn-walk';
 import ScopeManager from '../analysis/ScopeManager';

--- a/src/transpiler/transformers/WrapperTransformer.ts
+++ b/src/transpiler/transformers/WrapperTransformer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import * as acorn from 'acorn';
 import { generate } from 'astring';

--- a/src/transpiler/utils/ASTFactory.ts
+++ b/src/transpiler/utils/ASTFactory.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 export const CONTEXT_NAME = '$';
 

--- a/tests/Indicator/Indicator.test.ts
+++ b/tests/Indicator/Indicator.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect, vi } from 'vitest';
 import { Indicator } from '../../src/Indicator';

--- a/tests/core/last-bar-time.test.ts
+++ b/tests/core/last-bar-time.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: `last_bar_time` was implemented as

--- a/tests/namespaces/array-edge-cases.test.ts
+++ b/tests/namespaces/array-edge-cases.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/namespaces/array-mutations.test.ts
+++ b/tests/namespaces/array-mutations.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/namespaces/array/bounds-check.test.ts
+++ b/tests/namespaces/array/bounds-check.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Array.get Bounds Checking Tests

--- a/tests/namespaces/array/min-max.test.ts
+++ b/tests/namespaces/array/min-max.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../../src/PineTS.class';

--- a/tests/namespaces/barstate.test.ts
+++ b/tests/namespaces/barstate.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Barstate Namespace Tests

--- a/tests/namespaces/chart/visible-range.test.ts
+++ b/tests/namespaces/chart/visible-range.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Visible-range built-ins + setVisibleRange + update() + usesVisibleRange tag.

--- a/tests/namespaces/input-methods.test.ts
+++ b/tests/namespaces/input-methods.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/namespaces/input.test.ts
+++ b/tests/namespaces/input.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/namespaces/map/map-iteration.test.ts
+++ b/tests/namespaces/map/map-iteration.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: `for [k, v] in map` iterated 0 times even when the map

--- a/tests/namespaces/math-edge-cases.test.ts
+++ b/tests/namespaces/math-edge-cases.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/namespaces/matrix/matrix-advanced.test.ts
+++ b/tests/namespaces/matrix/matrix-advanced.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../../src/PineTS.class';

--- a/tests/namespaces/request-edge-cases.test.ts
+++ b/tests/namespaces/request-edge-cases.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/namespaces/request-htf-pre-phase4.test.ts
+++ b/tests/namespaces/request-htf-pre-phase4.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * `request.security` (HTF) regression tests — Phase 4 baseline.

--- a/tests/namespaces/request-htf-slicing.test.ts
+++ b/tests/namespaces/request-htf-slicing.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * `request.security` (HTF) slow-path slicing — Phase 4.

--- a/tests/namespaces/request-lower-tf-fast-path.test.ts
+++ b/tests/namespaces/request-lower-tf-fast-path.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: `request.security_lower_tf` used to spawn a full secondary

--- a/tests/namespaces/request-lower-tf-slicing.test.ts
+++ b/tests/namespaces/request-lower-tf-slicing.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * `request.security_lower_tf` slow-path slicing — Phases 1 + 2.

--- a/tests/namespaces/request-lower-tf-window.test.ts
+++ b/tests/namespaces/request-lower-tf-window.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: request.security_lower_tf used to subtract a flat 30-day

--- a/tests/namespaces/silent-in-secondary.test.ts
+++ b/tests/namespaces/silent-in-secondary.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: side-effect-only operations executed inside a secondary

--- a/tests/namespaces/str-format-patterns.test.ts
+++ b/tests/namespaces/str-format-patterns.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Str Namespace: Format Pattern Tests

--- a/tests/namespaces/strategy/basic.test.ts
+++ b/tests/namespaces/strategy/basic.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../../src/PineTS.class';

--- a/tests/transpiler/await-injection.test.ts
+++ b/tests/transpiler/await-injection.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { transpile } from '../../src/transpiler/index';

--- a/tests/transpiler/complex-expressions.test.ts
+++ b/tests/transpiler/complex-expressions.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/transpiler/error-handling.test.ts
+++ b/tests/transpiler/error-handling.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/transpiler/for-loop-namespace.test.ts
+++ b/tests/transpiler/for-loop-namespace.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * For Loop Test Condition: Namespace Method Call Tests

--- a/tests/transpiler/function-param-named-args.test.ts
+++ b/tests/transpiler/function-param-named-args.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Function Parameter in Named Arguments (ObjectExpression) Tests

--- a/tests/transpiler/function-scope-property-access.test.ts
+++ b/tests/transpiler/function-scope-property-access.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS, Provider } from 'index';

--- a/tests/transpiler/loop-series-wrapping.test.ts
+++ b/tests/transpiler/loop-series-wrapping.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Loop Series Variable $.get() Wrapping Tests

--- a/tests/transpiler/multiline-continuation.test.ts
+++ b/tests/transpiler/multiline-continuation.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: multi-line binary-operator continuation inside a function

--- a/tests/transpiler/not-and-fn-param.test.ts
+++ b/tests/transpiler/not-and-fn-param.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: `not paramA and not paramB` (and the equivalent `or`-form,

--- a/tests/transpiler/optional-chaining-get.test.ts
+++ b/tests/transpiler/optional-chaining-get.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS, Provider } from 'index';

--- a/tests/transpiler/param-history-callsite.test.ts
+++ b/tests/transpiler/param-history-callsite.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Regression: function-level `*.param(value, idx, 'pN')` calls used to

--- a/tests/transpiler/parser-fixes.test.ts
+++ b/tests/transpiler/parser-fixes.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Parser & Codegen Fixes Test Suite

--- a/tests/transpiler/pine-to-js.test.ts
+++ b/tests/transpiler/pine-to-js.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { pineToJS } from '../../src/transpiler/pineToJS/pineToJS.index';

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Pine Script to JavaScript Transpiler Test Suite

--- a/tests/transpiler/scope-edge-cases.test.ts
+++ b/tests/transpiler/scope-edge-cases.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/transpiler/switch.test.ts
+++ b/tests/transpiler/switch.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';

--- a/tests/transpiler/while-loop-hoisting.test.ts
+++ b/tests/transpiler/while-loop-hoisting.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * While Loop Test Condition Hoisting Tests

--- a/tests/transpiler/wrapper-callsite-state.test.ts
+++ b/tests/transpiler/wrapper-callsite-state.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2026 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 /**
  * Wrapper-callsite-state regression tests

--- a/tests/transpiler/wrapper-transformer.test.ts
+++ b/tests/transpiler/wrapper-transformer.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alaa-eddine KADDOURI
+// Copyright (C) 2026 LuxAlgo
 
 import { describe, it, expect } from 'vitest';
 import { wrapInContextFunction } from '../../src/transpiler/transformers/WrapperTransformer';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation, license text, and comment-only copyright updates; no changes to execution paths, transpiler logic, or dependencies.
> 
> **Overview**
> This PR updates **project ownership and branding** to LuxAlgo without changing runtime behavior, APIs, or build logic.
> 
> **Copyright and package metadata** — SPDX headers across `src/`, tests, and `rollup.config.js` now read `Copyright (C) 2026 LuxAlgo` (replacing the prior author line). `package.json` sets `author` to **LuxAlgo**, and `LICENSE-COMMERCIAL.md` uses a 2026-present LuxAlgo copyright.
> 
> **Docs and discovery** — GitHub Pages config (`docs/_config.yml`) and doc pages point repository and contribution links to **`LuxAlgo/PineTS`**. Footers attribute LuxAlgo instead of the previous maintainer. `docs/strategy.md` source links use the LuxAlgo repo path.
> 
> **README** — Adds an Awesome Quant badge and a LuxAlgo copyright line in the footer; contributor avatars still include the original author.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab483828e0c4681495f8549527db5657a22e91a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->