### PR TITLE
Fix int/int division to match Pine v5/v6 semantics

### DIFF
--- a/src/namespaces/math/methods/__idiv.ts
+++ b/src/namespaces/math/methods/__idiv.ts
@@ -3,15 +3,16 @@
 import { Series } from '../../../Series';
 
 /**
- * Pine integer division — the `/` (and `%`, via the transpiler) operator applied
- * to two **integer** operands. In Pine, `int / int` yields an `int`: the result
- * is truncated toward zero (`11 / 2 === 5`, `-11 / 2 === -5`), whereas JavaScript
- * `/` is always float division (`5.5`).
+ * Pine v5 constant integer division. In Pine v5, `/` truncates toward zero
+ * (`11 / 2 === 5`, `-11 / 2 === -5`) ONLY when both operands are
+ * 'const'-qualified ints; any 'input'/'simple'/'series' int operand preserves
+ * the fractional remainder, and Pine v6+ never truncates at all (see
+ * TradingView's v6 migration guide, "Fractional division of constants").
  *
- * The transpiler rewrites a `/` BinaryExpression to this helper ONLY when BOTH
- * operands are provably `int` at compile time (see TypeInferencePass). Any float
- * operand keeps native `/`, so genuine float division (`4.0 / 2.0`, `close / 2`)
- * is untouched.
+ * The transpiler rewrites a `/` BinaryExpression to this helper ONLY for v5
+ * sources and ONLY when BOTH operands are provably const int at compile time
+ * (see TypeInferencePass). Everything else keeps native `/`, so genuine
+ * fractional division (`4.0 / 2.0`, `close / 2`, `i / 4`) is untouched.
  *
  * Semantics:
  * - `na` (NaN) in either operand propagates → NaN.

--- a/src/transpiler/analysis/TypeInferencePass.ts
+++ b/src/transpiler/analysis/TypeInferencePass.ts
@@ -1,38 +1,44 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * TypeInferencePass — Pine base-type inference (RC2b P0).
+ * TypeInferencePass — Pine v5 const-int division inference.
  *
  * Runs BEFORE the main lowering pass, on the clean AST (operands are still bare
- * identifiers, `input.int(...)` calls, and literals — not yet `$.get(...)`).
+ * identifiers and literals — not yet `$.get(...)`), and ONLY for Pine v5 sources
+ * (the caller in `transpiler/index.ts` gates on the //@version directive).
  *
- * Purpose: replicate Pine's `int / int → int` semantics. JavaScript `/` is always
- * float division (`11 / 2 === 5.5`), but Pine truncates toward zero when both
- * operands are integers (`11 / 2 === 5`, `-11 / 2 === -5`). Int-ness is a
- * compile-time fact — a `float` series holding `4.0` is an ordinary JS number at
- * runtime — so a static pass is the only correct discriminator.
+ * Purpose: replicate Pine v5's `const int / const int → int` truncation.
+ * Per TradingView's v6 migration guide ("Fractional division of constants"):
  *
- * When a `/` BinaryExpression has BOTH operands provably `int`, it is rewritten in
- * place to `$.pine.math.__idiv(left, right)`; the main pass then lowers the operand
- * subtrees inside the call args. Anything not provably int keeps native `/`, so
- * partial coverage never corrupts a genuine float division — the worst case is a
- * missed truncation.
+ *   - In v5, `int / int` truncates toward zero ONLY when BOTH operands are
+ *     qualified as 'const' (compile-time constants): `5 / 2 === 2`.
+ *   - If at least one operand is 'input', 'simple', or 'series' — loop counters,
+ *     mutable (`:=`-reassigned) variables, `var` declarations, `input.int(...)`,
+ *     int builtins like `bar_index` — the fractional remainder is PRESERVED
+ *     even in v5: `i / 4 === 0.75`.
+ *   - In v6, `int / int` NEVER truncates, regardless of qualifiers. (v6 scripts
+ *     never reach this pass.)
  *
- * Scope note (P0): the ONLY consumer of type info is the `/` rewrite, so we track
- * a minimal lattice — `int` vs `notint` (float / string / bool / na / unknown).
- * `notint` simply means "not provably int", which is all the rewrite needs. A
- * fuller int/float/bool/string lattice (for str.tostring formatting, casts, etc.)
- * can be layered on later without changing this rewrite.
+ * When a `/` BinaryExpression has BOTH operands provably const int, it is
+ * rewritten in place to `$.pine.math.__idiv(left, right)`; the main pass then
+ * lowers the operand subtrees inside the call args. Anything not provably
+ * const-int keeps native `/`, so partial coverage never corrupts a genuine
+ * fractional division — the worst case is a missed truncation.
+ *
+ * Lattice: `constint` (compile-time int constant) → `int` (int-typed but
+ * input/simple/series-qualified) → `notint` (float / string / bool / na /
+ * unknown). Only `constint / constint` triggers the rewrite; the `int` tier
+ * exists so int-ness still propagates through arithmetic without ever
+ * upgrading a non-const operand to const.
  */
-import * as walk from 'acorn-walk';
 import ScopeManager from './ScopeManager';
 import { ASTFactory } from '../utils/ASTFactory';
 
-type T = 'int' | 'notint';
+type T = 'constint' | 'int' | 'notint';
 
 /**
- * Built-in variables that are `int`-typed in Pine. Their divisions (`bar_index / 2`)
- * are integer division even though at runtime they are plain JS numbers.
+ * Built-in variables that are `int`-typed in Pine. They are series-qualified,
+ * never 'const', so they can propagate int-ness but never trigger truncation.
  */
 const INT_BUILTIN_VARS = new Set<string>([
     'bar_index', 'last_bar_index',
@@ -41,17 +47,17 @@ const INT_BUILTIN_VARS = new Set<string>([
 ]);
 
 /**
- * Built-in calls that RETURN `int` (dotted callee name). CONSERVATIVE subset —
- * only functions whose result is unambiguously an int (counts, indices, bar
- * offsets). Anything absent defaults to `notint` (no truncation), so an omission
- * is a safe missed-truncation, never a wrong one.
+ * Built-in calls that RETURN `int` (dotted callee name). All are 'input',
+ * 'simple' or 'series' qualified — never 'const' — so they propagate int-ness
+ * without enabling truncation. CONSERVATIVE subset — anything absent defaults
+ * to `notint`, which is a safe missed inference, never a wrong one.
  *
  * Deliberately EXCLUDED (fail-safe on uncertainty):
  * - `ta.pivothigh` / `ta.pivotlow` — return the pivot PRICE (float), not a bar
  *   count. (Listing them as int caused a real over-truncation regression.)
  * - `math.round` — overloaded (1-arg → int, 2-arg → float).
  * - `math.sign`, `str.pos`, `input.time` — return type uncertain; excluded until
- *   verified rather than risk truncating a float.
+ *   verified rather than risk mis-typing a float.
  */
 const INT_RETURNING_CALLS = new Set<string>([
     'input.int',
@@ -92,6 +98,43 @@ function calleeName(callee: any): string | null {
     return null;
 }
 
+/**
+ * Collect every identifier name that is EVER written after declaration —
+ * `:=` reassignments (AssignmentExpression) and loop-counter updates
+ * (UpdateExpression / compound assignment in for-headers). Pine qualifies a
+ * mutated variable as 'series' program-wide, so a single write anywhere
+ * disqualifies the name from 'const' everywhere. Name-based (not scope-based):
+ * a shadowed name may be over-disqualified, which fails safe (missed
+ * truncation), never wrong.
+ */
+function collectMutatedNames(ast: any): Set<string> {
+    const mutated = new Set<string>();
+    (function scan(node: any): void {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'AssignmentExpression' && node.left?.type === 'Identifier') {
+            mutated.add(node.left.name);
+        } else if (node.type === 'UpdateExpression' && node.argument?.type === 'Identifier') {
+            mutated.add(node.argument.name);
+        }
+        for (const key in node) {
+            if (key === 'type' || key === 'start' || key === 'end' || key === 'loc' || key === 'raw') continue;
+            const child = node[key];
+            if (Array.isArray(child)) {
+                for (const c of child) if (c && typeof c === 'object') scan(c);
+            } else if (child && typeof child === 'object') {
+                scan(child);
+            }
+        }
+    })(ast);
+    return mutated;
+}
+
+/** JOIN two types: int-ness survives only if both sides are int-ish, and the
+ *  result of a join is never const (a value that can vary is not a constant). */
+function join(a: T, b: T): T {
+    return a !== 'notint' && b !== 'notint' ? 'int' : 'notint';
+}
+
 /** Scope stack of variable-name → inferred type. Pine rarely shadows, but function
  *  bodies get their own frame so a param never leaks a type to the global scope. */
 class Env {
@@ -108,46 +151,46 @@ class Env {
         return undefined;
     }
     /**
-     * Reassignment (`x := ...`): JOIN with the existing type. A variable is `int`
-     * only if EVERY value it holds is `int`; once it takes a `notint` value (its
-     * `na`/float initializer, or any float assignment) it stays `notint` forever.
-     * This mirrors Pine's "type is fixed at declaration" — a `var float x = na`
-     * reassigned to a float pivot stays float — and fails safe: a mis-typed
-     * signature can never upgrade a float variable to int and truncate it.
+     * Reassignment (`x := ...`): JOIN with the existing type. A variable is
+     * int-ish only if EVERY value it holds is int-ish; once it takes a `notint`
+     * value (its `na`/float initializer, or any float assignment) it stays
+     * `notint` forever. This mirrors Pine's "type is fixed at declaration" — a
+     * `var float x = na` reassigned to a float pivot stays float — and fails
+     * safe: a mis-typed signature can never upgrade a float variable to int.
      */
     assign(name: string, t: T): void {
         for (let i = this.stack.length - 1; i >= 0; i--) {
             if (this.stack[i].has(name)) {
-                const cur = this.stack[i].get(name);
-                this.stack[i].set(name, cur === 'int' && t === 'int' ? 'int' : 'notint');
+                this.stack[i].set(name, join(this.stack[i].get(name)!, t));
                 return;
             }
         }
-        this.stack[this.stack.length - 1].set(name, t);
+        this.stack[this.stack.length - 1].set(name, join(t, t));
     }
 }
 
 export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): void {
     const env = new Env();
+    const mutatedNames = collectMutatedNames(ast);
 
     // Visit a node; for expressions, return its inferred type AND rewrite any
-    // provably-int `/` inside it. Every child is visited exactly once so no
-    // division is missed. Unknown/unhandled shapes fall back to generic child
+    // provably-const-int `/` inside it. Every child is visited exactly once so
+    // no division is missed. Unknown/unhandled shapes fall back to generic child
     // recursion and yield `notint` (safe: no rewrite).
     function visit(node: any): T {
         if (!node || typeof node !== 'object') return 'notint';
 
         switch (node.type) {
             case 'Literal':
-                if (typeof node.value === 'number') return isIntLiteral(node) ? 'int' : 'notint';
+                if (typeof node.value === 'number') return isIntLiteral(node) ? 'constint' : 'notint';
                 return 'notint';
 
             case 'Identifier':
-                if (INT_BUILTIN_VARS.has(node.name)) return 'int';
+                if (INT_BUILTIN_VARS.has(node.name)) return 'int'; // series int, never const
                 return env.get(node.name) ?? 'notint';
 
             case 'UnaryExpression':
-                // Unary +/- preserve numeric type (`-11` is int); `!`/`~` are notint.
+                // Unary +/- preserve numeric type (`-11` is const int); `!`/`~` are notint.
                 if (node.operator === '-' || node.operator === '+') return visit(node.argument);
                 visit(node.argument);
                 return 'notint';
@@ -155,21 +198,23 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
             case 'BinaryExpression': {
                 const lt = visit(node.left);
                 const rt = visit(node.right);
-                const bothInt = lt === 'int' && rt === 'int';
                 if (node.operator === '/') {
-                    if (bothInt) {
-                        // int / int → int (truncated toward zero). Rewrite in place;
-                        // the main pass lowers node.left / node.right in the args.
+                    if (lt === 'constint' && rt === 'constint') {
+                        // v5 const int / const int → const int (truncated toward
+                        // zero). Rewrite in place; the main pass lowers
+                        // node.left / node.right in the args.
                         const call = ASTFactory.createMathIntDivCall(node.left, node.right);
                         Object.assign(node, call);
-                        return 'int';
+                        return 'constint';
                     }
+                    // Any non-const int operand → fractional result (even in v5).
                     return 'notint';
                 }
-                // `+ - * %` preserve int when both operands are int (so a downstream
-                // `/` sees the propagated int-ness). Comparisons / others → notint.
+                // `+ - * %` preserve int-ness (and const-ness) so a downstream
+                // `/` sees it. Comparisons / others → notint.
                 if (node.operator === '+' || node.operator === '-' || node.operator === '*' || node.operator === '%') {
-                    return bothInt ? 'int' : 'notint';
+                    if (lt === 'constint' && rt === 'constint') return 'constint';
+                    return lt !== 'notint' && rt !== 'notint' ? 'int' : 'notint';
                 }
                 return 'notint';
             }
@@ -178,7 +223,9 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
                 visit(node.test);
                 const c = visit(node.consequent);
                 const a = visit(node.alternate);
-                return c === 'int' && a === 'int' ? 'int' : 'notint';
+                // Never const: we don't track bool const-ness of the test, and a
+                // missed truncation is safe while a wrong one is not.
+                return join(c, a);
             }
 
             case 'LogicalExpression':
@@ -203,8 +250,17 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
 
             case 'VariableDeclaration': {
                 for (const d of node.declarations || []) {
-                    const t = d.init ? visit(d.init) : 'notint';
-                    if (d.id?.type === 'Identifier') env.set(d.id.name, t);
+                    let t = d.init ? visit(d.init) : 'notint';
+                    if (d.id?.type === 'Identifier') {
+                        // Const-ness requires an immutable non-`var` binding:
+                        // `var`/`varip` declarations and any name that is ever
+                        // reassigned (incl. loop counters) are at best simple/
+                        // series ints in Pine's qualifier model.
+                        if (t === 'constint' && (node.kind === 'var' || mutatedNames.has(d.id.name))) {
+                            t = 'int';
+                        }
+                        env.set(d.id.name, t);
+                    }
                 }
                 return 'notint';
             }
@@ -212,7 +268,7 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
             case 'AssignmentExpression': {
                 const t = visit(node.right);
                 // `x := ...` reassignment: JOIN with the existing type (never
-                // upgrades a notint variable to int — see Env.assign).
+                // upgrades a notint variable, never yields const — see Env.assign).
                 if (node.left?.type === 'Identifier') env.assign(node.left.name, t);
                 else visit(node.left);
                 return t;

--- a/src/transpiler/index.ts
+++ b/src/transpiler/index.ts
@@ -58,20 +58,25 @@ import { runTransformationPass, transformEqualityChecks, propagateAsyncAwait } f
 import { extractPineScriptVersion, pineToJS } from './pineToJS/pineToJS.index';
 import { buildLtfSlices } from './slicing/buildLtfSlices';
 
-function getPineTSFromSource(source: string | Function): string {
+/**
+ * Resolve the input into PineTS code plus the Pine Script version it came from.
+ * `version` is null for PineTS-syntax / function input (no //@version marker):
+ * such code is JavaScript-like and follows JS semantics, not a Pine version.
+ */
+function getPineTSFromSource(source: string | Function): { code: string; version: number | null } {
     if (typeof source === 'function') {
-        return source.toString();
+        return { code: source.toString(), version: null };
     } else {
         const pineScriptVersion = extractPineScriptVersion(source);
         if (pineScriptVersion === null) {
             //assume it's PineTS syntax ==> use it as is
-            return source;
+            return { code: source, version: null };
         }
         if (pineScriptVersion >= 5) {
             //assume it's Pine Script syntax ==> use pineToJS to transpile it
             const pineToJSResult = pineToJS(source);
             if (pineToJSResult.success) {
-                return pineToJSResult.code;
+                return { code: pineToJSResult.code, version: pineScriptVersion };
             } else {
                 throw new Error(`Failed to transpile Pine Script version ${pineScriptVersion}: ${pineToJSResult.error}`);
             }
@@ -89,7 +94,8 @@ export function transpile(source: string | Function, options: { debug: boolean; 
 
     const { debug } = options;
 
-    let code = getPineTSFromSource(source);
+    const { code: sourceCode, version: pineVersion } = getPineTSFromSource(source);
+    let code = sourceCode;
 
     // Pre-process: Wrap in context function if not already wrapped
     code = wrapInContextFunction(code);
@@ -127,11 +133,19 @@ export function transpile(source: string | Function, options: { debug: boolean; 
     // Returns the original parameter name of the root function if any
     const originalParamName = runAnalysisPass(ast, scopeManager) || '';
 
-    // Type inference (RC2b): replicate Pine `int / int → int`. Runs on the clean
-    // pre-lowering AST (operands still bare identifiers / `input.int(...)` /
-    // literals) and rewrites provably-int `/` to `$.pine.math.__idiv(...)`. The
-    // main pass below then lowers the operand subtrees inside the call args.
-    runTypeInferencePass(ast, scopeManager);
+    // Type inference: replicate Pine v5 `const int / const int → int` truncation.
+    // Runs on the clean pre-lowering AST (operands still bare identifiers /
+    // literals) and rewrites provably-const-int `/` to `$.pine.math.__idiv(...)`;
+    // the main pass below then lowers the operand subtrees inside the call args.
+    //
+    // Version-gated: only Pine v5 truncates, and only when BOTH operands are
+    // 'const'-qualified ints. Pine v6+ always performs fractional division
+    // (see TradingView's v6 migration guide, "Fractional division of constants"),
+    // and PineTS-syntax / function input (pineVersion === null) is JavaScript,
+    // where `/` is always float division.
+    if (pineVersion !== null && pineVersion < 6) {
+        runTypeInferencePass(ast, scopeManager);
+    }
 
     // Second pass: transform the code
     runTransformationPass(ast, scopeManager, originalParamName, options, sourceLines);

--- a/tests/core/pinescript.test.ts
+++ b/tests/core/pinescript.test.ts
@@ -2650,12 +2650,13 @@ describe('PineScript Language', () => {
         console.log('>>> TEST: Operator Precedence Complex');
         console.log('>>> result: ', context.result);
 
-        // RC2b (Pine int/int → int): `5 / 2` is integer division (= 2, not 2.5),
-        // so complex1 = 2 + 3*4 - 5/2 = 2 + 12 - 2 = 12; and complex2 =
-        // ((2+3)*(4-5))/2 = -5/2 = -2 (truncated toward zero, not -2.5).
+        // PineTS-syntax input follows JavaScript semantics: `/` is always float
+        // division (only Pine v5 const/const divisions truncate, and this is not
+        // Pine source). So complex1 = 2 + 3*4 - 5/2 = 2 + 12 - 2.5 = 11.5, and
+        // complex2 = ((2+3)*(4-5))/2 = -5/2 = -2.5.
         const expected = {
-            complex1: [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
-            complex2: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2],
+            complex1: [11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5],
+            complex2: [-2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5],
             complex3: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
             complex4: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
         };

--- a/tests/transpiler/int-division.test.ts
+++ b/tests/transpiler/int-division.test.ts
@@ -1,61 +1,76 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * RC2b — Pine integer division (`int / int → int`) regression suite.
+ * Pine integer division (`int / int`) regression suite.
  *
- * Pine truncates `/` toward zero when BOTH operands are integers (`11 / 2 === 5`,
- * `-11 / 2 === -5`); JavaScript `/` is always float. The TypeInferencePass rewrites
- * a `/` to `$.pine.math.__idiv(...)` ONLY when both operands are provably int, and
- * MUST leave every other division as native `/` (fail-safe — a missed truncation is
- * acceptable, a wrong truncation of a float is a bug).
+ * Reference: TradingView's "To Pine Script version 6" migration guide, section
+ * "Fractional division of constants":
  *
- * These tests lock down both directions:
- *   - int-division IS applied for the provable-int cases, and
- *   - float / unknown divisions are NEVER truncated — including the two real
- *     over-truncation regressions this suite exists to prevent:
- *       (1) `ta.pivothigh` / `ta.pivotlow` return a float PRICE, not an int bar
- *           count (they were wrongly typed int, truncating pivot-range math);
- *       (2) a `var float x = na` reassigned from a float value must stay float
- *           (JOIN-on-reassignment: once notint, always notint).
+ *   - Pine v5: `int / int` truncates toward zero ONLY when BOTH operands are
+ *     qualified as 'const' (e.g. `5 / 2 === 2`). If at least one operand is
+ *     'input', 'simple', or 'series' (loop counters, mutable variables,
+ *     `input.int(...)`, `bar_index`, ...), the fractional remainder is PRESERVED
+ *     (`i / 4 === 0.75`).
+ *   - Pine v6: `int / int` NEVER truncates, regardless of qualifiers
+ *     (`5 / 2 === 2.5`).
+ *
+ * The TypeInferencePass therefore rewrites `/` to `$.pine.math.__idiv(...)` only
+ * for v5 sources AND only when both operands are provably const int. Everything
+ * else — v6 scripts, bare PineTS syntax (JS semantics), and any non-const int
+ * operand — keeps native float `/`.
+ *
+ * This suite also guards two historical over-truncation regressions:
+ *   (1) `ta.pivothigh` / `ta.pivotlow` return a float PRICE, not an int bar count;
+ *   (2) a `var float x = na` reassigned from a float value must stay float.
  */
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';
 import { Provider } from '@pinets/marketData/Provider.class';
 import { transpile } from '../../src/transpiler/index';
 
-/** Transpile a Pine v6 snippet and return the generated JS as a string. */
-function tj(body: string): string {
-    return transpile(`//@version=6\nindicator("t")\n${body}`).toString();
+/** Transpile a Pine snippet at the given version, return the generated JS. */
+function tj(body: string, version: 5 | 6 = 5): string {
+    return transpile(`//@version=${version}\nindicator("t")\n${body}`).toString();
 }
 
 const IDIV = '__idiv';
 
-describe('RC2b: Pine integer division (__idiv)', () => {
-    describe('applies int-division (→ __idiv) when both operands are provably int', () => {
-        it('int literal / int literal', () => {
-            expect(tj('x = 11 / 2')).toContain(IDIV);
+describe('Pine v5: __idiv applied ONLY for const int / const int', () => {
+    it('int literal / int literal', () => {
+        expect(tj('x = 11 / 2')).toContain(IDIV);
+    });
+    it('const-int arithmetic / int literal', () => {
+        expect(tj('y = (3 + 4) / 2')).toContain(IDIV);
+    });
+    it('unary-minus int literal', () => {
+        expect(tj('y = -11 / 2')).toContain(IDIV);
+    });
+    it('const int variable (literal init, never reassigned) / int', () => {
+        expect(tj('iv = 7\ny = iv / 2')).toContain(IDIV);
+    });
+
+    describe('non-const int operands preserve the fractional remainder (no __idiv)', () => {
+        it('input.int is input-qualified, not const', () => {
+            expect(tj('depth = input.int(11)\ny = depth / 2')).not.toContain(IDIV);
         });
-        it('input.int-typed variable / int', () => {
-            expect(tj('depth = input.int(11)\ny = depth / 2')).toContain(IDIV);
+        it('bar_index is a series int, not const', () => {
+            expect(tj('y = bar_index / 2')).not.toContain(IDIV);
         });
-        it('int-typed builtin (bar_index) / int', () => {
-            expect(tj('y = bar_index / 2')).toContain(IDIV);
+        it('loop counter is a series int, not const', () => {
+            expect(tj('int gridSteps = 4\nfloat f = na\nfor i = 1 to 3\n    f := i / gridSteps')).not.toContain(IDIV);
         });
-        it('int-only arithmetic / int', () => {
-            expect(tj('y = (3 + 4) / 2')).toContain(IDIV);
+        it('reassigned int variable is series, not const', () => {
+            expect(tj('c = 0\nc := c + 1\ny = c / 2')).not.toContain(IDIV);
         });
-        it('unary-minus int literal', () => {
-            expect(tj('y = -11 / 2')).toContain(IDIV);
+        it('var-declared int is not const', () => {
+            expect(tj('var v = 8\ny = v / 2')).not.toContain(IDIV);
         });
-        it('int variable (literal init) / int', () => {
-            expect(tj('iv = 7\ny = iv / 2')).toContain(IDIV);
-        });
-        it('int variable reassigned only to ints stays int', () => {
-            expect(tj('c = 0\nc := c + 1\ny = c / 2')).toContain(IDIV);
+        it('const var divided by a later-reassigned var', () => {
+            expect(tj('k = 8\nm = 2\ny = k / m\nm := 4')).not.toContain(IDIV);
         });
     });
 
-    describe('never truncates float / unknown divisions (stays native /)', () => {
+    describe('never truncates float / unknown divisions', () => {
         it('float builtin (close) / int', () => {
             expect(tj('y = close / 2')).not.toContain(IDIV);
         });
@@ -69,8 +84,7 @@ describe('RC2b: Pine integer division (__idiv)', () => {
             expect(tj('y = close / high')).not.toContain(IDIV);
         });
 
-        // REGRESSION (1): ta.pivothigh / ta.pivotlow return the pivot PRICE (float),
-        // not an int bar count. They must NOT trigger int-division.
+        // REGRESSION (1): ta.pivothigh / ta.pivotlow return the pivot PRICE (float).
         it('ta.pivothigh() / int stays float', () => {
             expect(tj('ph = ta.pivothigh(5, 5)\ny = ph / 2')).not.toContain(IDIV);
         });
@@ -79,9 +93,7 @@ describe('RC2b: Pine integer division (__idiv)', () => {
         });
 
         // REGRESSION (2, zigzag): a `var float x = na` reassigned from a float
-        // pivot must stay float. JOIN semantics: once a variable holds a notint
-        // value (its na initializer), it stays notint forever, so a mis-typed
-        // signature can never upgrade it to int and truncate its range math.
+        // pivot must stay float (JOIN semantics: once notint, always notint).
         it('var float = na reassigned from a float pivot stays float', () => {
             const js = tj([
                 'var float lastHigh = na',
@@ -97,49 +109,102 @@ describe('RC2b: Pine integer division (__idiv)', () => {
             expect(js).not.toContain(IDIV);
         });
     });
+});
 
-    // pine2js must preserve float-ness through codegen, otherwise int/float
-    // division is indistinguishable downstream (`2.0` flattened to `2`).
-    describe('float-literal preservation (pine2js codegen)', () => {
-        it('preserves an integer-valued float literal (2.0 stays 2.0)', () => {
-            expect(tj('y = 2.0')).toContain('2.0');
-        });
-        it('normalizes a dot-prefix literal (.5 → 0.5)', () => {
-            expect(tj('y = .5')).toContain('0.5');
-        });
+describe('Pine v6: int division NEVER truncates (no __idiv, ever)', () => {
+    it('int literal / int literal', () => {
+        expect(tj('x = 11 / 2', 6)).not.toContain(IDIV);
+    });
+    it('const int variable / int', () => {
+        expect(tj('iv = 7\ny = iv / 2', 6)).not.toContain(IDIV);
+    });
+    it('const-int arithmetic / int', () => {
+        expect(tj('y = (3 + 4) / 2', 6)).not.toContain(IDIV);
+    });
+    it('loop counter / int variable', () => {
+        expect(tj('int gridSteps = 4\nfloat f = na\nfor i = 1 to 3\n    f := i / gridSteps', 6)).not.toContain(IDIV);
     });
 });
 
-describe('RC2b: integer division runtime values', () => {
-    async function evalExprs(exprs: Record<string, string>): Promise<Record<string, any>> {
+describe('bare PineTS syntax: JS float-division semantics (no __idiv)', () => {
+    it('int literal / int literal stays native /', () => {
+        const js = transpile(`($) => {\n    const { plot } = $.pine;\n    plot(11 / 2, 'y');\n}`).toString();
+        expect(js).not.toContain(IDIV);
+    });
+});
+
+// pine2js must preserve float-ness through codegen, otherwise int/float
+// division is indistinguishable downstream (`2.0` flattened to `2`).
+describe('float-literal preservation (pine2js codegen)', () => {
+    it('preserves an integer-valued float literal (2.0 stays 2.0)', () => {
+        expect(tj('y = 2.0')).toContain('2.0');
+    });
+    it('normalizes a dot-prefix literal (.5 → 0.5)', () => {
+        expect(tj('y = .5')).toContain('0.5');
+    });
+});
+
+describe('integer division runtime values', () => {
+    async function runPine(script: string): Promise<Record<string, any>> {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
-        const lines = Object.entries(exprs).map(([name, e]) => `plotchar(${e}, '${name}');`).join('\n');
-        const code = `const { plotchar } = context.pine;\n${lines}`;
-        const { plots } = await pineTS.run(code);
+        const { plots } = await pineTS.run(script);
         const out: Record<string, any> = {};
-        for (const name of Object.keys(exprs)) out[name] = plots[name].data[0].value;
+        for (const [name, plot] of Object.entries(plots) as any) {
+            if (!name.startsWith('__')) out[name] = plot.data.at(-1).value;
+        }
         return out;
     }
 
-    it('truncates int/int toward zero', async () => {
-        const r = await evalExprs({ a: '11 / 2', b: '10 / 2', c: '7 / 2', d: '-11 / 2', e: '-7 / 2' });
-        expect(r.a).toBe(5);
-        expect(r.b).toBe(5);
-        expect(r.c).toBe(3);
-        expect(r.d).toBe(-5); // toward zero, NOT floor (-6)
-        expect(r.e).toBe(-3);
+    // Expected values from TradingView's v6 migration guide ("Fractional
+    // division of constants") and Pine v5 semantics.
+    it('v5: truncates const/const toward zero, preserves fraction otherwise', async () => {
+        const r = await runPine([
+            '//@version=5',
+            'indicator("t")',
+            'int gridSteps = 4',
+            'float fromLoop = na',
+            'for i = 1 to 3',
+            '    fromLoop := i / gridSteps',
+            'plot(fromLoop, "loop")',
+            'plot(11 / 2, "lit")',
+            'plot(-11 / 2, "negLit")',
+            'plot(5 / 2.0, "mixed")',
+        ].join('\n'));
+        expect(r.loop).toBe(0.75); // loop counter is series int → fractional even in v5
+        expect(r.lit).toBe(5); // const/const → truncated
+        expect(r.negLit).toBe(-5); // toward zero, NOT floor (-6)
+        expect(r.mixed).toBe(2.5);
     });
 
-    it('keeps float division exact', async () => {
-        const r = await evalExprs({ a: '11 / 2.0', b: '2.5 / 2', c: '(1.0 * 5) / 2' });
-        expect(r.a).toBe(5.5);
-        expect(r.b).toBe(1.25);
-        expect(r.c).toBe(2.5);
+    it('v6: always fractional', async () => {
+        const r = await runPine([
+            '//@version=6',
+            'indicator("t")',
+            'int gridSteps = 4',
+            'float fromLoop = na',
+            'for i = 1 to 3',
+            '    fromLoop := i / gridSteps',
+            'plot(fromLoop, "loop")',
+            'plot(5 / 2, "lit")',
+            'plot(5 / 2.0, "mixed")',
+        ].join('\n'));
+        expect(r.loop).toBe(0.75);
+        expect(r.lit).toBe(2.5);
+        expect(r.mixed).toBe(2.5);
     });
 
-    it('preserves div-by-zero semantics (Infinity / NaN), not na', async () => {
-        const r = await evalExprs({ a: '1 / 0', b: '0 / 0' });
-        expect(r.a).toBe(Infinity);
-        expect(Number.isNaN(r.b)).toBe(true);
+    it('v5: div-by-zero semantics preserved through __idiv (Infinity / NaN)', async () => {
+        const r = await runPine(['//@version=5', 'indicator("t")', 'plot(1 / 0, "inf")', 'plot(0 / 0, "nan")'].join('\n'));
+        expect(r.inf).toBe(Infinity);
+        expect(Number.isNaN(r.nan)).toBe(true);
+    });
+
+    it('bare PineTS syntax: JS float division', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+        const { plots } = await pineTS.run(($: any) => {
+            const { plotchar } = $.pine;
+            plotchar(11 / 2, 'a');
+        });
+        expect(plots['a'].data[0].value).toBe(5.5);
     });
 });

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -408,9 +408,11 @@ plot(sum)
         expect(jsCode).toContain('+');
         expect(jsCode).toContain('-');
         expect(jsCode).toContain('*');
-        // `10 / 2` is int/int division, which lowers to the Pine integer-division
-        // helper (RC2b: `__idiv`) rather than a raw `/`. `%` still transpiles native.
-        expect(jsCode).toContain('__idiv');
+        // Pine v6 never truncates int/int division (see the v6 migration guide,
+        // "Fractional division of constants"), so `10 / 2` stays a native `/`
+        // and must NOT lower to the v5-only `__idiv` helper.
+        expect(jsCode).toContain('/');
+        expect(jsCode).not.toContain('__idiv');
         expect(jsCode).toContain('%');
     });
 


### PR DESCRIPTION
## Summary

- Fixes silent wrong results for `int / int` division: the transpiler rewrote **every** provably-int `/` into the truncating `__idiv` helper, regardless of `//@version` and of operand qualifiers. Real Pine truncates only in **v5** and only for **`const int / const int`**; loop counters, mutable (`:=`) variables, `var` declarations, `input.int(...)`, and int builtins (`bar_index`, ...) preserve the fractional remainder even in v5, and **v6 never truncates** (see [TradingView's v6 migration guide, "Fractional division of constants"](https://www.tradingview.com/pine-script-docs/migration-guides/to-pine-version-6/)).
- `transpile()` now threads the detected Pine version through and runs the int-division pass **only for v5 sources**; v6+ scripts and bare PineTS/JS input always keep native float `/`.
- `TypeInferencePass` now uses a `constint`/`int`/`notint` lattice with a mutated-names pre-scan, so only compile-time const-int operands (int literals, arithmetic over them, and immutable non-`var` bindings of them) trigger the `__idiv` rewrite. Everything else fails safe to native `/`.
- Real-world impact example: LuxAlgo "Market Structure & Scatter Dashboard" (v6) computed `i / gridSteps` as 0 instead of 0.25/0.5/0.75, collapsing all grid lines and % labels onto the chart's center axes.

Before/after for the repro (`Provider.Mock`):

| Case | Expected (TradingView) | Before | After |
| --- | --- | --- | --- |
| v6 `i / gridSteps` (loop counter) | 0.75 | 0 | 0.75 |
| v6 `5 / 2` | 2.5 | 2 | 2.5 |
| v5 `i / gridSteps` (loop counter) | 0.75 | 0 | 0.75 |
| v5 `5 / 2` (const/const) | 2 | 2 | 2 |

## Tests

- Rewrote `tests/transpiler/int-division.test.ts` against the migration-guide reference (28 tests): v5 const/const truncation (toward zero), v5 fractional results for input/series/loop-counter/`var`/reassigned operands, v6 never truncating, bare PineTS syntax following JS float semantics, div-by-zero semantics, and the two historical over-truncation regressions (pivot prices, `var float = na` reassignment). 14 of them failed on the buggy behavior before the fix.
- Corrected two tests that had locked in the old behavior: `pinescript-to-js.test.ts` (asserted a v6 script emits `__idiv`) and the "Operator Precedence Complex" runtime values in `pinescript.test.ts` (PineTS-syntax `5 / 2` is 2.5, not 2).
- Full suite: 1766 passed; the only failure is a pre-existing one in gitignored `tests/_local` that reproduces identically on unmodified `dev`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core transpiler arithmetic for all Pine scripts. Fail-safe (missed truncation, not wrong truncation) but incorrect qualifier inference would still alter indicator math.
> 
> **Overview**
> Stops the transpiler from truncating **every** int `/` int. Truncation now happens only for **Pine v5** and only when **both operands are const ints**, matching TradingView’s v6 migration guide.
> 
> `transpile()` threads the `//@version` through and skips `TypeInferencePass` for v6+ and bare PineTS/JS input (native float `/`). The pass uses a `constint` / `int` / `notint` lattice plus a mutated-name scan so loop counters, `:=` reassignments, `var`, `input.int`, and series builtins like `bar_index` keep fractional results even in v5.
> 
> Tests cover v5 const/const truncation (toward zero), v5 fractional non-const cases, v6 never truncating, and PineTS JS semantics. This fixes scripts such as LuxAlgo’s Market Structure dashboard where `i / gridSteps` collapsed to 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d19e89acc6d1b8414419ba50b9b0d15c179c80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->