### PR TITLE
Fix time() session-spec parsing, add session namespace, expose timenow

### DIFF
--- a/docs/api-coverage/pinescript-v6/session.json
+++ b/docs/api-coverage/pinescript-v6/session.json
@@ -1,15 +1,15 @@
 {
   "Session Flags": {
-    "session.isfirstbar": false,
-    "session.isfirstbar_regular": false,
-    "session.islastbar": false,
-    "session.islastbar_regular": false,
-    "session.ismarket": false,
-    "session.ispostmarket": false,
-    "session.ispremarket": false
+    "session.isfirstbar": true,
+    "session.isfirstbar_regular": true,
+    "session.islastbar": true,
+    "session.islastbar_regular": true,
+    "session.ismarket": true,
+    "session.ispostmarket": true,
+    "session.ispremarket": true
   },
   "Session Constants": {
-    "session.extended": false,
-    "session.regular": false
+    "session.extended": true,
+    "session.regular": true
   }
 }

--- a/docs/api-coverage/session.md
+++ b/docs/api-coverage/session.md
@@ -10,17 +10,17 @@ parent: API Coverage
 
 | Function                     | Status | Description                  |
 | ---------------------------- | ------ | ---------------------------- |
-| `session.isfirstbar`         |        | First bar of session         |
-| `session.isfirstbar_regular` |        | First bar of regular session |
-| `session.islastbar`          |        | Last bar of session          |
-| `session.islastbar_regular`  |        | Last bar of regular session  |
-| `session.ismarket`           |        | Market session               |
-| `session.ispostmarket`       |        | Post-market session          |
-| `session.ispremarket`        |        | Pre-market session           |
+| `session.isfirstbar`         | ✅     | First bar of session         |
+| `session.isfirstbar_regular` | ✅     | First bar of regular session |
+| `session.islastbar`          | ✅     | Last bar of session          |
+| `session.islastbar_regular`  | ✅     | Last bar of regular session  |
+| `session.ismarket`           | ✅     | Market session               |
+| `session.ispostmarket`       | ✅     | Post-market session          |
+| `session.ispremarket`        | ✅     | Pre-market session           |
 
 ### Session Constants
 
 | Function           | Status | Description               |
 | ------------------ | ------ | ------------------------- |
-| `session.extended` |        | Extended session constant |
-| `session.regular`  |        | Regular session constant  |
+| `session.extended` | ✅     | Extended session constant |
+| `session.regular`  | ✅     | Regular session constant  |

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -6,6 +6,7 @@ import { PineArray } from './namespaces/array/array.index';
 import { PineMap } from './namespaces/map/map.index';
 import { PineMatrix } from './namespaces/matrix/matrix.index';
 import { Barstate } from './namespaces/Barstate';
+import { Session } from './namespaces/Session';
 import { Core, NAHelper, AlertHelper } from './namespaces/Core';
 import { PineColor } from './namespaces/color/PineColor';
 import { TimeHelper, TimeComponentHelper, EXTRACTORS, getDatePartsInTimezone } from './namespaces/Time';
@@ -222,6 +223,7 @@ export class Context {
             //FIXME : this is a temporary solution to get the barstate values,
             //we need to implement a better way to handle realtime states
             barstate: new Barstate(this),
+            session: new Session(this),
             get bar_index() {
                 return _this.data.bar_index;
             },

--- a/src/namespaces/Session.ts
+++ b/src/namespaces/Session.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { getDatePartsInTimezone } from './Time';
+
+/**
+ * Pine Script `session` namespace.
+ *
+ * Constants:
+ * - session.regular / session.extended — session-type strings for ticker.new()/ticker.modify().
+ *
+ * Variables:
+ * - session.isfirstbar / session.islastbar — first/last bar of the trading session.
+ * - session.isfirstbar_regular / session.islastbar_regular — same, for the regular session.
+ * - session.ismarket / session.ispremarket / session.ispostmarket — intra-session location.
+ *
+ * PineTS providers serve continuous (regular-session) data, and the reference
+ * providers are 24/7 crypto markets where a trading session is a calendar day
+ * in the exchange timezone. Session boundaries are therefore detected as
+ * trading-day changes between consecutive bars in `syminfo.timezone`. All bars
+ * belong to the market session, so `ismarket` is always true and the
+ * pre/post-market flags are always false.
+ */
+export class Session {
+    public readonly regular = 'regular';
+    public readonly extended = 'extended';
+
+    constructor(private context: any) {}
+
+    private get _timezone(): string {
+        return this.context.pine?.syminfo?.timezone || 'UTC';
+    }
+
+    /** Calendar-day key ("Y-M-D" in exchange timezone) of a bar's open time. */
+    private _dayKey(timestamp: number): string {
+        const parts = getDatePartsInTimezone(timestamp, this._timezone);
+        return `${parts.year}-${parts.month}-${parts.day}`;
+    }
+
+    public get isfirstbar(): boolean {
+        const idx = this.context.idx;
+        const md = this.context.marketData;
+        if (!Array.isArray(md) || !md[idx]) return false;
+        if (idx === 0) return true;
+        return this._dayKey(md[idx].openTime) !== this._dayKey(md[idx - 1].openTime);
+    }
+
+    public get islastbar(): boolean {
+        const idx = this.context.idx;
+        const md = this.context.marketData;
+        if (!Array.isArray(md) || !md[idx]) return false;
+        if (idx === md.length - 1) return true;
+        return this._dayKey(md[idx].openTime) !== this._dayKey(md[idx + 1].openTime);
+    }
+
+    public get isfirstbar_regular(): boolean {
+        return this.isfirstbar;
+    }
+
+    public get islastbar_regular(): boolean {
+        return this.islastbar;
+    }
+
+    public get ismarket(): boolean {
+        return true;
+    }
+
+    public get ispremarket(): boolean {
+        return false;
+    }
+
+    public get ispostmarket(): boolean {
+        return false;
+    }
+}

--- a/src/namespaces/Time.ts
+++ b/src/namespaces/Time.ts
@@ -2,6 +2,8 @@
 
 import { Series } from '../Series';
 import { parseArgsForPineParams } from './utils';
+import { parseSessionSpec, isInSessionSpec } from './sessionSpec';
+import { PineRuntimeError } from '../errors/PineRuntimeError';
 
 // ── Timeframe alignment utilities ───────────────────────────────────
 
@@ -271,33 +273,20 @@ export class TimeHelper {
     }
 
     /**
-     * Basic session check: parses "HHMM-HHMM" format and tests if
-     * the timestamp falls within the session window.
+     * Session check: parses a full Pine session string — comma-separated
+     * "HHMM-HHMM" windows with an optional ":days" suffix (1=Sunday..7=Saturday)
+     * — and tests whether the timestamp falls within the session.
+     * Malformed session strings halt the script, mirroring TradingView.
      */
     private _isInSession(timestamp: number, session: string, timezone: string): boolean {
-        // Parse session format "HHMM-HHMM" (e.g. "0930-1600")
-        const match = session.match(/^(\d{2})(\d{2})-(\d{2})(\d{2})$/);
-        if (!match) return true; // If session format is unrecognized, pass through
-
-        const startHour = parseInt(match[1], 10);
-        const startMin = parseInt(match[2], 10);
-        const endHour = parseInt(match[3], 10);
-        const endMin = parseInt(match[4], 10);
-
-        // Get hour/minute in the target timezone using the shared utility
-        const parts = getDatePartsInTimezone(timestamp, timezone);
-        const hour = parts.hour;
-        const minute = parts.minute;
-
-        const barTime = hour * 60 + minute;
-        const sessionStart = startHour * 60 + startMin;
-        const sessionEnd = endHour * 60 + endMin;
-
-        if (sessionStart <= sessionEnd) {
-            return barTime >= sessionStart && barTime < sessionEnd;
+        const spec = parseSessionSpec(session);
+        if (!spec) {
+            throw new PineRuntimeError(`Invalid session specification: "${session}"`, 'time');
         }
-        // Overnight session (e.g. "1800-0930")
-        return barTime >= sessionStart || barTime < sessionEnd;
+
+        const parts = getDatePartsInTimezone(timestamp, timezone);
+        const minutesOfDay = parts.hour * 60 + parts.minute;
+        return isInSessionSpec(spec, minutesOfDay, parts.dayOfWeek);
     }
 }
 

--- a/src/namespaces/sessionSpec.ts
+++ b/src/namespaces/sessionSpec.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Pine Script session-string parsing and matching.
+ *
+ * Session string syntax (see TradingView docs, "Sessions"):
+ *
+ *     <time_period>[,<time_period>...][:<days>]
+ *
+ * - <time_period> is "HHmm-HHmm" in 24-hour exchange time. Multiple
+ *   comma-separated periods describe a session with breaks.
+ * - <days> is a set of digits 1-7 (1 = Sunday ... 7 = Saturday). When
+ *   omitted, the session applies to all days ("1234567").
+ * - "24x7" is a special string equivalent to "0000-0000:1234567".
+ * - An end time of "0000" means end-of-day midnight, so "0000-0000" is a
+ *   full 24-hour session on each applicable day.
+ * - When the start time is at or after the end time the session spans
+ *   midnight; per TradingView, such an overnight session belongs to the
+ *   day it ENDS on (e.g. "1700-1700:2" starts Sunday 17:00 and ends
+ *   Monday 17:00 — the Monday trading day).
+ */
+
+interface SessionWindow {
+    /** Minutes from midnight, inclusive. */
+    start: number;
+    /** Minutes from midnight, exclusive. End-of-day midnight is 1440. */
+    end: number;
+}
+
+export interface SessionSpec {
+    windows: SessionWindow[];
+    /** Pine day numbers the session applies to: 1 = Sunday ... 7 = Saturday. */
+    days: Set<number>;
+}
+
+const WINDOW_RE = /^(\d{2})(\d{2})-(\d{2})(\d{2})$/;
+
+/**
+ * Parse a Pine session string. Returns null when the string is malformed
+ * (callers decide whether that is a runtime error).
+ */
+export function parseSessionSpec(spec: string): SessionSpec | null {
+    if (typeof spec !== 'string') return null;
+    const trimmed = spec.trim();
+    if (!trimmed) return null;
+
+    if (trimmed === '24x7') {
+        return { windows: [{ start: 0, end: 1440 }], days: new Set([1, 2, 3, 4, 5, 6, 7]) };
+    }
+
+    const colonParts = trimmed.split(':');
+    if (colonParts.length > 2) return null;
+
+    const days = new Set<number>();
+    if (colonParts.length === 2) {
+        if (!/^[1-7]+$/.test(colonParts[1])) return null;
+        for (const digit of colonParts[1]) days.add(parseInt(digit, 10));
+    } else {
+        for (let d = 1; d <= 7; d++) days.add(d);
+    }
+
+    const windows: SessionWindow[] = [];
+    for (const period of colonParts[0].split(',')) {
+        const match = period.match(WINDOW_RE);
+        if (!match) return null;
+
+        const startHour = parseInt(match[1], 10);
+        const startMin = parseInt(match[2], 10);
+        const endHour = parseInt(match[3], 10);
+        const endMin = parseInt(match[4], 10);
+        if (startHour > 23 || startMin > 59 || endHour > 23 || endMin > 59) return null;
+
+        const start = startHour * 60 + startMin;
+        // "0000" as an end time means end-of-day midnight (24:00).
+        const end = endHour === 0 && endMin === 0 ? 1440 : endHour * 60 + endMin;
+        windows.push({ start, end });
+    }
+
+    return { windows, days };
+}
+
+/**
+ * Test whether a bar time (already decomposed in the session's timezone)
+ * falls inside the session.
+ *
+ * @param minutesOfDay minutes since midnight in the session timezone
+ * @param jsDayOfWeek  JS day-of-week convention (0 = Sunday ... 6 = Saturday)
+ */
+export function isInSessionSpec(spec: SessionSpec, minutesOfDay: number, jsDayOfWeek: number): boolean {
+    const pineDayToday = jsDayOfWeek + 1; // 1 = Sunday ... 7 = Saturday
+    const pineDayTomorrow = (pineDayToday % 7) + 1;
+
+    for (const { start, end } of spec.windows) {
+        if (start < end) {
+            // Same-day window; the trading day is the current day.
+            if (minutesOfDay >= start && minutesOfDay < end && spec.days.has(pineDayToday)) return true;
+        } else {
+            // Overnight window (start >= end): the trading day is the day the
+            // session ends. The pre-midnight part belongs to tomorrow's
+            // trading day, the post-midnight part to today's.
+            if (minutesOfDay >= start && spec.days.has(pineDayTomorrow)) return true;
+            if (minutesOfDay < end && spec.days.has(pineDayToday)) return true;
+        }
+    }
+    return false;
+}

--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -144,6 +144,7 @@ export const NAMESPACE_COLLISION_NAMES = new Set([
     'alert',
     'barstate',
     'syminfo',
+    'session',
     'timeframe',
     'strategy',
     'log',
@@ -241,11 +242,13 @@ export const CONTEXT_PINE_VARS = [
     'timeframe',
     'syminfo',
     'barstate',
+    'session',
 
     //builtin variables
     'bar_index',
     'last_bar_index',
     'last_bar_time',
+    'timenow',
     'inputs',
     'time',
     'time_close',

--- a/tests/core/timenow.test.ts
+++ b/tests/core/timenow.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+describe('timenow built-in variable', () => {
+    const makePineTS = () => new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-02-01').getTime());
+
+    it('timenow is usable from Pine Script and returns current wall-clock time', async () => {
+        const code = `
+//@version=5
+indicator("timenow test")
+plot(timenow, "now")
+`;
+        const before = Date.now();
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+        const after = Date.now();
+
+        const data = plots['now'].data.filter((d: any) => d.value != null && !isNaN(d.value));
+        expect(data.length).toBeGreaterThan(0);
+
+        // Every bar should see the same "current time" concept: a wall-clock
+        // timestamp captured during this test run (independent reference: Date.now()).
+        for (const d of data) {
+            expect(d.value).toBeGreaterThanOrEqual(before);
+            expect(d.value).toBeLessThanOrEqual(after);
+        }
+    });
+
+    it('timenow is usable from PineTS syntax', async () => {
+        const before = Date.now();
+        const pineTS = makePineTS();
+        const { result } = await pineTS.run(($: any) => {
+            const now = timenow;
+            return { now };
+        });
+        const after = Date.now();
+
+        expect(result.now[0]).toBeGreaterThanOrEqual(before);
+        expect(result.now[0]).toBeLessThanOrEqual(after);
+    });
+});

--- a/tests/namespaces/session-namespace.test.ts
+++ b/tests/namespaces/session-namespace.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Hourly mock data (UTC timezone, 24x7 crypto symbol): each trading day/session
+// is a calendar day in the exchange timezone, so on a 1h chart the first bar of
+// a session opens at 00:00 and the last bar opens at 23:00.
+describe('session namespace', () => {
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01T00:00:00Z').getTime(), new Date('2024-01-08T00:00:00Z').getTime());
+
+    it('exposes session.regular and session.extended constants', async () => {
+        const pineTS = makePineTS();
+        const { result } = await pineTS.run(($: any) => {
+            const reg = session.regular;
+            const ext = session.extended;
+            return { reg, ext };
+        });
+
+        expect(result.reg[0]).toBe('regular');
+        expect(result.ext[0]).toBe('extended');
+    });
+
+    it('session.isfirstbar is true only on the first bar of each trading day', async () => {
+        const code = `
+//@version=5
+indicator("session isfirstbar")
+plot(session.isfirstbar ? 1 : 0, "first")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['first'].data;
+        expect(data.length).toBeGreaterThan(24);
+
+        for (const d of data) {
+            const date = new Date(d.time);
+            if (d.value === 1) {
+                expect(date.getUTCHours()).toBe(0);
+            } else {
+                expect(date.getUTCHours()).not.toBe(0);
+            }
+        }
+
+        const firstBars = data.filter((d: any) => d.value === 1);
+        expect(firstBars.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('session.islastbar is true only on the last bar of each trading day', async () => {
+        const code = `
+//@version=5
+indicator("session islastbar")
+plot(session.islastbar ? 1 : 0, "last")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['last'].data;
+        expect(data.length).toBeGreaterThan(24);
+
+        for (let i = 0; i < data.length - 1; i++) {
+            const date = new Date(data[i].time);
+            if (data[i].value === 1) {
+                expect(date.getUTCHours()).toBe(23);
+            } else {
+                expect(date.getUTCHours()).not.toBe(23);
+            }
+        }
+
+        const lastBars = data.filter((d: any) => d.value === 1);
+        expect(lastBars.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('session.ismarket is true and pre/post market are false on 24x7 symbols', async () => {
+        const code = `
+//@version=5
+indicator("session market flags")
+plot(session.ismarket ? 1 : 0, "market")
+plot(session.ispremarket ? 1 : 0, "pre")
+plot(session.ispostmarket ? 1 : 0, "post")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        for (const d of plots['market'].data) expect(d.value).toBe(1);
+        for (const d of plots['pre'].data) expect(d.value).toBe(0);
+        for (const d of plots['post'].data) expect(d.value).toBe(0);
+    });
+
+    it('session.isfirstbar_regular / islastbar_regular mirror the regular-session flags', async () => {
+        const code = `
+//@version=5
+indicator("session regular flags")
+plot(session.isfirstbar_regular == session.isfirstbar ? 1 : 0, "first_eq")
+plot(session.islastbar_regular == session.islastbar ? 1 : 0, "last_eq")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        for (const d of plots['first_eq'].data) expect(d.value).toBe(1);
+        for (const d of plots['last_eq'].data) expect(d.value).toBe(1);
+    });
+});

--- a/tests/namespaces/time-session-spec.test.ts
+++ b/tests/namespaces/time-session-spec.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Hourly mock data: bars open at HH:00 UTC, symbol timezone is Etc/UTC.
+// Expected in/out-of-session values below are hand-derived from the Pine
+// session-spec rules (TradingView docs): "HHMM-HHMM[,HHMM-HHMM...][:days]",
+// days digits 1=Sunday..7=Saturday, overnight sessions belong to the day
+// on which they END (the trading day).
+describe('time() session spec parsing', () => {
+    // 2024-01-01 is a Monday.
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01T00:00:00Z').getTime(), new Date('2024-01-15T00:00:00Z').getTime());
+
+    it('day suffix does not disable session filtering (reported bug)', async () => {
+        // Reported repro: hourly bars open at HH:00 UTC = (HH-5):00 in UTC-5.
+        // No bar's open time ever falls inside 09:30-10:00, so EVERY bar must
+        // be out of session. The bug made every bar in-session because the
+        // ":1234567" suffix failed the HHMM-HHMM regex and passed through.
+        const code = `
+//@version=6
+indicator("time() session days suffix", overlay = true)
+inSession = not na(time(timeframe.period, "0930-1000:1234567", "UTC-5"))
+plot(inSession ? 1 : 0, "inSession")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['inSession'].data;
+        expect(data.length).toBeGreaterThan(0);
+        for (const d of data) {
+            expect(d.value).toBe(0);
+        }
+    });
+
+    it('day suffix filters by day of week (1=Sunday..7=Saturday)', async () => {
+        // "0000-0800:2" → in-session only on Mondays between 00:00 and 08:00.
+        const code = `
+//@version=5
+indicator("session day filter")
+t = time(timeframe.period, "0000-0800:2", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        let inCount = 0;
+        for (const d of data) {
+            const date = new Date(d.time);
+            const expected = date.getUTCDay() === 1 && date.getUTCHours() < 8 ? 1 : 0;
+            expect(d.value).toBe(expected);
+            if (d.value === 1) inCount++;
+        }
+        // Mondays Jan 1 and Jan 8 contribute 8 hourly bars each; the range end
+        // is inclusive, so Monday Jan 15 contributes its 00:00 bar as well.
+        expect(inCount).toBe(17);
+    });
+
+    it('supports comma-separated session windows', async () => {
+        // Hours 0,1 and 5,6 are in-session; everything else is not.
+        const code = `
+//@version=5
+indicator("session comma windows")
+t = time(timeframe.period, "0000-0200,0500-0700", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const h = new Date(d.time).getUTCHours();
+            const expected = h === 0 || h === 1 || h === 5 || h === 6 ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('supports overnight sessions crossing midnight', async () => {
+        // "2200-0200" → hours 22, 23, 0, 1 in-session.
+        const code = `
+//@version=5
+indicator("overnight session")
+t = time(timeframe.period, "2200-0200", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const h = new Date(d.time).getUTCHours();
+            const expected = h >= 22 || h < 2 ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('overnight session day suffix refers to the trading day the session ends on', async () => {
+        // "2200-0200:2" (Monday trading day) → Sunday 22:00/23:00 and Monday 00:00/01:00.
+        const code = `
+//@version=5
+indicator("overnight session trading day")
+t = time(timeframe.period, "2200-0200:2", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const date = new Date(d.time);
+            const day = date.getUTCDay(); // 0=Sun, 1=Mon
+            const h = date.getUTCHours();
+            const expected = (day === 0 && h >= 22) || (day === 1 && h < 2) ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('treats "HHMM-0000" end as end-of-day midnight', async () => {
+        // "2200-0000" → hours 22, 23 in-session (same-day evening window).
+        const code = `
+//@version=5
+indicator("midnight end session")
+t = time(timeframe.period, "2200-0000", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const h = new Date(d.time).getUTCHours();
+            const expected = h >= 22 ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('rejects malformed session strings instead of treating every bar as in-session', async () => {
+        const code = `
+//@version=5
+indicator("invalid session")
+t = time(timeframe.period, "not-a-session", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        await expect(pineTS.run(code)).rejects.toThrow(/session/i);
+    });
+});


### PR DESCRIPTION
## Summary

- **`time()` session filtering was broken for real Pine session strings**: `_isInSession` only matched `^HHMM-HHMM$` and returned `true` on mismatch, so any `:days` suffix (e.g. `0930-1000:1234567`) or comma-separated windows made **every bar in-session**. Session strings are now parsed per the TradingView spec in a new shared module (`src/namespaces/sessionSpec.ts`): comma-separated `HHMM-HHMM` windows, `:days` suffix (1=Sunday..7=Saturday, all days when omitted), overnight sessions belonging to the trading day they **end** on, `0000` as end-of-day midnight, and the special `24x7` string. Malformed session strings now halt the script with a `PineRuntimeError`, mirroring TradingView.
- **Added the `session` namespace** (`src/namespaces/Session.ts`): `session.regular`/`session.extended` constants and `isfirstbar`, `islastbar`, `isfirstbar_regular`, `islastbar_regular`, `ismarket`, `ispremarket`, `ispostmarket` variables. Session boundaries are detected as trading-day changes in `syminfo.timezone` (providers serve continuous regular-session data), so `ismarket` is always true and pre/post-market are false.
- **`timenow` was unreachable from scripts**: the runtime getter existed on the Context but the identifier was missing from `CONTEXT_PINE_VARS`, so it was never injected and scripts crashed with `ReferenceError: timenow is not defined`. Registered it in `src/transpiler/settings.ts`.
- Marked the session namespace as covered in `docs/api-coverage`.

## Test plan

- [x] 14 new regression tests, written to fail before the fix (reproduce -> failing test -> fix -> pass):
  - `tests/namespaces/time-session-spec.test.ts` — includes the exact reported repro (`time(timeframe.period, 0930-1000:1234567, UTC-5)` now returns `na` on every hourly bar), day filtering, comma windows, overnight sessions and their trading-day semantics, `HHMM-0000` handling, and malformed-string rejection. Expected values hand-derived from the TradingView sessions documentation.
  - `tests/namespaces/session-namespace.test.ts` — constants, first/last bar per trading day on hourly Mock data, market flags.
  - `tests/core/timenow.test.ts` — `timenow` from both Pine Script and PineTS syntax, bounded by wall-clock `Date.now()`.
- [x] Full suite green: 1771 passed / 0 repository failures (`npm test -- --run`). The only local failure is the gitignored `tests/_local/bitcoin-expectile-model.test.ts`, which requires `runtime.error` — already implemented on the pending `fix/rutime-namespace` branch and unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `time()` decides in-session vs `na` and how invalid session strings fail, which can change script results. Session flags are simplified for 24x7/continuous data and may not match equity pre/post-market semantics.
> 
> **Overview**
> Fixes `time()` session filtering so real Pine session strings work. Previously only `HHMM-HHMM` matched and anything else (including a `:days` suffix) treated **every bar as in-session**. Parsing now follows TradingView: comma-separated windows, optional day digits, overnight sessions belonging to the day they **end**, `0000` as end-of-day, and `24x7`. Invalid specs throw `PineRuntimeError` instead of passing through.
> 
> Adds the `session` namespace (`regular`/`extended`, first/last-bar flags, market/pre/post). Boundaries are calendar-day changes in `syminfo.timezone`; on continuous 24x7 data `ismarket` is always true and pre/post are false.
> 
> Exposes `timenow` via `CONTEXT_PINE_VARS` so scripts no longer hit `ReferenceError`. Coverage docs mark the session API as implemented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733bc96a01d7c8d3ac1b6c6312cf5d357b8f9ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->