### PR TITLE
Fix: last_bar_index returned the current bar's index during the historical run

### DIFF
--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -226,6 +226,18 @@ export class Context {
                 return _this.data.bar_index;
             },
             get last_bar_index() {
+                // TV semantics: `last_bar_index` is the bar_index of the LAST
+                // bar of the chart's history — a CONSTANT across the whole
+                // historical run (it only grows when new realtime bars are
+                // appended). `bar_index` values are the raw indices into the
+                // full preloaded `marketData` array, so its last index is the
+                // constant we need. Falling back to the progressively-fed
+                // `data.close` window (current bar's index) is best-effort if
+                // marketData isn't available.
+                const md = _this.marketData;
+                if (Array.isArray(md) && md.length > 0) {
+                    return md.length - 1;
+                }
                 return _this.data.close.length - 1;
             },
             get last_bar_time() {

--- a/tests/core/last-bar-index.test.ts
+++ b/tests/core/last-bar-index.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+
+/**
+ * TV semantics: `last_bar_index` is the bar_index of the LAST bar of the
+ * chart's history — a CONSTANT across the whole historical run (it only
+ * grows when new realtime bars are appended). It must NOT track the
+ * current bar_index during the historical run.
+ *
+ * Regression guard for: `last_bar_index` returning `close.length - 1`
+ * (the progressively-fed window size), which made it equal bar_index on
+ * every bar, so `bar_index < last_bar_index` was never true.
+ */
+describe('last_bar_index', () => {
+    it('is constant across the historical run and equals the final bar_index', async () => {
+        const pineTS = new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            '60',
+            null,
+            new Date('2024-01-01').getTime(),
+            new Date('2024-01-10').getTime()
+        );
+
+        const { plots } = await pineTS.run(($) => {
+            const { plotchar, bar_index, last_bar_index } = $.pine;
+
+            const isNotLast = bar_index < last_bar_index ? 1 : 0;
+
+            plotchar(bar_index, 'bi');
+            plotchar(last_bar_index, 'lbi');
+            plotchar(isNotLast, 'isNotLast');
+
+            return { bar_index, last_bar_index };
+        });
+
+        const biData = plots['bi'].data;
+        const lbiData = plots['lbi'].data;
+        const isNotLastData = plots['isNotLast'].data;
+
+        const barCount = biData.length;
+        expect(barCount).toBeGreaterThan(2);
+
+        const finalBarIndex = biData[barCount - 1].value;
+        expect(finalBarIndex).toBe(barCount - 1);
+
+        // TV: last_bar_index plots the same value (the final bar's index) on EVERY bar.
+        for (let i = 0; i < barCount; i++) {
+            expect(lbiData[i].value, `last_bar_index at bar ${i}`).toBe(finalBarIndex);
+        }
+
+        // TV: bar_index < last_bar_index is true on all bars except the last one.
+        for (let i = 0; i < barCount - 1; i++) {
+            expect(isNotLastData[i].value, `bar_index < last_bar_index at bar ${i}`).toBe(1);
+        }
+        expect(isNotLastData[barCount - 1].value).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

- `last_bar_index` was computed as `data.close.length - 1` — the size of the progressively-fed series window — so during the historical run it always equaled the current `bar_index`. Conditions like `bar_index < last_bar_index` were never true, breaking any script that gates logic on distance from the chart's last bar (e.g. lookback-window volume accumulation rendering zero-width boxes).
- TradingView semantics: `last_bar_index` is the bar_index of the **last** bar of the chart's history — constant across the whole historical run, growing only when new realtime bars arrive.
- The getter in `Context.class.ts` now reads `marketData.length - 1` (the full preloaded array that `bar_index` values index into), mirroring the existing `last_bar_time` getter. Streaming still works: new candles are appended to the same array, so the value grows with realtime bars like on TV.

## Test plan

- [x] New regression test `tests/core/last-bar-index.test.ts`: asserts `last_bar_index` is constant on every bar, equals the final `bar_index`, and `bar_index < last_bar_index` is true on all bars except the last. Failed before the fix (returned the current bar's index), passes after.
- [x] Full suite (`npm test -- --run`): 1754 passed; the only failure is a pre-existing one in gitignored `tests/_local/` (missing `runtime` namespace), verified unrelated by re-running against the unfixed code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small getter fix plus a regression test; no auth, data, or architectural changes.
> 
> **Overview**
> Makes `last_bar_index` match TradingView: a **constant** last-history index for the whole historical run, not the current bar.
> 
> The getter previously used `data.close.length - 1` (the growing window), so it always equaled `bar_index` and `bar_index < last_bar_index` never held. It now uses `marketData.length - 1`, same pattern as `last_bar_time`, with the old window as fallback.
> 
> Adds a regression test that the value is constant, equals the final `bar_index`, and the inequality is true on every bar except the last.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2494f8749cfe85ea96864cfc4f00046541f90f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->