### PR TITLE
Fix identifier-namespace collision for constant namespaces (position, font, order, currency, dayofweek, adjustment, barmerge)

### DIFF
--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -148,6 +148,19 @@ export const NAMESPACE_COLLISION_NAMES = new Set([
     'strategy',
     'log',
     'str',
+    // Constant/enum namespaces (member access only). TradingView allows user
+    // variables to share these names while namespace member access still
+    // works (e.g. `position = 1` alongside `position.top_right`), so the
+    // user variable must be renamed. `dayofweek` is dual-use (built-in
+    // variable + enum) — renaming only triggers when the user DECLARES a
+    // variable with the name, so bare built-in reads are unaffected.
+    'position',
+    'font',
+    'order',
+    'currency',
+    'dayofweek',
+    'adjustment',
+    'barmerge',
 ]);
 
 // JavaScript reserved keywords that ARE valid Pine identifiers but invalid as

--- a/tests/transpiler/namespace-identifier-collision.test.ts
+++ b/tests/transpiler/namespace-identifier-collision.test.ts
@@ -1,0 +1,129 @@
+// Regression guard: user identifiers named after constant/enum namespaces.
+//
+// TradingView allows a script to declare a variable whose name collides with
+// a constant namespace (position, font, order, currency, dayofweek,
+// adjustment, barmerge) while still using the namespace's members
+// (e.g. `position.top_right`) elsewhere in the same script.
+//
+// PineTS handles this via the pineToJS codegen rename pass: the user variable
+// is renamed with a `_$N` suffix while member-expression bases keep referring
+// to the namespace. Before the fix, these names were missing from
+// NAMESPACE_COLLISION_NAMES, so the declaration hijacked the identifier and
+// namespace member access threw `ReferenceError: <name> is not defined`.
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+
+function newPineTS() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+}
+
+function lastValue(plots: any, title: string) {
+    const data = plots[title]?.data;
+    expect(data, `plot "${title}" missing`).toBeDefined();
+    expect(data.length).toBeGreaterThan(0);
+    return data[data.length - 1].value;
+}
+
+describe('identifier-namespace collision (TV-allowed shadowing)', () => {
+    it('position: user variable coexists with table.new(position.top_right, ...)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("position collision repro", overlay = true)
+var table t = table.new(position.top_right, 1, 1)
+position = 1
+plot(position, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(1);
+    });
+
+    it('font: user variable coexists with font.family_monospace', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("font collision")
+var table t = table.new(position.top_left, 1, 1)
+table.cell(t, 0, 0, "x", text_font_family = font.family_monospace)
+font = 2
+plot(font, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(2);
+    });
+
+    it('order: user variable coexists with array.sort(..., order.descending)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("order collision")
+a = array.from(3.0, 1.0, 2.0)
+array.sort(a, order.descending)
+order = array.get(a, 0)
+plot(order, "p")
+`);
+        // descending sort puts the max (3.0) first
+        expect(lastValue(plots, 'p')).toBe(3);
+    });
+
+    it('currency: user variable coexists with currency.USD', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("currency collision")
+currency = 4
+plot(currency.USD == "USD" ? currency : -1, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(4);
+    });
+
+    it('dayofweek: user variable coexists with dayofweek.monday constant', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("dayofweek collision")
+dayofweek = dayofweek.monday + 1
+plot(dayofweek, "p")
+`);
+        // dayofweek.monday == 2 on TradingView
+        expect(lastValue(plots, 'p')).toBe(3);
+    });
+
+    it('adjustment: user variable coexists with adjustment.splits', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("adjustment collision")
+string adj = adjustment.splits
+adjustment = 5
+plot(adjustment, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(5);
+    });
+
+    it('barmerge: user variable coexists with barmerge.gaps_off', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("barmerge collision")
+string g = barmerge.gaps_off
+barmerge = 6
+plot(barmerge, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(6);
+    });
+
+    it('does not affect scripts that only READ these namespaces (no user declaration)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("no collision")
+var table t = table.new(position.bottom_right, 1, 1)
+plot(dayofweek.friday, "p")
+`);
+        // dayofweek.friday == 6 on TradingView
+        expect(lastValue(plots, 'p')).toBe(6);
+    });
+
+    it('dual-use dayofweek built-in variable still works when not shadowed', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("dayofweek builtin")
+plot(dayofweek, "p")
+`);
+        const v = lastValue(plots, 'p');
+        expect(v).toBeGreaterThanOrEqual(1);
+        expect(v).toBeLessThanOrEqual(7);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes identifier-namespace collision errors for the constant/enum namespaces `position`, `font`, `order`, `currency`, `dayofweek`, `adjustment`, and `barmerge`. TradingView allows a user variable to share these names while namespace member access still works, but PineTS threw `ReferenceError: <name> is not defined`.

Repro that failed before this fix:

```pine
//@version=6
indicator("position collision repro", overlay = true)
var table t = table.new(position.top_right, 1, 1)
position = 1
plot(position)
```

## Root cause

The pineToJS codegen already has a rename pass for user declarations that collide with namespace names (`_$N` suffix, member-expression bases untouched), driven by `NAMESPACE_COLLISION_NAMES` in `src/transpiler/settings.ts`. The seven affected namespaces were missing from that set, so the user declaration became a scoped variable, the Stage 2 transpiler stopped injecting the namespace from `$.pine`, and member access threw at runtime.

## Fix

- Add the seven names to `NAMESPACE_COLLISION_NAMES`. All of them already exist at runtime in `$.pine` via the `types` enum spread (`dayofweek` as the dual-use TimeComponentHelper). The rename only triggers when the user *declares* a variable with the name, so bare built-in reads (e.g. `plot(dayofweek)`) are unaffected.
- Add `tests/transpiler/namespace-identifier-collision.test.ts`: one runtime test per affected namespace (declares the colliding variable, uses a namespace member in a realistic call, asserts the plotted value from Pine semantics) plus two control tests for non-shadowed usage. All 7 collision tests failed with the reported `ReferenceError` before the fix and pass after.

## Test plan

- [x] Reproduced the reported script and confirmed the `ReferenceError`
- [x] New regression tests fail before the fix, pass after (9/9)
- [x] Full suite `npm test -- --run`: 1766 passed; the single failure is a pre-existing, unrelated test in gitignored `tests/_local/` (unimplemented `runtime.error` namespace), verified to fail identically without this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to an existing identifier-rename set; no new codegen logic. Dual-use `dayofweek` is the main edge case and is covered by tests.
> 
> **Overview**
> Fixes a runtime `ReferenceError` when a script declares a variable named after a constant/enum namespace (`position`, `font`, `order`, `currency`, `dayofweek`, `adjustment`, `barmerge`) while still using that namespace’s members (e.g. `position = 1` next to `table.new(position.top_right, …)`). TradingView allows this; PineTS previously treated the user declaration as the identifier and dropped the injected namespace.
> 
> Adds those seven names to `NAMESPACE_COLLISION_NAMES` so the existing pineToJS rename pass suffixes the user binding (`_$N`) and leaves member-expression bases as the namespace. Rename still only runs on a user **declaration**, so bare built-in reads like `plot(dayofweek)` stay unchanged.
> 
> Regression tests cover one collision per namespace plus controls for unshadowed namespace/built-in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40131f14d93bd77d24b6e416f6a17a875e67b529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->