### PR TITLE
[0.9.32] - 2026-08-24 - Session Support, `runtime.error` & Version-Accurate Integer Division

### DIFF
--- a/.github/badges/api-builtin.svg
+++ b/.github/badges/api-builtin.svg
@@ -1,5 +1,5 @@
-<svg width="152.52" height="24" viewBox="0 0 1271 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="builtin: 57/63 (90%)">
-  <title>builtin: 57/63 (90%)</title>
+<svg width="152.52" height="24" viewBox="0 0 1271 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="builtin: 58/63 (92%)">
+  <title>builtin: 58/63 (92%)</title>
   <g>
     <rect fill="#555" width="442" height="200"/>
     <rect fill="#3C1" x="442" width="829" height="200"/>
@@ -7,8 +7,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="342" fill="#000" opacity="0.1">builtin</text>
     <text x="50" y="138" textLength="342">builtin</text>
-    <text x="497" y="148" textLength="729" fill="#000" opacity="0.1">57/63 (90%)</text>
-    <text x="487" y="138" textLength="729">57/63 (90%)</text>
+    <text x="497" y="148" textLength="729" fill="#000" opacity="0.1">58/63 (92%)</text>
+    <text x="487" y="138" textLength="729">58/63 (92%)</text>
   </g>
   
 </svg>

--- a/.github/badges/api-coverage.svg
+++ b/.github/badges/api-coverage.svg
@@ -1,5 +1,5 @@
-<svg width="118.9" height="20" viewBox="0 0 1189 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="API coverage: 96%">
-  <title>API coverage: 96%</title>
+<svg width="118.9" height="20" viewBox="0 0 1189 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="API coverage: 98%">
+  <title>API coverage: 98%</title>
   <g>
     <rect fill="#555" width="829" height="200"/>
     <rect fill="#3C1" x="829" width="360" height="200"/>
@@ -7,8 +7,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="729" fill="#000" opacity="0.1">API coverage</text>
     <text x="50" y="138" textLength="729">API coverage</text>
-    <text x="884" y="148" textLength="260" fill="#000" opacity="0.1">96%</text>
-    <text x="874" y="138" textLength="260">96%</text>
+    <text x="884" y="148" textLength="260" fill="#000" opacity="0.1">98%</text>
+    <text x="874" y="138" textLength="260">98%</text>
   </g>
   
 </svg>

--- a/.github/badges/api-session.svg
+++ b/.github/badges/api-session.svg
@@ -1,14 +1,14 @@
-<svg width="134.76" height="24" viewBox="0 0 1123 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="session: 0/9 (0%)">
-  <title>session: 0/9 (0%)</title>
+<svg width="151.56" height="24" viewBox="0 0 1263 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="session: 9/9 (100%)">
+  <title>session: 9/9 (100%)</title>
   <g>
     <rect fill="#555" width="504" height="200"/>
-    <rect fill="#E43" x="504" width="619" height="200"/>
+    <rect fill="#3C1" x="504" width="759" height="200"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="404" fill="#000" opacity="0.1">session</text>
     <text x="50" y="138" textLength="404">session</text>
-    <text x="559" y="148" textLength="519" fill="#000" opacity="0.1">0/9 (0%)</text>
-    <text x="549" y="138" textLength="519">0/9 (0%)</text>
+    <text x="559" y="148" textLength="659" fill="#000" opacity="0.1">9/9 (100%)</text>
+    <text x="549" y="138" textLength="659">9/9 (100%)</text>
   </g>
   
 </svg>

--- a/.github/badges/coverage.svg
+++ b/.github/badges/coverage.svg
@@ -1,20 +1,20 @@
-<svg width="132.1" height="20" viewBox="0 0 1321 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="test coverage: 82.8%">
-  <title>test coverage: 82.8%</title>
-  <linearGradient id="ikxzl" x2="0" y2="100%">
+<svg width="132.1" height="20" viewBox="0 0 1321 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="test coverage: 84.3%">
+  <title>test coverage: 84.3%</title>
+  <linearGradient id="fSqIB" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="VYawE"><rect width="1321" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#VYawE)">
+  <mask id="xIlXC"><rect width="1321" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#xIlXC)">
     <rect width="851" height="200" fill="#555"/>
     <rect width="470" height="200" fill="#3C1" x="851"/>
-    <rect width="1321" height="200" fill="url(#ikxzl)"/>
+    <rect width="1321" height="200" fill="url(#fSqIB)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="751" fill="#000" opacity="0.25">test coverage</text>
     <text x="50" y="138" textLength="751">test coverage</text>
-    <text x="906" y="148" textLength="370" fill="#000" opacity="0.25">82.8%</text>
-    <text x="896" y="138" textLength="370">82.8%</text>
+    <text x="906" y="148" textLength="370" fill="#000" opacity="0.25">84.3%</text>
+    <text x="896" y="138" textLength="370">84.3%</text>
   </g>
   
 </svg>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## [0.9.32] - 2026-08-24 - Session Support, `runtime.error` & Version-Accurate Integer Division
+
+### Fixed
+
+- **`int / int` truncation ignored the Pine version and the operands' qualifiers**: 0.9.28's integer-division pass truncated **every** division whose operands statically inferred as `int`. Real Pine truncates only in **v5**, and only when both operands are **`const`-qualified** ints — loop counters, mutable variables, `input.int` and int builtins keep the fractional remainder, and **v6 never truncates at all** (TradingView v6 migration guide, "Fractional division of constants"). The detected `//@version` is now threaded through **`transpile()`** and the pass is gated to v5 sources (v6+ and bare PineTS/JS input keep native float `/`). **`TypeInferencePass`** was reworked from a binary int/notint split to a **`constint` / `int` / `notint`** lattice with a mutated-names pre-scan, so only compile-time-constant int operands trigger the `math.__idiv` rewrite.
+- **`runtime.error()` crashed with `ReferenceError: runtime is not defined`**: the `runtime` namespace did not exist, so any script *referencing* it failed as soon as the call executed — instead of TV's behavior (no-op when the guarding branch is not taken, halt with the script's message when it is). New **`src/namespaces/Runtime.ts`**: `runtime.error(message)` throws the existing catchable `PineRuntimeError` (`method: 'runtime.error'`), registered on `$.pine` and added to `CONTEXT_PINE_VARS` so the transpiler injects the namespace binding.
+- **`last_bar_index` tracked the running `bar_index` instead of the chart's constant last-bar index**: it was derived from the progressively-fed `data.close` window, so it returned the **current** bar's index on every bar — `bar_index < last_bar_index` was false everywhere, breaking every "not the last bar" guard. It now reads the length of the fully-preloaded `marketData` array: a constant across the whole historical run, as in TV (it only grows when realtime bars are appended). The window-based read remains as a best-effort fallback when `marketData` is unavailable.
+- **`time(timeframe, session, timezone)` mis-parsed session specs**: any `:days` suffix failed the `HHMM-HHMM` regex, so **every bar was silently treated as in-session**. The new parser (**`src/namespaces/sessionSpec.ts`**) handles full Pine session strings — comma-separated `HHMM-HHMM` windows, the `:days` suffix (`1` = Sunday … `7` = Saturday), overnight sessions belonging to the day they **end**, `"0000"` as end-of-day, and `"24x7"` — and malformed strings now throw `PineRuntimeError` like TV instead of passing silently.
+- **`timenow` crashed with a `ReferenceError`**: the runtime getter existed, but the identifier was never registered in the transpiler settings, so it was never injected into the generated code.
+- **User variables named after a constant namespace crashed**: TV allows `position`, `font`, `order`, `currency`, `dayofweek`, `adjustment` and `barmerge` as user variable names while namespace member access still works. These seven were missing from `NAMESPACE_COLLISION_NAMES`, so the codegen rename pass never renamed the user variable and the namespace was no longer injected from `$.pine` → `ReferenceError: <name> is not defined`.
+
+### Added
+
+- **`session` namespace**: `session.regular` / `session.extended` constants, `session.isfirstbar` / `session.islastbar` (plus their `*_regular` variants), and `session.ismarket` / `session.ispremarket` / `session.ispostmarket`.
+- **Tests**: `tests/namespaces/runtime.test.ts` (guarded call is a no-op, halts with the exact message, throws a catchable `PineRuntimeError`, PineTS-syntax path); `tests/core/last-bar-index.test.ts` (constant on every bar, equals the final `bar_index`, `bar_index < last_bar_index` true on all bars but the last); `tests/namespaces/time-session-spec.test.ts`, `tests/namespaces/session-namespace.test.ts` and `tests/core/timenow.test.ts`; `tests/transpiler/namespace-identifier-collision.test.ts` (each of the seven namespaces shadowed, plus non-shadowed usage); and a reworked `tests/transpiler/int-division.test.ts` with reference-correct v5/v6 expectations (the original repro kept as a guard).
+
+---
+
 ## [0.9.31] - 2026-08-12 - Input Source Runtime Overrides
 
 ### Fixed

--- a/docs/api-coverage/builtin.md
+++ b/docs/api-coverage/builtin.md
@@ -82,4 +82,4 @@ parent: API Coverage
 | `timestamp()`      | ✅     | Timestamp function    |
 | `weekofyear()`     | ✅     | Week of year function |
 | `year()`           | ✅     | Year function         |
-| `runtime.error()`  |        | Runtime error         |
+| `runtime.error()`  | ✅     | Runtime error         |

--- a/docs/api-coverage/pinescript-v6/builtin.json
+++ b/docs/api-coverage/pinescript-v6/builtin.json
@@ -62,6 +62,6 @@
         "timestamp()": true,
         "weekofyear()": true,
         "year()": true,
-        "runtime.error()": false
+        "runtime.error()": true
     }
 }

--- a/docs/api-coverage/pinescript-v6/session.json
+++ b/docs/api-coverage/pinescript-v6/session.json
@@ -1,15 +1,15 @@
 {
   "Session Flags": {
-    "session.isfirstbar": false,
-    "session.isfirstbar_regular": false,
-    "session.islastbar": false,
-    "session.islastbar_regular": false,
-    "session.ismarket": false,
-    "session.ispostmarket": false,
-    "session.ispremarket": false
+    "session.isfirstbar": true,
+    "session.isfirstbar_regular": true,
+    "session.islastbar": true,
+    "session.islastbar_regular": true,
+    "session.ismarket": true,
+    "session.ispostmarket": true,
+    "session.ispremarket": true
   },
   "Session Constants": {
-    "session.extended": false,
-    "session.regular": false
+    "session.extended": true,
+    "session.regular": true
   }
 }

--- a/docs/api-coverage/runtime.md
+++ b/docs/api-coverage/runtime.md
@@ -8,4 +8,4 @@ parent: API Coverage
 
 | Function          | Status |
 | ----------------- | ------ |
-| `runtime.error()` |        |
+| `runtime.error()` | ✅     |

--- a/docs/api-coverage/session.md
+++ b/docs/api-coverage/session.md
@@ -10,17 +10,17 @@ parent: API Coverage
 
 | Function                     | Status | Description                  |
 | ---------------------------- | ------ | ---------------------------- |
-| `session.isfirstbar`         |        | First bar of session         |
-| `session.isfirstbar_regular` |        | First bar of regular session |
-| `session.islastbar`          |        | Last bar of session          |
-| `session.islastbar_regular`  |        | Last bar of regular session  |
-| `session.ismarket`           |        | Market session               |
-| `session.ispostmarket`       |        | Post-market session          |
-| `session.ispremarket`        |        | Pre-market session           |
+| `session.isfirstbar`         | ✅     | First bar of session         |
+| `session.isfirstbar_regular` | ✅     | First bar of regular session |
+| `session.islastbar`          | ✅     | Last bar of session          |
+| `session.islastbar_regular`  | ✅     | Last bar of regular session  |
+| `session.ismarket`           | ✅     | Market session               |
+| `session.ispostmarket`       | ✅     | Post-market session          |
+| `session.ispremarket`        | ✅     | Pre-market session           |
 
 ### Session Constants
 
 | Function           | Status | Description               |
 | ------------------ | ------ | ------------------------- |
-| `session.extended` |        | Extended session constant |
-| `session.regular`  |        | Regular session constant  |
+| `session.extended` | ✅     | Extended session constant |
+| `session.regular`  | ✅     | Regular session constant  |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pinets",
-    "version": "0.9.31",
+    "version": "0.9.32",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pinets",
-            "version": "0.9.31",
+            "version": "0.9.32",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "acorn": "^8.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pinets",
-    "version": "0.9.31",
+    "version": "0.9.32",
     "description": "Run Pine Script anywhere. PineTS is an open-source transpiler and runtime that brings Pine Script logic to Node.js and the browser with 1:1 syntax compatibility. Reliably write, port, and run indicators or strategies on your own infrastructure.",
     "keywords": [
         "Pine Script",

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -17,6 +17,7 @@ import { PineTypeObject } from './namespaces/PineTypeObject';
 import { Strategy, StrategyState } from './namespaces/strategy/strategy.index';
 import { Series } from './Series';
 import { Log } from './namespaces/Log';
+import { Runtime } from './namespaces/Runtime';
 import { Str } from './namespaces/Str';
 import types, { display, shape } from './namespaces/Types';
 import { Timeframe } from './namespaces/Timeframe';
@@ -259,6 +260,7 @@ export class Context {
                 return _this.inputs;
             },
             log: new Log(this),
+            runtime: new Runtime(this),
             str: new Str(this),
             // linefill namespace will be bound below via bindContextObject
             ...coreFunctions,

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -6,6 +6,7 @@ import { PineArray } from './namespaces/array/array.index';
 import { PineMap } from './namespaces/map/map.index';
 import { PineMatrix } from './namespaces/matrix/matrix.index';
 import { Barstate } from './namespaces/Barstate';
+import { Session } from './namespaces/Session';
 import { Core, NAHelper, AlertHelper } from './namespaces/Core';
 import { PineColor } from './namespaces/color/PineColor';
 import { TimeHelper, TimeComponentHelper, EXTRACTORS, getDatePartsInTimezone } from './namespaces/Time';
@@ -222,6 +223,7 @@ export class Context {
             //FIXME : this is a temporary solution to get the barstate values,
             //we need to implement a better way to handle realtime states
             barstate: new Barstate(this),
+            session: new Session(this),
             get bar_index() {
                 return _this.data.bar_index;
             },

--- a/src/Context.class.ts
+++ b/src/Context.class.ts
@@ -226,6 +226,18 @@ export class Context {
                 return _this.data.bar_index;
             },
             get last_bar_index() {
+                // TV semantics: `last_bar_index` is the bar_index of the LAST
+                // bar of the chart's history — a CONSTANT across the whole
+                // historical run (it only grows when new realtime bars are
+                // appended). `bar_index` values are the raw indices into the
+                // full preloaded `marketData` array, so its last index is the
+                // constant we need. Falling back to the progressively-fed
+                // `data.close` window (current bar's index) is best-effort if
+                // marketData isn't available.
+                const md = _this.marketData;
+                if (Array.isArray(md) && md.length > 0) {
+                    return md.length - 1;
+                }
                 return _this.data.close.length - 1;
             },
             get last_bar_time() {

--- a/src/namespaces/Runtime.ts
+++ b/src/namespaces/Runtime.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import { Series } from '../Series';
+import { Context } from '..';
+import { PineRuntimeError } from '../errors/PineRuntimeError';
+
+/**
+ * Pine Script `runtime` namespace.
+ *
+ * `runtime.error(message)` halts script execution with a runtime error,
+ * mirroring TradingView behavior. The thrown PineRuntimeError propagates
+ * out of the run loop so consumers can catch it (see PineRuntimeError docs).
+ */
+export class Runtime {
+    constructor(private context: Context) {}
+
+    param(source: any, index: number = 0, _name?: string) {
+        return Series.from(source).get(index);
+    }
+
+    error(message: any): never {
+        const msg = Series.from(message).get(0);
+        throw new PineRuntimeError(typeof msg === 'string' ? msg : String(msg ?? ''), 'runtime.error');
+    }
+}

--- a/src/namespaces/Session.ts
+++ b/src/namespaces/Session.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { getDatePartsInTimezone } from './Time';
+
+/**
+ * Pine Script `session` namespace.
+ *
+ * Constants:
+ * - session.regular / session.extended — session-type strings for ticker.new()/ticker.modify().
+ *
+ * Variables:
+ * - session.isfirstbar / session.islastbar — first/last bar of the trading session.
+ * - session.isfirstbar_regular / session.islastbar_regular — same, for the regular session.
+ * - session.ismarket / session.ispremarket / session.ispostmarket — intra-session location.
+ *
+ * PineTS providers serve continuous (regular-session) data, and the reference
+ * providers are 24/7 crypto markets where a trading session is a calendar day
+ * in the exchange timezone. Session boundaries are therefore detected as
+ * trading-day changes between consecutive bars in `syminfo.timezone`. All bars
+ * belong to the market session, so `ismarket` is always true and the
+ * pre/post-market flags are always false.
+ */
+export class Session {
+    public readonly regular = 'regular';
+    public readonly extended = 'extended';
+
+    constructor(private context: any) {}
+
+    private get _timezone(): string {
+        return this.context.pine?.syminfo?.timezone || 'UTC';
+    }
+
+    /** Calendar-day key ("Y-M-D" in exchange timezone) of a bar's open time. */
+    private _dayKey(timestamp: number): string {
+        const parts = getDatePartsInTimezone(timestamp, this._timezone);
+        return `${parts.year}-${parts.month}-${parts.day}`;
+    }
+
+    public get isfirstbar(): boolean {
+        const idx = this.context.idx;
+        const md = this.context.marketData;
+        if (!Array.isArray(md) || !md[idx]) return false;
+        if (idx === 0) return true;
+        return this._dayKey(md[idx].openTime) !== this._dayKey(md[idx - 1].openTime);
+    }
+
+    public get islastbar(): boolean {
+        const idx = this.context.idx;
+        const md = this.context.marketData;
+        if (!Array.isArray(md) || !md[idx]) return false;
+        if (idx === md.length - 1) return true;
+        return this._dayKey(md[idx].openTime) !== this._dayKey(md[idx + 1].openTime);
+    }
+
+    public get isfirstbar_regular(): boolean {
+        return this.isfirstbar;
+    }
+
+    public get islastbar_regular(): boolean {
+        return this.islastbar;
+    }
+
+    public get ismarket(): boolean {
+        return true;
+    }
+
+    public get ispremarket(): boolean {
+        return false;
+    }
+
+    public get ispostmarket(): boolean {
+        return false;
+    }
+}

--- a/src/namespaces/Time.ts
+++ b/src/namespaces/Time.ts
@@ -2,6 +2,8 @@
 
 import { Series } from '../Series';
 import { parseArgsForPineParams } from './utils';
+import { parseSessionSpec, isInSessionSpec } from './sessionSpec';
+import { PineRuntimeError } from '../errors/PineRuntimeError';
 
 // ── Timeframe alignment utilities ───────────────────────────────────
 
@@ -271,33 +273,20 @@ export class TimeHelper {
     }
 
     /**
-     * Basic session check: parses "HHMM-HHMM" format and tests if
-     * the timestamp falls within the session window.
+     * Session check: parses a full Pine session string — comma-separated
+     * "HHMM-HHMM" windows with an optional ":days" suffix (1=Sunday..7=Saturday)
+     * — and tests whether the timestamp falls within the session.
+     * Malformed session strings halt the script, mirroring TradingView.
      */
     private _isInSession(timestamp: number, session: string, timezone: string): boolean {
-        // Parse session format "HHMM-HHMM" (e.g. "0930-1600")
-        const match = session.match(/^(\d{2})(\d{2})-(\d{2})(\d{2})$/);
-        if (!match) return true; // If session format is unrecognized, pass through
-
-        const startHour = parseInt(match[1], 10);
-        const startMin = parseInt(match[2], 10);
-        const endHour = parseInt(match[3], 10);
-        const endMin = parseInt(match[4], 10);
-
-        // Get hour/minute in the target timezone using the shared utility
-        const parts = getDatePartsInTimezone(timestamp, timezone);
-        const hour = parts.hour;
-        const minute = parts.minute;
-
-        const barTime = hour * 60 + minute;
-        const sessionStart = startHour * 60 + startMin;
-        const sessionEnd = endHour * 60 + endMin;
-
-        if (sessionStart <= sessionEnd) {
-            return barTime >= sessionStart && barTime < sessionEnd;
+        const spec = parseSessionSpec(session);
+        if (!spec) {
+            throw new PineRuntimeError(`Invalid session specification: "${session}"`, 'time');
         }
-        // Overnight session (e.g. "1800-0930")
-        return barTime >= sessionStart || barTime < sessionEnd;
+
+        const parts = getDatePartsInTimezone(timestamp, timezone);
+        const minutesOfDay = parts.hour * 60 + parts.minute;
+        return isInSessionSpec(spec, minutesOfDay, parts.dayOfWeek);
     }
 }
 

--- a/src/namespaces/math/methods/__idiv.ts
+++ b/src/namespaces/math/methods/__idiv.ts
@@ -3,15 +3,16 @@
 import { Series } from '../../../Series';
 
 /**
- * Pine integer division — the `/` (and `%`, via the transpiler) operator applied
- * to two **integer** operands. In Pine, `int / int` yields an `int`: the result
- * is truncated toward zero (`11 / 2 === 5`, `-11 / 2 === -5`), whereas JavaScript
- * `/` is always float division (`5.5`).
+ * Pine v5 constant integer division. In Pine v5, `/` truncates toward zero
+ * (`11 / 2 === 5`, `-11 / 2 === -5`) ONLY when both operands are
+ * 'const'-qualified ints; any 'input'/'simple'/'series' int operand preserves
+ * the fractional remainder, and Pine v6+ never truncates at all (see
+ * TradingView's v6 migration guide, "Fractional division of constants").
  *
- * The transpiler rewrites a `/` BinaryExpression to this helper ONLY when BOTH
- * operands are provably `int` at compile time (see TypeInferencePass). Any float
- * operand keeps native `/`, so genuine float division (`4.0 / 2.0`, `close / 2`)
- * is untouched.
+ * The transpiler rewrites a `/` BinaryExpression to this helper ONLY for v5
+ * sources and ONLY when BOTH operands are provably const int at compile time
+ * (see TypeInferencePass). Everything else keeps native `/`, so genuine
+ * fractional division (`4.0 / 2.0`, `close / 2`, `i / 4`) is untouched.
  *
  * Semantics:
  * - `na` (NaN) in either operand propagates → NaN.

--- a/src/namespaces/sessionSpec.ts
+++ b/src/namespaces/sessionSpec.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Pine Script session-string parsing and matching.
+ *
+ * Session string syntax (see TradingView docs, "Sessions"):
+ *
+ *     <time_period>[,<time_period>...][:<days>]
+ *
+ * - <time_period> is "HHmm-HHmm" in 24-hour exchange time. Multiple
+ *   comma-separated periods describe a session with breaks.
+ * - <days> is a set of digits 1-7 (1 = Sunday ... 7 = Saturday). When
+ *   omitted, the session applies to all days ("1234567").
+ * - "24x7" is a special string equivalent to "0000-0000:1234567".
+ * - An end time of "0000" means end-of-day midnight, so "0000-0000" is a
+ *   full 24-hour session on each applicable day.
+ * - When the start time is at or after the end time the session spans
+ *   midnight; per TradingView, such an overnight session belongs to the
+ *   day it ENDS on (e.g. "1700-1700:2" starts Sunday 17:00 and ends
+ *   Monday 17:00 — the Monday trading day).
+ */
+
+interface SessionWindow {
+    /** Minutes from midnight, inclusive. */
+    start: number;
+    /** Minutes from midnight, exclusive. End-of-day midnight is 1440. */
+    end: number;
+}
+
+export interface SessionSpec {
+    windows: SessionWindow[];
+    /** Pine day numbers the session applies to: 1 = Sunday ... 7 = Saturday. */
+    days: Set<number>;
+}
+
+const WINDOW_RE = /^(\d{2})(\d{2})-(\d{2})(\d{2})$/;
+
+/**
+ * Parse a Pine session string. Returns null when the string is malformed
+ * (callers decide whether that is a runtime error).
+ */
+export function parseSessionSpec(spec: string): SessionSpec | null {
+    if (typeof spec !== 'string') return null;
+    const trimmed = spec.trim();
+    if (!trimmed) return null;
+
+    if (trimmed === '24x7') {
+        return { windows: [{ start: 0, end: 1440 }], days: new Set([1, 2, 3, 4, 5, 6, 7]) };
+    }
+
+    const colonParts = trimmed.split(':');
+    if (colonParts.length > 2) return null;
+
+    const days = new Set<number>();
+    if (colonParts.length === 2) {
+        if (!/^[1-7]+$/.test(colonParts[1])) return null;
+        for (const digit of colonParts[1]) days.add(parseInt(digit, 10));
+    } else {
+        for (let d = 1; d <= 7; d++) days.add(d);
+    }
+
+    const windows: SessionWindow[] = [];
+    for (const period of colonParts[0].split(',')) {
+        const match = period.match(WINDOW_RE);
+        if (!match) return null;
+
+        const startHour = parseInt(match[1], 10);
+        const startMin = parseInt(match[2], 10);
+        const endHour = parseInt(match[3], 10);
+        const endMin = parseInt(match[4], 10);
+        if (startHour > 23 || startMin > 59 || endHour > 23 || endMin > 59) return null;
+
+        const start = startHour * 60 + startMin;
+        // "0000" as an end time means end-of-day midnight (24:00).
+        const end = endHour === 0 && endMin === 0 ? 1440 : endHour * 60 + endMin;
+        windows.push({ start, end });
+    }
+
+    return { windows, days };
+}
+
+/**
+ * Test whether a bar time (already decomposed in the session's timezone)
+ * falls inside the session.
+ *
+ * @param minutesOfDay minutes since midnight in the session timezone
+ * @param jsDayOfWeek  JS day-of-week convention (0 = Sunday ... 6 = Saturday)
+ */
+export function isInSessionSpec(spec: SessionSpec, minutesOfDay: number, jsDayOfWeek: number): boolean {
+    const pineDayToday = jsDayOfWeek + 1; // 1 = Sunday ... 7 = Saturday
+    const pineDayTomorrow = (pineDayToday % 7) + 1;
+
+    for (const { start, end } of spec.windows) {
+        if (start < end) {
+            // Same-day window; the trading day is the current day.
+            if (minutesOfDay >= start && minutesOfDay < end && spec.days.has(pineDayToday)) return true;
+        } else {
+            // Overnight window (start >= end): the trading day is the day the
+            // session ends. The pre-midnight part belongs to tomorrow's
+            // trading day, the post-midnight part to today's.
+            if (minutesOfDay >= start && spec.days.has(pineDayTomorrow)) return true;
+            if (minutesOfDay < end && spec.days.has(pineDayToday)) return true;
+        }
+    }
+    return false;
+}

--- a/src/transpiler/analysis/TypeInferencePass.ts
+++ b/src/transpiler/analysis/TypeInferencePass.ts
@@ -1,38 +1,44 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * TypeInferencePass — Pine base-type inference (RC2b P0).
+ * TypeInferencePass — Pine v5 const-int division inference.
  *
  * Runs BEFORE the main lowering pass, on the clean AST (operands are still bare
- * identifiers, `input.int(...)` calls, and literals — not yet `$.get(...)`).
+ * identifiers and literals — not yet `$.get(...)`), and ONLY for Pine v5 sources
+ * (the caller in `transpiler/index.ts` gates on the //@version directive).
  *
- * Purpose: replicate Pine's `int / int → int` semantics. JavaScript `/` is always
- * float division (`11 / 2 === 5.5`), but Pine truncates toward zero when both
- * operands are integers (`11 / 2 === 5`, `-11 / 2 === -5`). Int-ness is a
- * compile-time fact — a `float` series holding `4.0` is an ordinary JS number at
- * runtime — so a static pass is the only correct discriminator.
+ * Purpose: replicate Pine v5's `const int / const int → int` truncation.
+ * Per TradingView's v6 migration guide ("Fractional division of constants"):
  *
- * When a `/` BinaryExpression has BOTH operands provably `int`, it is rewritten in
- * place to `$.pine.math.__idiv(left, right)`; the main pass then lowers the operand
- * subtrees inside the call args. Anything not provably int keeps native `/`, so
- * partial coverage never corrupts a genuine float division — the worst case is a
- * missed truncation.
+ *   - In v5, `int / int` truncates toward zero ONLY when BOTH operands are
+ *     qualified as 'const' (compile-time constants): `5 / 2 === 2`.
+ *   - If at least one operand is 'input', 'simple', or 'series' — loop counters,
+ *     mutable (`:=`-reassigned) variables, `var` declarations, `input.int(...)`,
+ *     int builtins like `bar_index` — the fractional remainder is PRESERVED
+ *     even in v5: `i / 4 === 0.75`.
+ *   - In v6, `int / int` NEVER truncates, regardless of qualifiers. (v6 scripts
+ *     never reach this pass.)
  *
- * Scope note (P0): the ONLY consumer of type info is the `/` rewrite, so we track
- * a minimal lattice — `int` vs `notint` (float / string / bool / na / unknown).
- * `notint` simply means "not provably int", which is all the rewrite needs. A
- * fuller int/float/bool/string lattice (for str.tostring formatting, casts, etc.)
- * can be layered on later without changing this rewrite.
+ * When a `/` BinaryExpression has BOTH operands provably const int, it is
+ * rewritten in place to `$.pine.math.__idiv(left, right)`; the main pass then
+ * lowers the operand subtrees inside the call args. Anything not provably
+ * const-int keeps native `/`, so partial coverage never corrupts a genuine
+ * fractional division — the worst case is a missed truncation.
+ *
+ * Lattice: `constint` (compile-time int constant) → `int` (int-typed but
+ * input/simple/series-qualified) → `notint` (float / string / bool / na /
+ * unknown). Only `constint / constint` triggers the rewrite; the `int` tier
+ * exists so int-ness still propagates through arithmetic without ever
+ * upgrading a non-const operand to const.
  */
-import * as walk from 'acorn-walk';
 import ScopeManager from './ScopeManager';
 import { ASTFactory } from '../utils/ASTFactory';
 
-type T = 'int' | 'notint';
+type T = 'constint' | 'int' | 'notint';
 
 /**
- * Built-in variables that are `int`-typed in Pine. Their divisions (`bar_index / 2`)
- * are integer division even though at runtime they are plain JS numbers.
+ * Built-in variables that are `int`-typed in Pine. They are series-qualified,
+ * never 'const', so they can propagate int-ness but never trigger truncation.
  */
 const INT_BUILTIN_VARS = new Set<string>([
     'bar_index', 'last_bar_index',
@@ -41,17 +47,17 @@ const INT_BUILTIN_VARS = new Set<string>([
 ]);
 
 /**
- * Built-in calls that RETURN `int` (dotted callee name). CONSERVATIVE subset —
- * only functions whose result is unambiguously an int (counts, indices, bar
- * offsets). Anything absent defaults to `notint` (no truncation), so an omission
- * is a safe missed-truncation, never a wrong one.
+ * Built-in calls that RETURN `int` (dotted callee name). All are 'input',
+ * 'simple' or 'series' qualified — never 'const' — so they propagate int-ness
+ * without enabling truncation. CONSERVATIVE subset — anything absent defaults
+ * to `notint`, which is a safe missed inference, never a wrong one.
  *
  * Deliberately EXCLUDED (fail-safe on uncertainty):
  * - `ta.pivothigh` / `ta.pivotlow` — return the pivot PRICE (float), not a bar
  *   count. (Listing them as int caused a real over-truncation regression.)
  * - `math.round` — overloaded (1-arg → int, 2-arg → float).
  * - `math.sign`, `str.pos`, `input.time` — return type uncertain; excluded until
- *   verified rather than risk truncating a float.
+ *   verified rather than risk mis-typing a float.
  */
 const INT_RETURNING_CALLS = new Set<string>([
     'input.int',
@@ -92,6 +98,43 @@ function calleeName(callee: any): string | null {
     return null;
 }
 
+/**
+ * Collect every identifier name that is EVER written after declaration —
+ * `:=` reassignments (AssignmentExpression) and loop-counter updates
+ * (UpdateExpression / compound assignment in for-headers). Pine qualifies a
+ * mutated variable as 'series' program-wide, so a single write anywhere
+ * disqualifies the name from 'const' everywhere. Name-based (not scope-based):
+ * a shadowed name may be over-disqualified, which fails safe (missed
+ * truncation), never wrong.
+ */
+function collectMutatedNames(ast: any): Set<string> {
+    const mutated = new Set<string>();
+    (function scan(node: any): void {
+        if (!node || typeof node !== 'object') return;
+        if (node.type === 'AssignmentExpression' && node.left?.type === 'Identifier') {
+            mutated.add(node.left.name);
+        } else if (node.type === 'UpdateExpression' && node.argument?.type === 'Identifier') {
+            mutated.add(node.argument.name);
+        }
+        for (const key in node) {
+            if (key === 'type' || key === 'start' || key === 'end' || key === 'loc' || key === 'raw') continue;
+            const child = node[key];
+            if (Array.isArray(child)) {
+                for (const c of child) if (c && typeof c === 'object') scan(c);
+            } else if (child && typeof child === 'object') {
+                scan(child);
+            }
+        }
+    })(ast);
+    return mutated;
+}
+
+/** JOIN two types: int-ness survives only if both sides are int-ish, and the
+ *  result of a join is never const (a value that can vary is not a constant). */
+function join(a: T, b: T): T {
+    return a !== 'notint' && b !== 'notint' ? 'int' : 'notint';
+}
+
 /** Scope stack of variable-name → inferred type. Pine rarely shadows, but function
  *  bodies get their own frame so a param never leaks a type to the global scope. */
 class Env {
@@ -108,46 +151,46 @@ class Env {
         return undefined;
     }
     /**
-     * Reassignment (`x := ...`): JOIN with the existing type. A variable is `int`
-     * only if EVERY value it holds is `int`; once it takes a `notint` value (its
-     * `na`/float initializer, or any float assignment) it stays `notint` forever.
-     * This mirrors Pine's "type is fixed at declaration" — a `var float x = na`
-     * reassigned to a float pivot stays float — and fails safe: a mis-typed
-     * signature can never upgrade a float variable to int and truncate it.
+     * Reassignment (`x := ...`): JOIN with the existing type. A variable is
+     * int-ish only if EVERY value it holds is int-ish; once it takes a `notint`
+     * value (its `na`/float initializer, or any float assignment) it stays
+     * `notint` forever. This mirrors Pine's "type is fixed at declaration" — a
+     * `var float x = na` reassigned to a float pivot stays float — and fails
+     * safe: a mis-typed signature can never upgrade a float variable to int.
      */
     assign(name: string, t: T): void {
         for (let i = this.stack.length - 1; i >= 0; i--) {
             if (this.stack[i].has(name)) {
-                const cur = this.stack[i].get(name);
-                this.stack[i].set(name, cur === 'int' && t === 'int' ? 'int' : 'notint');
+                this.stack[i].set(name, join(this.stack[i].get(name)!, t));
                 return;
             }
         }
-        this.stack[this.stack.length - 1].set(name, t);
+        this.stack[this.stack.length - 1].set(name, join(t, t));
     }
 }
 
 export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): void {
     const env = new Env();
+    const mutatedNames = collectMutatedNames(ast);
 
     // Visit a node; for expressions, return its inferred type AND rewrite any
-    // provably-int `/` inside it. Every child is visited exactly once so no
-    // division is missed. Unknown/unhandled shapes fall back to generic child
+    // provably-const-int `/` inside it. Every child is visited exactly once so
+    // no division is missed. Unknown/unhandled shapes fall back to generic child
     // recursion and yield `notint` (safe: no rewrite).
     function visit(node: any): T {
         if (!node || typeof node !== 'object') return 'notint';
 
         switch (node.type) {
             case 'Literal':
-                if (typeof node.value === 'number') return isIntLiteral(node) ? 'int' : 'notint';
+                if (typeof node.value === 'number') return isIntLiteral(node) ? 'constint' : 'notint';
                 return 'notint';
 
             case 'Identifier':
-                if (INT_BUILTIN_VARS.has(node.name)) return 'int';
+                if (INT_BUILTIN_VARS.has(node.name)) return 'int'; // series int, never const
                 return env.get(node.name) ?? 'notint';
 
             case 'UnaryExpression':
-                // Unary +/- preserve numeric type (`-11` is int); `!`/`~` are notint.
+                // Unary +/- preserve numeric type (`-11` is const int); `!`/`~` are notint.
                 if (node.operator === '-' || node.operator === '+') return visit(node.argument);
                 visit(node.argument);
                 return 'notint';
@@ -155,21 +198,23 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
             case 'BinaryExpression': {
                 const lt = visit(node.left);
                 const rt = visit(node.right);
-                const bothInt = lt === 'int' && rt === 'int';
                 if (node.operator === '/') {
-                    if (bothInt) {
-                        // int / int → int (truncated toward zero). Rewrite in place;
-                        // the main pass lowers node.left / node.right in the args.
+                    if (lt === 'constint' && rt === 'constint') {
+                        // v5 const int / const int → const int (truncated toward
+                        // zero). Rewrite in place; the main pass lowers
+                        // node.left / node.right in the args.
                         const call = ASTFactory.createMathIntDivCall(node.left, node.right);
                         Object.assign(node, call);
-                        return 'int';
+                        return 'constint';
                     }
+                    // Any non-const int operand → fractional result (even in v5).
                     return 'notint';
                 }
-                // `+ - * %` preserve int when both operands are int (so a downstream
-                // `/` sees the propagated int-ness). Comparisons / others → notint.
+                // `+ - * %` preserve int-ness (and const-ness) so a downstream
+                // `/` sees it. Comparisons / others → notint.
                 if (node.operator === '+' || node.operator === '-' || node.operator === '*' || node.operator === '%') {
-                    return bothInt ? 'int' : 'notint';
+                    if (lt === 'constint' && rt === 'constint') return 'constint';
+                    return lt !== 'notint' && rt !== 'notint' ? 'int' : 'notint';
                 }
                 return 'notint';
             }
@@ -178,7 +223,9 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
                 visit(node.test);
                 const c = visit(node.consequent);
                 const a = visit(node.alternate);
-                return c === 'int' && a === 'int' ? 'int' : 'notint';
+                // Never const: we don't track bool const-ness of the test, and a
+                // missed truncation is safe while a wrong one is not.
+                return join(c, a);
             }
 
             case 'LogicalExpression':
@@ -203,8 +250,17 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
 
             case 'VariableDeclaration': {
                 for (const d of node.declarations || []) {
-                    const t = d.init ? visit(d.init) : 'notint';
-                    if (d.id?.type === 'Identifier') env.set(d.id.name, t);
+                    let t = d.init ? visit(d.init) : 'notint';
+                    if (d.id?.type === 'Identifier') {
+                        // Const-ness requires an immutable non-`var` binding:
+                        // `var`/`varip` declarations and any name that is ever
+                        // reassigned (incl. loop counters) are at best simple/
+                        // series ints in Pine's qualifier model.
+                        if (t === 'constint' && (node.kind === 'var' || mutatedNames.has(d.id.name))) {
+                            t = 'int';
+                        }
+                        env.set(d.id.name, t);
+                    }
                 }
                 return 'notint';
             }
@@ -212,7 +268,7 @@ export function runTypeInferencePass(ast: any, _scopeManager: ScopeManager): voi
             case 'AssignmentExpression': {
                 const t = visit(node.right);
                 // `x := ...` reassignment: JOIN with the existing type (never
-                // upgrades a notint variable to int — see Env.assign).
+                // upgrades a notint variable, never yields const — see Env.assign).
                 if (node.left?.type === 'Identifier') env.assign(node.left.name, t);
                 else visit(node.left);
                 return t;

--- a/src/transpiler/index.ts
+++ b/src/transpiler/index.ts
@@ -58,20 +58,25 @@ import { runTransformationPass, transformEqualityChecks, propagateAsyncAwait } f
 import { extractPineScriptVersion, pineToJS } from './pineToJS/pineToJS.index';
 import { buildLtfSlices } from './slicing/buildLtfSlices';
 
-function getPineTSFromSource(source: string | Function): string {
+/**
+ * Resolve the input into PineTS code plus the Pine Script version it came from.
+ * `version` is null for PineTS-syntax / function input (no //@version marker):
+ * such code is JavaScript-like and follows JS semantics, not a Pine version.
+ */
+function getPineTSFromSource(source: string | Function): { code: string; version: number | null } {
     if (typeof source === 'function') {
-        return source.toString();
+        return { code: source.toString(), version: null };
     } else {
         const pineScriptVersion = extractPineScriptVersion(source);
         if (pineScriptVersion === null) {
             //assume it's PineTS syntax ==> use it as is
-            return source;
+            return { code: source, version: null };
         }
         if (pineScriptVersion >= 5) {
             //assume it's Pine Script syntax ==> use pineToJS to transpile it
             const pineToJSResult = pineToJS(source);
             if (pineToJSResult.success) {
-                return pineToJSResult.code;
+                return { code: pineToJSResult.code, version: pineScriptVersion };
             } else {
                 throw new Error(`Failed to transpile Pine Script version ${pineScriptVersion}: ${pineToJSResult.error}`);
             }
@@ -89,7 +94,8 @@ export function transpile(source: string | Function, options: { debug: boolean; 
 
     const { debug } = options;
 
-    let code = getPineTSFromSource(source);
+    const { code: sourceCode, version: pineVersion } = getPineTSFromSource(source);
+    let code = sourceCode;
 
     // Pre-process: Wrap in context function if not already wrapped
     code = wrapInContextFunction(code);
@@ -127,11 +133,19 @@ export function transpile(source: string | Function, options: { debug: boolean; 
     // Returns the original parameter name of the root function if any
     const originalParamName = runAnalysisPass(ast, scopeManager) || '';
 
-    // Type inference (RC2b): replicate Pine `int / int → int`. Runs on the clean
-    // pre-lowering AST (operands still bare identifiers / `input.int(...)` /
-    // literals) and rewrites provably-int `/` to `$.pine.math.__idiv(...)`. The
-    // main pass below then lowers the operand subtrees inside the call args.
-    runTypeInferencePass(ast, scopeManager);
+    // Type inference: replicate Pine v5 `const int / const int → int` truncation.
+    // Runs on the clean pre-lowering AST (operands still bare identifiers /
+    // literals) and rewrites provably-const-int `/` to `$.pine.math.__idiv(...)`;
+    // the main pass below then lowers the operand subtrees inside the call args.
+    //
+    // Version-gated: only Pine v5 truncates, and only when BOTH operands are
+    // 'const'-qualified ints. Pine v6+ always performs fractional division
+    // (see TradingView's v6 migration guide, "Fractional division of constants"),
+    // and PineTS-syntax / function input (pineVersion === null) is JavaScript,
+    // where `/` is always float division.
+    if (pineVersion !== null && pineVersion < 6) {
+        runTypeInferencePass(ast, scopeManager);
+    }
 
     // Second pass: transform the code
     runTransformationPass(ast, scopeManager, originalParamName, options, sourceLines);

--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -144,6 +144,7 @@ export const NAMESPACE_COLLISION_NAMES = new Set([
     'alert',
     'barstate',
     'syminfo',
+    'session',
     'timeframe',
     'strategy',
     'log',
@@ -241,11 +242,13 @@ export const CONTEXT_PINE_VARS = [
     'timeframe',
     'syminfo',
     'barstate',
+    'session',
 
     //builtin variables
     'bar_index',
     'last_bar_index',
     'last_bar_time',
+    'timenow',
     'inputs',
     'time',
     'time_close',

--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -230,6 +230,7 @@ export const CONTEXT_PINE_VARS = [
     'map',
     'matrix',
     'log',
+    'runtime',
     //types
     'Type', //UDT
     'bool',

--- a/src/transpiler/settings.ts
+++ b/src/transpiler/settings.ts
@@ -148,6 +148,19 @@ export const NAMESPACE_COLLISION_NAMES = new Set([
     'strategy',
     'log',
     'str',
+    // Constant/enum namespaces (member access only). TradingView allows user
+    // variables to share these names while namespace member access still
+    // works (e.g. `position = 1` alongside `position.top_right`), so the
+    // user variable must be renamed. `dayofweek` is dual-use (built-in
+    // variable + enum) — renaming only triggers when the user DECLARES a
+    // variable with the name, so bare built-in reads are unaffected.
+    'position',
+    'font',
+    'order',
+    'currency',
+    'dayofweek',
+    'adjustment',
+    'barmerge',
 ]);
 
 // JavaScript reserved keywords that ARE valid Pine identifiers but invalid as

--- a/tests/core/last-bar-index.test.ts
+++ b/tests/core/last-bar-index.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+
+/**
+ * TV semantics: `last_bar_index` is the bar_index of the LAST bar of the
+ * chart's history — a CONSTANT across the whole historical run (it only
+ * grows when new realtime bars are appended). It must NOT track the
+ * current bar_index during the historical run.
+ *
+ * Regression guard for: `last_bar_index` returning `close.length - 1`
+ * (the progressively-fed window size), which made it equal bar_index on
+ * every bar, so `bar_index < last_bar_index` was never true.
+ */
+describe('last_bar_index', () => {
+    it('is constant across the historical run and equals the final bar_index', async () => {
+        const pineTS = new PineTS(
+            Provider.Mock,
+            'BTCUSDC',
+            '60',
+            null,
+            new Date('2024-01-01').getTime(),
+            new Date('2024-01-10').getTime()
+        );
+
+        const { plots } = await pineTS.run(($) => {
+            const { plotchar, bar_index, last_bar_index } = $.pine;
+
+            const isNotLast = bar_index < last_bar_index ? 1 : 0;
+
+            plotchar(bar_index, 'bi');
+            plotchar(last_bar_index, 'lbi');
+            plotchar(isNotLast, 'isNotLast');
+
+            return { bar_index, last_bar_index };
+        });
+
+        const biData = plots['bi'].data;
+        const lbiData = plots['lbi'].data;
+        const isNotLastData = plots['isNotLast'].data;
+
+        const barCount = biData.length;
+        expect(barCount).toBeGreaterThan(2);
+
+        const finalBarIndex = biData[barCount - 1].value;
+        expect(finalBarIndex).toBe(barCount - 1);
+
+        // TV: last_bar_index plots the same value (the final bar's index) on EVERY bar.
+        for (let i = 0; i < barCount; i++) {
+            expect(lbiData[i].value, `last_bar_index at bar ${i}`).toBe(finalBarIndex);
+        }
+
+        // TV: bar_index < last_bar_index is true on all bars except the last one.
+        for (let i = 0; i < barCount - 1; i++) {
+            expect(isNotLastData[i].value, `bar_index < last_bar_index at bar ${i}`).toBe(1);
+        }
+        expect(isNotLastData[barCount - 1].value).toBe(0);
+    });
+});

--- a/tests/core/pinescript.test.ts
+++ b/tests/core/pinescript.test.ts
@@ -2650,12 +2650,13 @@ describe('PineScript Language', () => {
         console.log('>>> TEST: Operator Precedence Complex');
         console.log('>>> result: ', context.result);
 
-        // RC2b (Pine int/int → int): `5 / 2` is integer division (= 2, not 2.5),
-        // so complex1 = 2 + 3*4 - 5/2 = 2 + 12 - 2 = 12; and complex2 =
-        // ((2+3)*(4-5))/2 = -5/2 = -2 (truncated toward zero, not -2.5).
+        // PineTS-syntax input follows JavaScript semantics: `/` is always float
+        // division (only Pine v5 const/const divisions truncate, and this is not
+        // Pine source). So complex1 = 2 + 3*4 - 5/2 = 2 + 12 - 2.5 = 11.5, and
+        // complex2 = ((2+3)*(4-5))/2 = -5/2 = -2.5.
         const expected = {
-            complex1: [12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12],
-            complex2: [-2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2, -2],
+            complex1: [11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5, 11.5],
+            complex2: [-2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5, -2.5],
             complex3: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
             complex4: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true],
         };

--- a/tests/core/timenow.test.ts
+++ b/tests/core/timenow.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+describe('timenow built-in variable', () => {
+    const makePineTS = () => new PineTS(Provider.Mock, 'BTCUSDC', 'D', null, new Date('2025-01-01').getTime(), new Date('2025-02-01').getTime());
+
+    it('timenow is usable from Pine Script and returns current wall-clock time', async () => {
+        const code = `
+//@version=5
+indicator("timenow test")
+plot(timenow, "now")
+`;
+        const before = Date.now();
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+        const after = Date.now();
+
+        const data = plots['now'].data.filter((d: any) => d.value != null && !isNaN(d.value));
+        expect(data.length).toBeGreaterThan(0);
+
+        // Every bar should see the same "current time" concept: a wall-clock
+        // timestamp captured during this test run (independent reference: Date.now()).
+        for (const d of data) {
+            expect(d.value).toBeGreaterThanOrEqual(before);
+            expect(d.value).toBeLessThanOrEqual(after);
+        }
+    });
+
+    it('timenow is usable from PineTS syntax', async () => {
+        const before = Date.now();
+        const pineTS = makePineTS();
+        const { result } = await pineTS.run(($: any) => {
+            const now = timenow;
+            return { now };
+        });
+        const after = Date.now();
+
+        expect(result.now[0]).toBeGreaterThanOrEqual(before);
+        expect(result.now[0]).toBeLessThanOrEqual(after);
+    });
+});

--- a/tests/namespaces/runtime.test.ts
+++ b/tests/namespaces/runtime.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 LuxAlgo
+
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+import { PineRuntimeError } from '../../src/errors/PineRuntimeError';
+
+// Regression guard for the `runtime` namespace (runtime.error).
+// Previously the namespace didn't exist at all, so any script referencing
+// `runtime.error(...)` — even inside a never-taken branch executed at
+// runtime — crashed with "runtime is not defined" instead of behaving
+// like TradingView (no-op when unreached, halt with the message when hit).
+
+const GUARDED_SCRIPT = `
+//@version=6
+indicator("Runtime error guard", overlay = true)
+if timeframe.in_seconds(timeframe.period) < 86400
+    runtime.error('Only the daily timeframe or higher are available for this model')
+plot(close, 'c')
+`;
+
+describe('runtime.error', () => {
+    it('does not block execution when the guard condition is false', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1D', null, new Date('2024-01-01').getTime(), new Date('2024-03-01').getTime());
+
+        const { plots } = await pineTS.run(GUARDED_SCRIPT);
+
+        expect(plots['c'].data.length).toBeGreaterThan(0);
+    });
+
+    it('halts the script with the given message when called', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-05').getTime());
+
+        await expect(pineTS.run(GUARDED_SCRIPT)).rejects.toThrow('Only the daily timeframe or higher are available for this model');
+    });
+
+    it('throws a catchable PineRuntimeError with method "runtime.error"', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-05').getTime());
+
+        let caught: unknown;
+        try {
+            await pineTS.run(GUARDED_SCRIPT);
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeInstanceOf(PineRuntimeError);
+        expect((caught as PineRuntimeError).method).toBe('runtime.error');
+    });
+
+    it('works in PineTS syntax as well', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-05').getTime());
+
+        await expect(
+            pineTS.run(($: any) => {
+                const { runtime } = $.pine;
+                runtime.error('boom');
+            }),
+        ).rejects.toThrow('boom');
+    });
+});

--- a/tests/namespaces/session-namespace.test.ts
+++ b/tests/namespaces/session-namespace.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Hourly mock data (UTC timezone, 24x7 crypto symbol): each trading day/session
+// is a calendar day in the exchange timezone, so on a 1h chart the first bar of
+// a session opens at 00:00 and the last bar opens at 23:00.
+describe('session namespace', () => {
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01T00:00:00Z').getTime(), new Date('2024-01-08T00:00:00Z').getTime());
+
+    it('exposes session.regular and session.extended constants', async () => {
+        const pineTS = makePineTS();
+        const { result } = await pineTS.run(($: any) => {
+            const reg = session.regular;
+            const ext = session.extended;
+            return { reg, ext };
+        });
+
+        expect(result.reg[0]).toBe('regular');
+        expect(result.ext[0]).toBe('extended');
+    });
+
+    it('session.isfirstbar is true only on the first bar of each trading day', async () => {
+        const code = `
+//@version=5
+indicator("session isfirstbar")
+plot(session.isfirstbar ? 1 : 0, "first")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['first'].data;
+        expect(data.length).toBeGreaterThan(24);
+
+        for (const d of data) {
+            const date = new Date(d.time);
+            if (d.value === 1) {
+                expect(date.getUTCHours()).toBe(0);
+            } else {
+                expect(date.getUTCHours()).not.toBe(0);
+            }
+        }
+
+        const firstBars = data.filter((d: any) => d.value === 1);
+        expect(firstBars.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('session.islastbar is true only on the last bar of each trading day', async () => {
+        const code = `
+//@version=5
+indicator("session islastbar")
+plot(session.islastbar ? 1 : 0, "last")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['last'].data;
+        expect(data.length).toBeGreaterThan(24);
+
+        for (let i = 0; i < data.length - 1; i++) {
+            const date = new Date(data[i].time);
+            if (data[i].value === 1) {
+                expect(date.getUTCHours()).toBe(23);
+            } else {
+                expect(date.getUTCHours()).not.toBe(23);
+            }
+        }
+
+        const lastBars = data.filter((d: any) => d.value === 1);
+        expect(lastBars.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('session.ismarket is true and pre/post market are false on 24x7 symbols', async () => {
+        const code = `
+//@version=5
+indicator("session market flags")
+plot(session.ismarket ? 1 : 0, "market")
+plot(session.ispremarket ? 1 : 0, "pre")
+plot(session.ispostmarket ? 1 : 0, "post")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        for (const d of plots['market'].data) expect(d.value).toBe(1);
+        for (const d of plots['pre'].data) expect(d.value).toBe(0);
+        for (const d of plots['post'].data) expect(d.value).toBe(0);
+    });
+
+    it('session.isfirstbar_regular / islastbar_regular mirror the regular-session flags', async () => {
+        const code = `
+//@version=5
+indicator("session regular flags")
+plot(session.isfirstbar_regular == session.isfirstbar ? 1 : 0, "first_eq")
+plot(session.islastbar_regular == session.islastbar ? 1 : 0, "last_eq")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        for (const d of plots['first_eq'].data) expect(d.value).toBe(1);
+        for (const d of plots['last_eq'].data) expect(d.value).toBe(1);
+    });
+});

--- a/tests/namespaces/time-session-spec.test.ts
+++ b/tests/namespaces/time-session-spec.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { PineTS, Provider } from 'index';
+
+// Hourly mock data: bars open at HH:00 UTC, symbol timezone is Etc/UTC.
+// Expected in/out-of-session values below are hand-derived from the Pine
+// session-spec rules (TradingView docs): "HHMM-HHMM[,HHMM-HHMM...][:days]",
+// days digits 1=Sunday..7=Saturday, overnight sessions belong to the day
+// on which they END (the trading day).
+describe('time() session spec parsing', () => {
+    // 2024-01-01 is a Monday.
+    const makePineTS = () =>
+        new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01T00:00:00Z').getTime(), new Date('2024-01-15T00:00:00Z').getTime());
+
+    it('day suffix does not disable session filtering (reported bug)', async () => {
+        // Reported repro: hourly bars open at HH:00 UTC = (HH-5):00 in UTC-5.
+        // No bar's open time ever falls inside 09:30-10:00, so EVERY bar must
+        // be out of session. The bug made every bar in-session because the
+        // ":1234567" suffix failed the HHMM-HHMM regex and passed through.
+        const code = `
+//@version=6
+indicator("time() session days suffix", overlay = true)
+inSession = not na(time(timeframe.period, "0930-1000:1234567", "UTC-5"))
+plot(inSession ? 1 : 0, "inSession")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['inSession'].data;
+        expect(data.length).toBeGreaterThan(0);
+        for (const d of data) {
+            expect(d.value).toBe(0);
+        }
+    });
+
+    it('day suffix filters by day of week (1=Sunday..7=Saturday)', async () => {
+        // "0000-0800:2" → in-session only on Mondays between 00:00 and 08:00.
+        const code = `
+//@version=5
+indicator("session day filter")
+t = time(timeframe.period, "0000-0800:2", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        let inCount = 0;
+        for (const d of data) {
+            const date = new Date(d.time);
+            const expected = date.getUTCDay() === 1 && date.getUTCHours() < 8 ? 1 : 0;
+            expect(d.value).toBe(expected);
+            if (d.value === 1) inCount++;
+        }
+        // Mondays Jan 1 and Jan 8 contribute 8 hourly bars each; the range end
+        // is inclusive, so Monday Jan 15 contributes its 00:00 bar as well.
+        expect(inCount).toBe(17);
+    });
+
+    it('supports comma-separated session windows', async () => {
+        // Hours 0,1 and 5,6 are in-session; everything else is not.
+        const code = `
+//@version=5
+indicator("session comma windows")
+t = time(timeframe.period, "0000-0200,0500-0700", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const h = new Date(d.time).getUTCHours();
+            const expected = h === 0 || h === 1 || h === 5 || h === 6 ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('supports overnight sessions crossing midnight', async () => {
+        // "2200-0200" → hours 22, 23, 0, 1 in-session.
+        const code = `
+//@version=5
+indicator("overnight session")
+t = time(timeframe.period, "2200-0200", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const h = new Date(d.time).getUTCHours();
+            const expected = h >= 22 || h < 2 ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('overnight session day suffix refers to the trading day the session ends on', async () => {
+        // "2200-0200:2" (Monday trading day) → Sunday 22:00/23:00 and Monday 00:00/01:00.
+        const code = `
+//@version=5
+indicator("overnight session trading day")
+t = time(timeframe.period, "2200-0200:2", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const date = new Date(d.time);
+            const day = date.getUTCDay(); // 0=Sun, 1=Mon
+            const h = date.getUTCHours();
+            const expected = (day === 0 && h >= 22) || (day === 1 && h < 2) ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('treats "HHMM-0000" end as end-of-day midnight', async () => {
+        // "2200-0000" → hours 22, 23 in-session (same-day evening window).
+        const code = `
+//@version=5
+indicator("midnight end session")
+t = time(timeframe.period, "2200-0000", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        const { plots } = await pineTS.run(code);
+
+        const data = plots['in'].data;
+        expect(data.length).toBeGreaterThan(0);
+
+        for (const d of data) {
+            const h = new Date(d.time).getUTCHours();
+            const expected = h >= 22 ? 1 : 0;
+            expect(d.value).toBe(expected);
+        }
+    });
+
+    it('rejects malformed session strings instead of treating every bar as in-session', async () => {
+        const code = `
+//@version=5
+indicator("invalid session")
+t = time(timeframe.period, "not-a-session", "UTC")
+plot(na(t) ? 0 : 1, "in")
+`;
+        const pineTS = makePineTS();
+        await expect(pineTS.run(code)).rejects.toThrow(/session/i);
+    });
+});

--- a/tests/transpiler/int-division.test.ts
+++ b/tests/transpiler/int-division.test.ts
@@ -1,61 +1,76 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * RC2b — Pine integer division (`int / int → int`) regression suite.
+ * Pine integer division (`int / int`) regression suite.
  *
- * Pine truncates `/` toward zero when BOTH operands are integers (`11 / 2 === 5`,
- * `-11 / 2 === -5`); JavaScript `/` is always float. The TypeInferencePass rewrites
- * a `/` to `$.pine.math.__idiv(...)` ONLY when both operands are provably int, and
- * MUST leave every other division as native `/` (fail-safe — a missed truncation is
- * acceptable, a wrong truncation of a float is a bug).
+ * Reference: TradingView's "To Pine Script version 6" migration guide, section
+ * "Fractional division of constants":
  *
- * These tests lock down both directions:
- *   - int-division IS applied for the provable-int cases, and
- *   - float / unknown divisions are NEVER truncated — including the two real
- *     over-truncation regressions this suite exists to prevent:
- *       (1) `ta.pivothigh` / `ta.pivotlow` return a float PRICE, not an int bar
- *           count (they were wrongly typed int, truncating pivot-range math);
- *       (2) a `var float x = na` reassigned from a float value must stay float
- *           (JOIN-on-reassignment: once notint, always notint).
+ *   - Pine v5: `int / int` truncates toward zero ONLY when BOTH operands are
+ *     qualified as 'const' (e.g. `5 / 2 === 2`). If at least one operand is
+ *     'input', 'simple', or 'series' (loop counters, mutable variables,
+ *     `input.int(...)`, `bar_index`, ...), the fractional remainder is PRESERVED
+ *     (`i / 4 === 0.75`).
+ *   - Pine v6: `int / int` NEVER truncates, regardless of qualifiers
+ *     (`5 / 2 === 2.5`).
+ *
+ * The TypeInferencePass therefore rewrites `/` to `$.pine.math.__idiv(...)` only
+ * for v5 sources AND only when both operands are provably const int. Everything
+ * else — v6 scripts, bare PineTS syntax (JS semantics), and any non-const int
+ * operand — keeps native float `/`.
+ *
+ * This suite also guards two historical over-truncation regressions:
+ *   (1) `ta.pivothigh` / `ta.pivotlow` return a float PRICE, not an int bar count;
+ *   (2) a `var float x = na` reassigned from a float value must stay float.
  */
 import { describe, it, expect } from 'vitest';
 import { PineTS } from '../../src/PineTS.class';
 import { Provider } from '@pinets/marketData/Provider.class';
 import { transpile } from '../../src/transpiler/index';
 
-/** Transpile a Pine v6 snippet and return the generated JS as a string. */
-function tj(body: string): string {
-    return transpile(`//@version=6\nindicator("t")\n${body}`).toString();
+/** Transpile a Pine snippet at the given version, return the generated JS. */
+function tj(body: string, version: 5 | 6 = 5): string {
+    return transpile(`//@version=${version}\nindicator("t")\n${body}`).toString();
 }
 
 const IDIV = '__idiv';
 
-describe('RC2b: Pine integer division (__idiv)', () => {
-    describe('applies int-division (→ __idiv) when both operands are provably int', () => {
-        it('int literal / int literal', () => {
-            expect(tj('x = 11 / 2')).toContain(IDIV);
+describe('Pine v5: __idiv applied ONLY for const int / const int', () => {
+    it('int literal / int literal', () => {
+        expect(tj('x = 11 / 2')).toContain(IDIV);
+    });
+    it('const-int arithmetic / int literal', () => {
+        expect(tj('y = (3 + 4) / 2')).toContain(IDIV);
+    });
+    it('unary-minus int literal', () => {
+        expect(tj('y = -11 / 2')).toContain(IDIV);
+    });
+    it('const int variable (literal init, never reassigned) / int', () => {
+        expect(tj('iv = 7\ny = iv / 2')).toContain(IDIV);
+    });
+
+    describe('non-const int operands preserve the fractional remainder (no __idiv)', () => {
+        it('input.int is input-qualified, not const', () => {
+            expect(tj('depth = input.int(11)\ny = depth / 2')).not.toContain(IDIV);
         });
-        it('input.int-typed variable / int', () => {
-            expect(tj('depth = input.int(11)\ny = depth / 2')).toContain(IDIV);
+        it('bar_index is a series int, not const', () => {
+            expect(tj('y = bar_index / 2')).not.toContain(IDIV);
         });
-        it('int-typed builtin (bar_index) / int', () => {
-            expect(tj('y = bar_index / 2')).toContain(IDIV);
+        it('loop counter is a series int, not const', () => {
+            expect(tj('int gridSteps = 4\nfloat f = na\nfor i = 1 to 3\n    f := i / gridSteps')).not.toContain(IDIV);
         });
-        it('int-only arithmetic / int', () => {
-            expect(tj('y = (3 + 4) / 2')).toContain(IDIV);
+        it('reassigned int variable is series, not const', () => {
+            expect(tj('c = 0\nc := c + 1\ny = c / 2')).not.toContain(IDIV);
         });
-        it('unary-minus int literal', () => {
-            expect(tj('y = -11 / 2')).toContain(IDIV);
+        it('var-declared int is not const', () => {
+            expect(tj('var v = 8\ny = v / 2')).not.toContain(IDIV);
         });
-        it('int variable (literal init) / int', () => {
-            expect(tj('iv = 7\ny = iv / 2')).toContain(IDIV);
-        });
-        it('int variable reassigned only to ints stays int', () => {
-            expect(tj('c = 0\nc := c + 1\ny = c / 2')).toContain(IDIV);
+        it('const var divided by a later-reassigned var', () => {
+            expect(tj('k = 8\nm = 2\ny = k / m\nm := 4')).not.toContain(IDIV);
         });
     });
 
-    describe('never truncates float / unknown divisions (stays native /)', () => {
+    describe('never truncates float / unknown divisions', () => {
         it('float builtin (close) / int', () => {
             expect(tj('y = close / 2')).not.toContain(IDIV);
         });
@@ -69,8 +84,7 @@ describe('RC2b: Pine integer division (__idiv)', () => {
             expect(tj('y = close / high')).not.toContain(IDIV);
         });
 
-        // REGRESSION (1): ta.pivothigh / ta.pivotlow return the pivot PRICE (float),
-        // not an int bar count. They must NOT trigger int-division.
+        // REGRESSION (1): ta.pivothigh / ta.pivotlow return the pivot PRICE (float).
         it('ta.pivothigh() / int stays float', () => {
             expect(tj('ph = ta.pivothigh(5, 5)\ny = ph / 2')).not.toContain(IDIV);
         });
@@ -79,9 +93,7 @@ describe('RC2b: Pine integer division (__idiv)', () => {
         });
 
         // REGRESSION (2, zigzag): a `var float x = na` reassigned from a float
-        // pivot must stay float. JOIN semantics: once a variable holds a notint
-        // value (its na initializer), it stays notint forever, so a mis-typed
-        // signature can never upgrade it to int and truncate its range math.
+        // pivot must stay float (JOIN semantics: once notint, always notint).
         it('var float = na reassigned from a float pivot stays float', () => {
             const js = tj([
                 'var float lastHigh = na',
@@ -97,49 +109,102 @@ describe('RC2b: Pine integer division (__idiv)', () => {
             expect(js).not.toContain(IDIV);
         });
     });
+});
 
-    // pine2js must preserve float-ness through codegen, otherwise int/float
-    // division is indistinguishable downstream (`2.0` flattened to `2`).
-    describe('float-literal preservation (pine2js codegen)', () => {
-        it('preserves an integer-valued float literal (2.0 stays 2.0)', () => {
-            expect(tj('y = 2.0')).toContain('2.0');
-        });
-        it('normalizes a dot-prefix literal (.5 → 0.5)', () => {
-            expect(tj('y = .5')).toContain('0.5');
-        });
+describe('Pine v6: int division NEVER truncates (no __idiv, ever)', () => {
+    it('int literal / int literal', () => {
+        expect(tj('x = 11 / 2', 6)).not.toContain(IDIV);
+    });
+    it('const int variable / int', () => {
+        expect(tj('iv = 7\ny = iv / 2', 6)).not.toContain(IDIV);
+    });
+    it('const-int arithmetic / int', () => {
+        expect(tj('y = (3 + 4) / 2', 6)).not.toContain(IDIV);
+    });
+    it('loop counter / int variable', () => {
+        expect(tj('int gridSteps = 4\nfloat f = na\nfor i = 1 to 3\n    f := i / gridSteps', 6)).not.toContain(IDIV);
     });
 });
 
-describe('RC2b: integer division runtime values', () => {
-    async function evalExprs(exprs: Record<string, string>): Promise<Record<string, any>> {
+describe('bare PineTS syntax: JS float-division semantics (no __idiv)', () => {
+    it('int literal / int literal stays native /', () => {
+        const js = transpile(`($) => {\n    const { plot } = $.pine;\n    plot(11 / 2, 'y');\n}`).toString();
+        expect(js).not.toContain(IDIV);
+    });
+});
+
+// pine2js must preserve float-ness through codegen, otherwise int/float
+// division is indistinguishable downstream (`2.0` flattened to `2`).
+describe('float-literal preservation (pine2js codegen)', () => {
+    it('preserves an integer-valued float literal (2.0 stays 2.0)', () => {
+        expect(tj('y = 2.0')).toContain('2.0');
+    });
+    it('normalizes a dot-prefix literal (.5 → 0.5)', () => {
+        expect(tj('y = .5')).toContain('0.5');
+    });
+});
+
+describe('integer division runtime values', () => {
+    async function runPine(script: string): Promise<Record<string, any>> {
         const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
-        const lines = Object.entries(exprs).map(([name, e]) => `plotchar(${e}, '${name}');`).join('\n');
-        const code = `const { plotchar } = context.pine;\n${lines}`;
-        const { plots } = await pineTS.run(code);
+        const { plots } = await pineTS.run(script);
         const out: Record<string, any> = {};
-        for (const name of Object.keys(exprs)) out[name] = plots[name].data[0].value;
+        for (const [name, plot] of Object.entries(plots) as any) {
+            if (!name.startsWith('__')) out[name] = plot.data.at(-1).value;
+        }
         return out;
     }
 
-    it('truncates int/int toward zero', async () => {
-        const r = await evalExprs({ a: '11 / 2', b: '10 / 2', c: '7 / 2', d: '-11 / 2', e: '-7 / 2' });
-        expect(r.a).toBe(5);
-        expect(r.b).toBe(5);
-        expect(r.c).toBe(3);
-        expect(r.d).toBe(-5); // toward zero, NOT floor (-6)
-        expect(r.e).toBe(-3);
+    // Expected values from TradingView's v6 migration guide ("Fractional
+    // division of constants") and Pine v5 semantics.
+    it('v5: truncates const/const toward zero, preserves fraction otherwise', async () => {
+        const r = await runPine([
+            '//@version=5',
+            'indicator("t")',
+            'int gridSteps = 4',
+            'float fromLoop = na',
+            'for i = 1 to 3',
+            '    fromLoop := i / gridSteps',
+            'plot(fromLoop, "loop")',
+            'plot(11 / 2, "lit")',
+            'plot(-11 / 2, "negLit")',
+            'plot(5 / 2.0, "mixed")',
+        ].join('\n'));
+        expect(r.loop).toBe(0.75); // loop counter is series int → fractional even in v5
+        expect(r.lit).toBe(5); // const/const → truncated
+        expect(r.negLit).toBe(-5); // toward zero, NOT floor (-6)
+        expect(r.mixed).toBe(2.5);
     });
 
-    it('keeps float division exact', async () => {
-        const r = await evalExprs({ a: '11 / 2.0', b: '2.5 / 2', c: '(1.0 * 5) / 2' });
-        expect(r.a).toBe(5.5);
-        expect(r.b).toBe(1.25);
-        expect(r.c).toBe(2.5);
+    it('v6: always fractional', async () => {
+        const r = await runPine([
+            '//@version=6',
+            'indicator("t")',
+            'int gridSteps = 4',
+            'float fromLoop = na',
+            'for i = 1 to 3',
+            '    fromLoop := i / gridSteps',
+            'plot(fromLoop, "loop")',
+            'plot(5 / 2, "lit")',
+            'plot(5 / 2.0, "mixed")',
+        ].join('\n'));
+        expect(r.loop).toBe(0.75);
+        expect(r.lit).toBe(2.5);
+        expect(r.mixed).toBe(2.5);
     });
 
-    it('preserves div-by-zero semantics (Infinity / NaN), not na', async () => {
-        const r = await evalExprs({ a: '1 / 0', b: '0 / 0' });
-        expect(r.a).toBe(Infinity);
-        expect(Number.isNaN(r.b)).toBe(true);
+    it('v5: div-by-zero semantics preserved through __idiv (Infinity / NaN)', async () => {
+        const r = await runPine(['//@version=5', 'indicator("t")', 'plot(1 / 0, "inf")', 'plot(0 / 0, "nan")'].join('\n'));
+        expect(r.inf).toBe(Infinity);
+        expect(Number.isNaN(r.nan)).toBe(true);
+    });
+
+    it('bare PineTS syntax: JS float division', async () => {
+        const pineTS = new PineTS(Provider.Mock, 'BTCUSDC', '1h', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+        const { plots } = await pineTS.run(($: any) => {
+            const { plotchar } = $.pine;
+            plotchar(11 / 2, 'a');
+        });
+        expect(plots['a'].data[0].value).toBe(5.5);
     });
 });

--- a/tests/transpiler/namespace-identifier-collision.test.ts
+++ b/tests/transpiler/namespace-identifier-collision.test.ts
@@ -1,0 +1,129 @@
+// Regression guard: user identifiers named after constant/enum namespaces.
+//
+// TradingView allows a script to declare a variable whose name collides with
+// a constant namespace (position, font, order, currency, dayofweek,
+// adjustment, barmerge) while still using the namespace's members
+// (e.g. `position.top_right`) elsewhere in the same script.
+//
+// PineTS handles this via the pineToJS codegen rename pass: the user variable
+// is renamed with a `_$N` suffix while member-expression bases keep referring
+// to the namespace. Before the fix, these names were missing from
+// NAMESPACE_COLLISION_NAMES, so the declaration hijacked the identifier and
+// namespace member access threw `ReferenceError: <name> is not defined`.
+import { describe, it, expect } from 'vitest';
+import { PineTS } from '../../src/PineTS.class';
+import { Provider } from '../../src/marketData/Provider.class';
+
+function newPineTS() {
+    return new PineTS(Provider.Mock, 'BTCUSDC', '60', null, new Date('2024-01-01').getTime(), new Date('2024-01-10').getTime());
+}
+
+function lastValue(plots: any, title: string) {
+    const data = plots[title]?.data;
+    expect(data, `plot "${title}" missing`).toBeDefined();
+    expect(data.length).toBeGreaterThan(0);
+    return data[data.length - 1].value;
+}
+
+describe('identifier-namespace collision (TV-allowed shadowing)', () => {
+    it('position: user variable coexists with table.new(position.top_right, ...)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("position collision repro", overlay = true)
+var table t = table.new(position.top_right, 1, 1)
+position = 1
+plot(position, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(1);
+    });
+
+    it('font: user variable coexists with font.family_monospace', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("font collision")
+var table t = table.new(position.top_left, 1, 1)
+table.cell(t, 0, 0, "x", text_font_family = font.family_monospace)
+font = 2
+plot(font, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(2);
+    });
+
+    it('order: user variable coexists with array.sort(..., order.descending)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("order collision")
+a = array.from(3.0, 1.0, 2.0)
+array.sort(a, order.descending)
+order = array.get(a, 0)
+plot(order, "p")
+`);
+        // descending sort puts the max (3.0) first
+        expect(lastValue(plots, 'p')).toBe(3);
+    });
+
+    it('currency: user variable coexists with currency.USD', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("currency collision")
+currency = 4
+plot(currency.USD == "USD" ? currency : -1, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(4);
+    });
+
+    it('dayofweek: user variable coexists with dayofweek.monday constant', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("dayofweek collision")
+dayofweek = dayofweek.monday + 1
+plot(dayofweek, "p")
+`);
+        // dayofweek.monday == 2 on TradingView
+        expect(lastValue(plots, 'p')).toBe(3);
+    });
+
+    it('adjustment: user variable coexists with adjustment.splits', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("adjustment collision")
+string adj = adjustment.splits
+adjustment = 5
+plot(adjustment, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(5);
+    });
+
+    it('barmerge: user variable coexists with barmerge.gaps_off', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("barmerge collision")
+string g = barmerge.gaps_off
+barmerge = 6
+plot(barmerge, "p")
+`);
+        expect(lastValue(plots, 'p')).toBe(6);
+    });
+
+    it('does not affect scripts that only READ these namespaces (no user declaration)', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("no collision")
+var table t = table.new(position.bottom_right, 1, 1)
+plot(dayofweek.friday, "p")
+`);
+        // dayofweek.friday == 6 on TradingView
+        expect(lastValue(plots, 'p')).toBe(6);
+    });
+
+    it('dual-use dayofweek built-in variable still works when not shadowed', async () => {
+        const { plots } = await newPineTS().run(`
+//@version=6
+indicator("dayofweek builtin")
+plot(dayofweek, "p")
+`);
+        const v = lastValue(plots, 'p');
+        expect(v).toBeGreaterThanOrEqual(1);
+        expect(v).toBeLessThanOrEqual(7);
+    });
+});

--- a/tests/transpiler/pinescript-to-js.test.ts
+++ b/tests/transpiler/pinescript-to-js.test.ts
@@ -408,9 +408,11 @@ plot(sum)
         expect(jsCode).toContain('+');
         expect(jsCode).toContain('-');
         expect(jsCode).toContain('*');
-        // `10 / 2` is int/int division, which lowers to the Pine integer-division
-        // helper (RC2b: `__idiv`) rather than a raw `/`. `%` still transpiles native.
-        expect(jsCode).toContain('__idiv');
+        // Pine v6 never truncates int/int division (see the v6 migration guide,
+        // "Fractional division of constants"), so `10 / 2` stays a native `/`
+        // and must NOT lower to the v5-only `__idiv` helper.
+        expect(jsCode).toContain('/');
+        expect(jsCode).not.toContain('__idiv');
         expect(jsCode).toContain('%');
     });
 

--- a/tests/transpiler/switch.test.ts
+++ b/tests/transpiler/switch.test.ts
@@ -241,9 +241,11 @@ plot(ma)
             const transpiledFn = transpile(indicatorCode, { debug: false });
             const code = transpiledFn.toString();
 
-            // Verify that default case includes both runtime.error and float(na)
+            // Verify that default case includes both runtime.error and float(na).
+            // `runtime` is a context-bound namespace, so the message argument is
+            // param-wrapped: runtime.param('...') feeding runtime.error(pN).
             expect(code).toContain('default:');
-            expect(code).toContain("runtime.error('No matching MA type found.')");
+            expect(code).toMatch(/runtime\.param\('No matching MA type found\.'/);
             expect(code).toMatch(/default:[^]*?runtime\.error[^]*?float/);
         });
 
@@ -267,7 +269,8 @@ plot(result)
             const code = transpiledFn.toString();
 
             // Check that both statements are present in default case
-            expect(code).toMatch(/default:[^]*?runtime\.error\('Invalid value'\)[^]*?return.*?float/);
+            // (message is param-wrapped before the runtime.error call)
+            expect(code).toMatch(/default:[^]*?runtime\.param\('Invalid value'[^]*?runtime\.error\([^]*?return.*?float/);
         });
     });
 


### PR DESCRIPTION
### Fixed

- **`int / int` truncation ignored the Pine version and the operands' qualifiers**: 0.9.28's integer-division pass truncated **every** division whose operands statically inferred as `int`. Real Pine truncates only in **v5**, and only when both operands are **`const`-qualified** ints — loop counters, mutable variables, `input.int` and int builtins keep the fractional remainder, and **v6 never truncates at all** (TradingView v6 migration guide, "Fractional division of constants"). The detected `//@version` is now threaded through **`transpile()`** and the pass is gated to v5 sources (v6+ and bare PineTS/JS input keep native float `/`). **`TypeInferencePass`** was reworked from a binary int/notint split to a **`constint` / `int` / `notint`** lattice with a mutated-names pre-scan, so only compile-time-constant int operands trigger the `math.__idiv` rewrite.
- **`runtime.error()` crashed with `ReferenceError: runtime is not defined`**: the `runtime` namespace did not exist, so any script *referencing* it failed as soon as the call executed — instead of TV's behavior (no-op when the guarding branch is not taken, halt with the script's message when it is). New **`src/namespaces/Runtime.ts`**: `runtime.error(message)` throws the existing catchable `PineRuntimeError` (`method: 'runtime.error'`), registered on `$.pine` and added to `CONTEXT_PINE_VARS` so the transpiler injects the namespace binding.
- **`last_bar_index` tracked the running `bar_index` instead of the chart's constant last-bar index**: it was derived from the progressively-fed `data.close` window, so it returned the **current** bar's index on every bar — `bar_index < last_bar_index` was false everywhere, breaking every "not the last bar" guard. It now reads the length of the fully-preloaded `marketData` array: a constant across the whole historical run, as in TV (it only grows when realtime bars are appended). The window-based read remains as a best-effort fallback when `marketData` is unavailable.
- **`time(timeframe, session, timezone)` mis-parsed session specs**: any `:days` suffix failed the `HHMM-HHMM` regex, so **every bar was silently treated as in-session**. The new parser (**`src/namespaces/sessionSpec.ts`**) handles full Pine session strings — comma-separated `HHMM-HHMM` windows, the `:days` suffix (`1` = Sunday … `7` = Saturday), overnight sessions belonging to the day they **end**, `"0000"` as end-of-day, and `"24x7"` — and malformed strings now throw `PineRuntimeError` like TV instead of passing silently.
- **`timenow` crashed with a `ReferenceError`**: the runtime getter existed, but the identifier was never registered in the transpiler settings, so it was never injected into the generated code.
- **User variables named after a constant namespace crashed**: TV allows `position`, `font`, `order`, `currency`, `dayofweek`, `adjustment` and `barmerge` as user variable names while namespace member access still works. These seven were missing from `NAMESPACE_COLLISION_NAMES`, so the codegen rename pass never renamed the user variable and the namespace was no longer injected from `$.pine` → `ReferenceError: <name> is not defined`.

### Added

- **`session` namespace**: `session.regular` / `session.extended` constants, `session.isfirstbar` / `session.islastbar` (plus their `*_regular` variants), and `session.ismarket` / `session.ispremarket` / `session.ispostmarket`.
- **Tests**: `tests/namespaces/runtime.test.ts` (guarded call is a no-op, halts with the exact message, throws a catchable `PineRuntimeError`, PineTS-syntax path); `tests/core/last-bar-index.test.ts` (constant on every bar, equals the final `bar_index`, `bar_index < last_bar_index` true on all bars but the last); `tests/namespaces/time-session-spec.test.ts`, `tests/namespaces/session-namespace.test.ts` and `tests/core/timenow.test.ts`; `tests/transpiler/namespace-identifier-collision.test.ts` (each of the seven namespaces shadowed, plus non-shadowed usage); and a reworked `tests/transpiler/int-division.test.ts` with reference-correct v5/v6 expectations (the original repro kept as a guard).